### PR TITLE
fix: enforce expert chat tool policy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,8 +150,10 @@ The fleet-autopilot track (Phase 4d) is largely closed; the active edge is quali
    settled through the chat ledger. Primary non-streaming answer-generation
    turns, streaming setup/tool rounds, final OpenAI token streaming, follow-up
    suggestions, compaction support calls, quick lookup, and standard-research
-   fallback calls now run through the `ExpertChatBackend` seam. Deep-research
-   job submission still uses the OpenAI Responses API path until there is a
+   fallback calls now run through the `ExpertChatBackend` seam. The shared
+   turn helper now rejects requested tools when the backend declares no tool
+   support and omits `tool_choice` on no-tool turns. Deep-research job
+   submission still uses the OpenAI Responses API path until there is a
    separate research-job backend contract. Local Ollama and plan-quota
    `ExpertChatBackend` adapters are wired into public read-only query routing
    with tools and streaming declared unsupported. Next:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Hardened expert-chat backend turn construction so requested tools are
+  rejected before dispatch when a backend declares no tool support, and
+  `tool_choice` is omitted on no-tool turns.
 - Made Anthropic-style expert-chat cost settlement use conservative fallback
   pricing when registry lookup fails, so metered input, output, cache-write,
   and cache-read usage cannot silently record as zero.

--- a/docs/design/expert-chat-capacity-backends.md
+++ b/docs/design/expert-chat-capacity-backends.md
@@ -46,7 +46,9 @@ cost ledger.
   read-only compiled-context turn. `AnthropicExpertChatBackend` now supports
   explicit non-agentic API query chat through the native Anthropic Messages API,
   with tools, streaming, and prompt-cache controls disabled until those policy
-  gates exist.
+  gates exist. The shared chat-turn helper rejects requested tools before
+  backend dispatch when `supports_tools=false` and omits `tool_choice` on
+  no-tool turns.
 - MCP `deepr_consult_experts` accepts `synthesis_backend=api|local|plan`.
   MCP `deepr_query_expert` accepts `backend=api|local|plan`. The default
   `api` path is OpenAI unless the caller explicitly sets `provider=anthropic`.
@@ -316,6 +318,8 @@ side-effect policy.
    rejects `agentic=true`, and records Anthropic usage buckets through the
    chat cost ledger)
 8. Add agentic tools per backend only when the backend declares support and the
-   tool has explicit cost and safety gates.
+   tool has explicit cost and safety gates. (partial 2026-06-30: the shared
+   chat-turn helper now enforces declared tool support before dispatch and
+   strips `tool_choice` from no-tool turns)
 9. Add prompt-cache controls only after cache estimation and settlement tests
    prove no silent-money path.

--- a/src/deepr/experts/chat_backends.py
+++ b/src/deepr/experts/chat_backends.py
@@ -80,12 +80,15 @@ async def complete_expert_chat_turn(
     tool_choice: str | None = "auto",
 ) -> ExpertChatResult:
     """Build and complete one expert chat turn through the configured backend."""
+    if tools and not backend.supports_tools:
+        raise ExpertChatUnsupportedFeature(f"{backend.provider} expert-chat backend does not support tools")
+    effective_tool_choice = tool_choice if tools else None
     return await backend.complete(
         ExpertChatRequest(
             model=selected_model.model,
             messages=messages,
             tools=tools,
-            tool_choice=tool_choice,
+            tool_choice=effective_tool_choice,
             reasoning_effort=_chat_reasoning_effort(selected_model),
         )
     )

--- a/tests/unit/test_experts/test_chat_backends.py
+++ b/tests/unit/test_experts/test_chat_backends.py
@@ -9,12 +9,81 @@ import pytest
 from deepr.experts.chat_backends import (
     AnthropicExpertChatBackend,
     ExpertChatRequest,
+    ExpertChatResult,
     ExpertChatStreamChunk,
     ExpertChatUnsupportedFeature,
     LocalOllamaExpertChatBackend,
     OpenAIExpertChatBackend,
     PlanQuotaExpertChatBackend,
+    complete_expert_chat_turn,
 )
+
+
+class RecordingChatBackend:
+    metered = False
+    supports_streaming = False
+    supports_prompt_cache = False
+
+    def __init__(self, *, supports_tools: bool, provider: str = "recording") -> None:
+        self.supports_tools = supports_tools
+        self.provider = provider
+        self.model = None
+        self.request: ExpertChatRequest | None = None
+
+    async def complete(self, request: ExpertChatRequest) -> ExpertChatResult:
+        self.request = request
+        return ExpertChatResult(message=SimpleNamespace(content="ok", tool_calls=[]))
+
+    def stream(self, request: ExpertChatRequest):
+        raise AssertionError("stream should not be called")
+
+
+@pytest.mark.asyncio
+async def test_complete_expert_chat_turn_omits_tool_choice_without_tools():
+    backend = RecordingChatBackend(supports_tools=True)
+
+    await complete_expert_chat_turn(
+        backend,
+        selected_model=SimpleNamespace(model="gpt-5.2", provider="openai", reasoning_effort="low"),
+        messages=[{"role": "user", "content": "q"}],
+    )
+
+    assert backend.request is not None
+    assert backend.request.tools is None
+    assert backend.request.tool_choice is None
+    assert backend.request.reasoning_effort == "low"
+
+
+@pytest.mark.asyncio
+async def test_complete_expert_chat_turn_rejects_tools_when_backend_does_not_support_them():
+    backend = RecordingChatBackend(supports_tools=False, provider="local")
+
+    with pytest.raises(ExpertChatUnsupportedFeature, match="does not support tools"):
+        await complete_expert_chat_turn(
+            backend,
+            selected_model=SimpleNamespace(model="qwen3:latest", provider="local", reasoning_effort=None),
+            messages=[{"role": "user", "content": "q"}],
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+        )
+
+    assert backend.request is None
+
+
+@pytest.mark.asyncio
+async def test_complete_expert_chat_turn_preserves_tool_choice_when_tools_supported():
+    backend = RecordingChatBackend(supports_tools=True)
+
+    await complete_expert_chat_turn(
+        backend,
+        selected_model=SimpleNamespace(model="gpt-5.2", provider="openai", reasoning_effort=None),
+        messages=[{"role": "user", "content": "q"}],
+        tools=[{"type": "function", "function": {"name": "lookup"}}],
+        tool_choice="auto",
+    )
+
+    assert backend.request is not None
+    assert backend.request.tools == [{"type": "function", "function": {"name": "lookup"}}]
+    assert backend.request.tool_choice == "auto"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Enforce `supports_tools` at the shared expert-chat turn helper before backend dispatch.
- Omit `tool_choice` on no-tool turns to avoid invalid OpenAI-shaped request drift.
- Update ROADMAP, CHANGELOG, and the backend design note to describe the shipped tool-policy gate without claiming full tool parity.

## Validation

- `python -m pytest tests/unit/test_experts/test_chat_backends.py tests/unit/test_experts/test_chat_budget.py -q`
- `ruff check src/deepr tests/unit/test_experts/test_chat_backends.py`
- `ruff format --check src/deepr tests/unit/test_experts/test_chat_backends.py`
- `python scripts/check_docs_consistency.py`
- `python scripts/check_file_sizes.py`
- `python scripts/check_ratchets.py`
- `mypy --strict --no-warn-unused-ignores --ignore-missing-imports src/deepr/core src/deepr/providers src/deepr/mcp`
- `python -m pytest tests/unit/ --ignore=tests/data -q --tb=short --cov=deepr --cov-report=term-missing`

Full unit result: 7092 passed, 8 skipped, branch coverage 84.12 percent.
