### PR TITLE
feat: route expert chat streaming through backend

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,17 +148,16 @@ The fleet-autopilot track (Phase 4d) is largely closed; the active edge is quali
    Anthropic Messages `ExpertChatBackend` with tools and streaming disabled,
    unsupported OpenAI sampling params omitted, and Anthropic usage buckets
    settled through the chat ledger. Primary non-streaming answer-generation
-   turns, streaming setup/tool rounds, follow-up suggestions, compaction
-   support calls, quick lookup, and standard-research fallback calls now run
-   through the `ExpertChatBackend` seam. Final token streaming still uses the
-   direct OpenAI provider stream until the backend contract grows a streaming
-   interface, and deep-research job submission still uses the OpenAI Responses
-   API path until there is a separate research-job backend contract. Local
-   Ollama and plan-quota `ExpertChatBackend` adapters are wired into public
-   read-only query routing with tools and streaming declared unsupported. Next:
+   turns, streaming setup/tool rounds, final OpenAI token streaming, follow-up
+   suggestions, compaction support calls, quick lookup, and standard-research
+   fallback calls now run through the `ExpertChatBackend` seam. Deep-research
+   job submission still uses the OpenAI Responses API path until there is a
+   separate research-job backend contract. Local Ollama and plan-quota
+   `ExpertChatBackend` adapters are wired into public read-only query routing
+   with tools and streaming declared unsupported. Next:
    [expert-chat-capacity-backends.md](docs/design/expert-chat-capacity-backends.md):
-   broaden backend parity behind no-fallback, tool-policy, streaming, and
-   budget-ledger gates.
+   broaden backend parity behind no-fallback, tool-policy, provider-streaming,
+   and budget-ledger gates.
 5. **Level 5 consult trace and semantic quality flywheel** - stored-belief perspectives, ledgered synthesis, `$0` consult evals, explicit local/plan synthesis, MCP-owned-capacity consult arguments, replayable `deepr-consult-trace-v1` records, sanitized `deepr-consult-trace-candidates-v1` review, `deepr-consult-quality-eval-case-v1` semantic review packets, and `deepr-consult-quality-review-v1` scored review artifacts are in place. `deepr expert review-consult-quality` now records human or calibrated-model scores, blocks lexical verdicts, enforces reviewer and acceptance gates, and promotes only accepted cases into gap or eval artifacts without writing beliefs. Next connect those reviewed artifacts to trend reporting, consult prompt regression selection, and calibrated-model judge runs behind explicit local, plan, or budgeted API capacity. Keep the trace contract disciplined: include a small always-present context packet, keep larger belief/source/gap packets context-selected, validate generated trace and host-handoff artifacts against schema before they ship, and report which checks ran so a failed consult can become a durable regression case. Why: consult is Deepr's primary team-of-experts surface, and self-improvement only works when failures become durable test cases instead of one-off anecdotes. See [level-5-6-expert-maturity.md](docs/design/level-5-6-expert-maturity.md).
 6. **Expert self-model and metacognitive monitor** - first-class read-only `deepr-expert-self-model-v1` records are in place for capabilities, limits, current goals, calibration, learning strategy, continuity summary, blocked capabilities, unresolved risks, and a bounded current-focus packet. Consult perspective context now carries the self-model focus packet when an expert profile is available, and sync learning loop records plus sync capacity gates now carry the same compact packet as read-only run context. `deepr expert monitor` now emits a read-only `deepr-metacognitive-monitor-v1` artifact that turns self-model risks, failed loop runs, capacity blocks, and consult trace candidates into review-required proposals without applying them. `deepr expert promote-monitor` previews by default and applies only with `--apply`, promoting one reviewed gap/eval proposal into a metacognition gap and/or local eval-case artifact. `deepr expert propose-self-model` now previews or writes a verifier-gated `deepr-expert-self-model-update-v1` review record for self-model-related monitor proposals, and `deepr expert accept-self-model` writes a separate `deepr-expert-self-model-update-acceptance-v1` artifact only when outcome evidence and policy gates are explicit. Accepted records are attached to sync loop-run context as read-only guidance; they do not mutate the derived self-model or grant authority. Next connect accepted records to concrete learning-policy effects only when measured before/after outcomes exist. Why: Level 5/6 in Deepr means the expert can inspect and improve its learning process while deterministic workflow code still owns spend, writes, schemas, rollout, and review gates.
    The consciousness-adjacent part should stay named as digital continuity: `deepr expert memory-card` now provides the first grounded identity envelope for a durable expert, joining self-model focus, belief events, current goals, calibration, gaps, contradictions, and update policy in `EXPERT.md`. Next attach accepted self-model records and loop-history deltas to the same working-state packet for learning transactions.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a streaming method to the expert-chat backend contract and routed final
+  OpenAI token streaming through `OpenAIExpertChatBackend`, including streamed
+  usage settlement. Local, plan, and Anthropic expert-chat backends continue to
+  declare streaming unsupported until provider-specific policy and tests exist.
 - Added explicit Anthropic API support for non-agentic MCP
   `deepr_query_expert backend=api` calls. `provider=anthropic` now selects a
   native Anthropic Messages `ExpertChatBackend`, disables tools and streaming,

--- a/docs/design/expert-chat-capacity-backends.md
+++ b/docs/design/expert-chat-capacity-backends.md
@@ -35,11 +35,10 @@ cost ledger.
   turn, follow-up suggestions, and conversation compaction now go through
   `ExpertChatBackend` with `OpenAIExpertChatBackend`. Quick lookup and the
   standard-research fallback now use the same backend seam while preserving
-  their operation-specific budget checks and ledger records. Final token
-  streaming still uses the direct provider stream until the backend contract
-  grows a streaming interface. Deep-research job submission still uses the
-  OpenAI Responses API path because it is a research-job contract, not one
-  normalized chat turn. `LocalOllamaExpertChatBackend` and
+  their operation-specific budget checks and ledger records. Final OpenAI token
+  streaming now uses the backend streaming contract. Deep-research job
+  submission still uses the OpenAI Responses API path because it is a
+  research-job contract, not one normalized chat turn. `LocalOllamaExpertChatBackend` and
   `PlanQuotaExpertChatBackend` now implement the same normalized backend
   contract for read-only compiled-context turns, declare no tools, no
   streaming, no prompt cache, and no Deepr dollar spend. MCP
@@ -154,6 +153,9 @@ class ExpertChatBackend(Protocol):
     supports_prompt_cache: bool
 
     async def complete(self, request: ExpertChatRequest) -> ExpertChatResult:
+        ...
+
+    def stream(self, request: ExpertChatRequest) -> AsyncIterator[ExpertChatStreamChunk]:
         ...
 ```
 
@@ -299,8 +301,9 @@ side-effect policy.
    behavior changes. (partial 2026-06-30: primary non-streaming
    answer-generation chat-completion turns, streaming setup/tool rounds,
    follow-up suggestions, conversation compaction, quick lookup, and
-   standard-research fallback now use `OpenAIExpertChatBackend`; final token
-   streaming waits for a streaming backend contract)
+   standard-research fallback now use `OpenAIExpertChatBackend`; updated
+   2026-06-30: final OpenAI token streaming now uses the backend streaming
+   contract)
 6. Add local and plan chat backends in read-only compiled-context mode.
    (done 2026-06-30: `LocalOllamaExpertChatBackend` and
    `PlanQuotaExpertChatBackend` implement the backend protocol with tools,

--- a/src/deepr/experts/chat.py
+++ b/src/deepr/experts/chat.py
@@ -16,6 +16,7 @@ from deepr.experts.chat_api_backends import build_api_expert_chat_backend, estim
 from deepr.experts.chat_backends import (
     ExpertChatRequest,
     complete_expert_chat_turn,
+    stream_expert_chat_turn,
 )
 from deepr.experts.chat_turns import (
     chat_generation_budget_denial,
@@ -2296,27 +2297,19 @@ Budget remaining: ${budget_remaining:.2f}
                 # No content yet - need a streaming call for the final answer
                 report_status("Generating response...")
                 conversation_messages.append(current_message)
-                stream_params = {
-                    "model": selected_model.model,
-                    "messages": conversation_messages,
-                    "stream": True,
-                    "stream_options": {"include_usage": True},
-                }
-                if selected_model.reasoning_effort and selected_model.provider == "openai":
-                    stream_params["reasoning_effort"] = selected_model.reasoning_effort
-
-                stream = await self.client.chat.completions.create(**stream_params)
                 final_message = ""
                 stream_usage = None
-                async for chunk in stream:
-                    usage = getattr(chunk, "usage", None)
-                    if usage is not None:
-                        stream_usage = usage
-                    delta = chunk.choices[0].delta if chunk.choices else None
-                    if delta and delta.content:
-                        final_message += delta.content
+                async for chunk in stream_expert_chat_turn(
+                    self.chat_backend,
+                    selected_model=selected_model,
+                    messages=conversation_messages,
+                ):
+                    if chunk.usage is not None:
+                        stream_usage = chunk.usage
+                    if chunk.text_delta:
+                        final_message += chunk.text_delta
                         if token_callback:
-                            token_callback(delta.content)
+                            token_callback(chunk.text_delta)
                 if stream_usage is not None:
                     self._account_chat_cost(stream_usage, selected_model)
             else:

--- a/src/deepr/experts/chat_backends.py
+++ b/src/deepr/experts/chat_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any, Protocol
@@ -34,6 +35,15 @@ class ExpertChatResult:
         return str(getattr(self.message, "content", "") or "")
 
 
+@dataclass(frozen=True)
+class ExpertChatStreamChunk:
+    """Normalized stream event for one expert chat text delta or usage update."""
+
+    text_delta: str = ""
+    usage: Any | None = None
+    raw_chunk: Any | None = None
+
+
 class ExpertChatUnsupportedFeature(ValueError):
     """Raised when a backend is asked to use a feature it does not declare."""
 
@@ -50,6 +60,9 @@ class ExpertChatBackend(Protocol):
 
     async def complete(self, request: ExpertChatRequest) -> ExpertChatResult:
         """Complete one chat turn."""
+
+    def stream(self, request: ExpertChatRequest) -> AsyncIterator[ExpertChatStreamChunk]:
+        """Stream one chat turn."""
 
 
 def _chat_reasoning_effort(model: Any) -> str | None:
@@ -78,6 +91,24 @@ async def complete_expert_chat_turn(
     )
 
 
+def stream_expert_chat_turn(
+    backend: ExpertChatBackend,
+    *,
+    selected_model: Any,
+    messages: list[Any],
+) -> AsyncIterator[ExpertChatStreamChunk]:
+    """Build and stream one expert chat turn through the configured backend."""
+    if not backend.supports_streaming:
+        raise ExpertChatUnsupportedFeature(f"{backend.provider} expert-chat backend does not support streaming")
+    return backend.stream(
+        ExpertChatRequest(
+            model=selected_model.model,
+            messages=messages,
+            reasoning_effort=_chat_reasoning_effort(selected_model),
+        )
+    )
+
+
 class OpenAIExpertChatBackend:
     """OpenAI chat-completions backend preserving the legacy chat path."""
 
@@ -92,6 +123,29 @@ class OpenAIExpertChatBackend:
         self.model = model
 
     async def complete(self, request: ExpertChatRequest) -> ExpertChatResult:
+        params = self._build_params(request)
+        response = await self.client.chat.completions.create(**params)
+        choice = response.choices[0]
+        return ExpertChatResult(
+            message=choice.message,
+            usage=getattr(response, "usage", None),
+            raw_response=response,
+            provider_request_id=str(getattr(response, "id", "") or ""),
+            stop_reason=str(getattr(choice, "finish_reason", "") or ""),
+        )
+
+    async def stream(self, request: ExpertChatRequest) -> AsyncIterator[ExpertChatStreamChunk]:
+        params = self._build_params(request)
+        params["stream"] = True
+        params["stream_options"] = {"include_usage": True}
+        stream = await self.client.chat.completions.create(**params)
+        async for chunk in stream:
+            usage = getattr(chunk, "usage", None)
+            delta = chunk.choices[0].delta if getattr(chunk, "choices", None) else None
+            text_delta = str(getattr(delta, "content", "") or "") if delta else ""
+            yield ExpertChatStreamChunk(text_delta=text_delta, usage=usage, raw_chunk=chunk)
+
+    def _build_params(self, request: ExpertChatRequest) -> dict[str, Any]:
         params: dict[str, Any] = {
             "model": request.model,
             "messages": request.messages,
@@ -103,16 +157,7 @@ class OpenAIExpertChatBackend:
         if request.reasoning_effort:
             params["reasoning_effort"] = request.reasoning_effort
         params.update(request.extra)
-
-        response = await self.client.chat.completions.create(**params)
-        choice = response.choices[0]
-        return ExpertChatResult(
-            message=choice.message,
-            usage=getattr(response, "usage", None),
-            raw_response=response,
-            provider_request_id=str(getattr(response, "id", "") or ""),
-            stop_reason=str(getattr(choice, "finish_reason", "") or ""),
-        )
+        return params
 
 
 class AnthropicExpertChatBackend:
@@ -146,6 +191,9 @@ class AnthropicExpertChatBackend:
             provider_request_id=str(getattr(response, "_request_id", "") or getattr(response, "id", "") or ""),
             stop_reason=stop_reason,
         )
+
+    def stream(self, request: ExpertChatRequest) -> AsyncIterator[ExpertChatStreamChunk]:
+        raise ExpertChatUnsupportedFeature("anthropic expert-chat backend does not support streaming yet")
 
     def _build_params(self, request: ExpertChatRequest, *, model: str) -> dict[str, Any]:
         extra = dict(request.extra)
@@ -244,6 +292,9 @@ class _OpenAIShapeNoToolExpertChatBackend:
             provider_request_id=str(getattr(response, "id", "") or ""),
             stop_reason=str(getattr(choice, "finish_reason", "") or ""),
         )
+
+    def stream(self, request: ExpertChatRequest) -> AsyncIterator[ExpertChatStreamChunk]:
+        raise ExpertChatUnsupportedFeature(f"{self.provider} expert-chat backend does not support streaming")
 
     def _build_params(self, request: ExpertChatRequest) -> dict[str, Any]:
         model = request.model or self.model

--- a/tests/unit/test_experts/test_chat_backends.py
+++ b/tests/unit/test_experts/test_chat_backends.py
@@ -9,6 +9,7 @@ import pytest
 from deepr.experts.chat_backends import (
     AnthropicExpertChatBackend,
     ExpertChatRequest,
+    ExpertChatStreamChunk,
     ExpertChatUnsupportedFeature,
     LocalOllamaExpertChatBackend,
     OpenAIExpertChatBackend,
@@ -51,6 +52,57 @@ async def test_openai_chat_backend_passes_request_shape_and_normalizes_result():
     assert result.usage.prompt_tokens == 7
     assert result.provider_request_id == "chatcmpl_123"
     assert result.stop_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_backend_streams_deltas_and_usage():
+    captured: dict[str, object] = {}
+
+    class FakeStream:
+        def __init__(self):
+            self._chunks = [
+                SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="hel"))], usage=None),
+                SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="lo"))], usage=None),
+                SimpleNamespace(choices=[], usage=SimpleNamespace(prompt_tokens=8, completion_tokens=2)),
+            ]
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._chunks:
+                raise StopAsyncIteration
+            return self._chunks.pop(0)
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return FakeStream()
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=FakeCompletions()))
+    backend = OpenAIExpertChatBackend(client, model="gpt-5.2")
+
+    chunks = [
+        chunk
+        async for chunk in backend.stream(
+            ExpertChatRequest(
+                model="gpt-5.2",
+                messages=[{"role": "user", "content": "q"}],
+                reasoning_effort="low",
+            )
+        )
+    ]
+
+    assert captured == {
+        "model": "gpt-5.2",
+        "messages": [{"role": "user", "content": "q"}],
+        "reasoning_effort": "low",
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    assert [chunk.text_delta for chunk in chunks] == ["hel", "lo", ""]
+    assert isinstance(chunks[0], ExpertChatStreamChunk)
+    assert chunks[-1].usage.prompt_tokens == 8
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_experts/test_chat_budget.py
+++ b/tests/unit/test_experts/test_chat_budget.py
@@ -9,7 +9,7 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 from deepr.experts.chat import ExpertChatSession
-from deepr.experts.chat_backends import ExpertChatResult
+from deepr.experts.chat_backends import ExpertChatResult, ExpertChatStreamChunk
 from deepr.experts.cost_safety import CostSafetyManager, reset_cost_safety_manager
 from deepr.experts.profile import ExpertProfile
 
@@ -31,6 +31,8 @@ class RecordingChatBackend:
 
     def __init__(self, *contents) -> None:
         self.requests = []
+        self.stream_requests = []
+        self.stream_chunks = []
         self._contents = list(contents)
 
     async def complete(self, request):
@@ -40,6 +42,11 @@ class RecordingChatBackend:
             message=SimpleNamespace(content=content, tool_calls=[]),
             usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5),
         )
+
+    async def stream(self, request):
+        self.stream_requests.append(request)
+        for chunk in self.stream_chunks:
+            yield chunk
 
 
 class RecordingNoToolChatBackend(RecordingChatBackend):
@@ -415,32 +422,17 @@ async def test_streaming_final_response_accounts_stream_usage(monkeypatch):
     accounted = []
     emitted = []
 
-    class FakeStream:
-        def __init__(self):
-            self._chunks = [
-                SimpleNamespace(
-                    choices=[SimpleNamespace(delta=SimpleNamespace(content="hello"))],
-                    usage=None,
-                ),
-                SimpleNamespace(choices=[], usage=SimpleNamespace(prompt_tokens=20, completion_tokens=7)),
-            ]
+    async def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("final streaming should run through chat_backend.stream")
 
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if not self._chunks:
-                raise StopAsyncIteration
-            return self._chunks.pop(0)
-
-    async def fake_stream_create(**kwargs):
-        assert kwargs["stream"] is True
-        assert kwargs["stream_options"] == {"include_usage": True}
-        return FakeStream()
-
-    monkeypatch.setattr(session.client.chat.completions, "create", fake_stream_create)
+    monkeypatch.setattr(session.client.chat.completions, "create", fail_if_called)
     session._account_chat_cost = lambda usage, model: accounted.append(usage)
-    session.chat_backend = RecordingChatBackend(None, "[]")
+    backend = RecordingChatBackend(None, "[]")
+    backend.stream_chunks = [
+        ExpertChatStreamChunk(text_delta="hello"),
+        ExpertChatStreamChunk(usage=SimpleNamespace(prompt_tokens=20, completion_tokens=7)),
+    ]
+    session.chat_backend = backend
 
     result = await session.send_message_streaming(
         "Stream a final answer",
@@ -449,4 +441,6 @@ async def test_streaming_final_response_accounts_stream_usage(monkeypatch):
 
     assert result == "hello"
     assert emitted == ["hello"]
+    assert len(backend.stream_requests) == 1
+    assert backend.stream_requests[0].model == session.expert.model
     assert [(u.prompt_tokens, u.completion_tokens) for u in accounted] == [(20, 7), (10, 5)]


### PR DESCRIPTION
## Summary

- add `ExpertChatStreamChunk` and a backend streaming method to the expert-chat backend contract
- route final OpenAI token streaming through `OpenAIExpertChatBackend.stream()`
- keep local, plan, and Anthropic expert-chat backends explicitly non-streaming
- update roadmap and design docs to remove the stale direct-stream caveat

## Validation

- `.agent\cycle2-sync-dev-full\Scripts\python.exe -m pytest tests\unit\test_experts\test_chat_backends.py tests\unit\test_experts\test_chat_budget.py -q`
- `.agent\cycle2-sync-dev-full\Scripts\python.exe -m pytest tests\unit\test_experts tests\unit\test_mcp -q`
- `.agent\cycle2-sync-dev-full\Scripts\python.exe -m pytest tests/unit/ -q --cov=src/deepr --cov-branch --cov-report=term --cov-report=xml:.agent/cycle20-coverage.xml`
- `.agent\cycle2-sync-dev-full\Scripts\ruff.exe check src\deepr`
- `.agent\cycle2-sync-dev-full\Scripts\ruff.exe format --check src\deepr`
- `.agent\cycle2-sync-dev-full\Scripts\python.exe scripts\check_file_sizes.py`
- `.agent\cycle2-sync-dev-full\Scripts\python.exe scripts\check_ratchets.py`
- `.agent\cycle2-sync-dev-full\Scripts\python.exe scripts\check_docs_consistency.py`
- `.agent\cycle2-sync-dev-full\Scripts\python.exe -m mypy --strict --no-warn-unused-ignores --ignore-missing-imports src/deepr/core src/deepr/providers src/deepr/mcp`
- `git diff --check`

Full unit result: 7088 passed, 8 skipped, branch coverage 84.20%.
