### PR TITLE
test: cover council bounded fanout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a council-level regression test proving expert consult fan-out runs
+  concurrently while respecting the bounded council concurrency cap.
 - Added local Ollama and plan-quota `ExpertChatBackend` adapters for read-only
   compiled-context turns. Both declare tools, streaming, and prompt cache
   unsupported, expose no Deepr dollar spend, and are groundwork for public

--- a/tests/unit/test_experts/test_council.py
+++ b/tests/unit/test_experts/test_council.py
@@ -6,6 +6,7 @@ loop. The live path remains a fallback for experts with no stored beliefs.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -87,6 +88,47 @@ async def test_fanout_falls_back_when_nothing_overlaps():
     selected = await ExpertCouncil().select_experts("quantum chromodynamics lattice", max_experts=10)
 
     assert [exp["name"] for exp in selected] == ["Coffee Brewing"]
+
+
+@pytest.mark.asyncio
+async def test_consult_queries_experts_with_bounded_concurrency(monkeypatch):
+    active = 0
+    peak_active = 0
+
+    async def fake_query(self, query, exp, per_expert_budget, progress_callback, agent_identity):
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return ExpertPerspective(
+            expert_name=exp["name"],
+            domain=exp.get("domain", ""),
+            response=f"{exp['name']} perspective",
+            cost=0.0,
+        )
+
+    monkeypatch.setattr("deepr.experts.council.MAX_COUNCIL_CONCURRENCY", 2)
+    monkeypatch.setattr(ExpertCouncil, "_query_expert", fake_query)
+
+    council = ExpertCouncil(synthesis_provider="local", allow_live_fallback=False)
+    experts = [{"name": f"Expert {idx}", "domain": "validation"} for idx in range(6)]
+
+    with patch.object(council, "_synthesise", new_callable=AsyncMock) as synth:
+        synth.return_value = {"text": "bounded synthesis", "agreements": [], "disagreements": [], "cost": 0.0}
+        result = await council.consult("Validate bounded fanout.", experts=experts, budget=1.0)
+
+    assert peak_active == 2
+    assert active == 0
+    assert [perspective["expert_name"] for perspective in result["perspectives"]] == [
+        "Expert 0",
+        "Expert 1",
+        "Expert 2",
+        "Expert 3",
+        "Expert 4",
+        "Expert 5",
+    ]
+    assert result["total_cost"] == 0.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a council-level regression proving `ExpertCouncil.consult()` dispatches expert calls concurrently while respecting the bounded concurrency cap
- record the validation-hardening change in the changelog

## Validation

- `deepr capacity probe-fleet --backend codex --backend claude --backend grok --backend antigravity --concurrency 4 --json` returned 4/4 OK
- `deepr mcp validate-consult-fleet --plan codex --plan claude --plan grok --plan antigravity --concurrency 4 --timeout 120 --json` returned 4/4 OK with 14/14 checks per plan
- `python -m pytest tests/unit/test_experts/test_council.py -q`
- focused plan, consult, and fanout suite: 148 passed
- `ruff check src/deepr tests/unit/test_experts/test_council.py`
- `ruff format --check src/deepr tests/unit/test_experts/test_council.py`
- `python scripts/check_docs_consistency.py`
- `python scripts/check_file_sizes.py`
- `python scripts/check_ratchets.py`
- `mypy --strict --no-warn-unused-ignores --ignore-missing-imports src/deepr/core src/deepr/providers src/deepr/mcp`
- `python -m pytest tests/unit/ -q --cov=src/deepr --cov-branch --cov-report=term --cov-report=xml:.agent/cycle17-coverage.xml`
- `git diff --check`

Full unit result: 7074 passed, 8 skipped, 84.23 percent branch coverage.

Deepr spend stayed `$0`; live validation consumed explicit subscription plan quota only. Grok and Antigravity remain explicit-only despite passing transport and consult-contract validation.
