### PR TITLE
feat: stream anthropic expert chat

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,10 +145,11 @@ The fleet-autopilot track (Phase 4d) is largely closed; the active edge is quali
    cost estimation. This is not full interactive chat backend parity: the
    default `backend=api` path remains the OpenAI-shaped chat path, but explicit
    `provider=anthropic` now runs non-agentic API query chat through a native
-   Anthropic Messages `ExpertChatBackend` with tools and streaming disabled,
-   unsupported OpenAI sampling params omitted, and Anthropic usage buckets
-   settled through the chat ledger. Primary non-streaming answer-generation
-   turns, streaming setup/tool rounds, final OpenAI token streaming, follow-up
+   Anthropic Messages `ExpertChatBackend` with tools disabled, native
+   non-agentic text streaming supported, unsupported OpenAI sampling params
+   omitted, and Anthropic usage buckets settled through the chat ledger.
+   Primary non-streaming answer-generation turns, streaming setup/tool rounds,
+   final OpenAI and Anthropic token streaming, follow-up
    suggestions, compaction support calls, quick lookup, and standard-research
    fallback calls now run through the `ExpertChatBackend` seam. The shared
    turn helper now rejects requested tools when the backend declares no tool

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,16 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and cache-read usage cannot silently record as zero.
 
 ### Added
+- Added non-agentic Anthropic expert-chat streaming through the native
+  Messages stream helper, yielding text deltas and final usage for cost
+  settlement while tools remain disabled.
 - Added a streaming method to the expert-chat backend contract and routed final
   OpenAI token streaming through `OpenAIExpertChatBackend`, including streamed
-  usage settlement. Local, plan, and Anthropic expert-chat backends continue to
+  usage settlement. Local and plan expert-chat backends continue to
   declare streaming unsupported until provider-specific policy and tests exist.
 - Added explicit Anthropic API support for non-agentic MCP
   `deepr_query_expert backend=api` calls. `provider=anthropic` now selects a
-  native Anthropic Messages `ExpertChatBackend`, disables tools and streaming,
-  omits OpenAI-only sampling parameters, rejects `agentic=true`, and records
-  Anthropic input, output, cache-write, and cache-read token buckets through
-  the chat cost ledger.
+  native Anthropic Messages `ExpertChatBackend`, disables tools, supports
+  non-agentic text streaming, omits OpenAI-only sampling parameters, rejects
+  `agentic=true`, and records Anthropic input, output, cache-write, and
+  cache-read token buckets through the chat cost ledger.
 - Wired MCP `deepr_query_expert backend=local|plan` to the owned-capacity
   `ExpertChatBackend` adapters for one read-only compiled-context turn. These
   modes now attach `readonly_chat_artifact`, keep `research_triggered=0`,

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -102,8 +102,9 @@ must not be described as usable capacity.
   `research_triggered=0`, and no live metered fallback.
   `deepr_query_expert backend=api` supports OpenAI by default and explicit
   `provider=anthropic` for non-agentic metered API turns. The Anthropic path
-  uses the native Messages API, disables tools and streaming, rejects
-  `agentic=true`, and records Anthropic usage buckets through the chat ledger.
+  uses the native Messages API, disables tools, supports non-agentic text
+  streaming, rejects `agentic=true`, and records Anthropic usage buckets
+  through the chat ledger.
   Passing several experts gives a bounded council with preserved dissent. CLI
   and MCP consults append local
   `deepr-consult-trace-v1` records with selected context metadata, checks run,

--- a/docs/design/expert-chat-capacity-backends.md
+++ b/docs/design/expert-chat-capacity-backends.md
@@ -45,10 +45,10 @@ cost ledger.
   `deepr_query_expert backend=local|plan` selects those adapters for one
   read-only compiled-context turn. `AnthropicExpertChatBackend` now supports
   explicit non-agentic API query chat through the native Anthropic Messages API,
-  with tools, streaming, and prompt-cache controls disabled until those policy
-  gates exist. The shared chat-turn helper rejects requested tools before
-  backend dispatch when `supports_tools=false` and omits `tool_choice` on
-  no-tool turns.
+  with native text streaming and final usage settlement. Tools and prompt-cache
+  controls remain disabled until those policy gates exist. The shared chat-turn
+  helper rejects requested tools before backend dispatch when
+  `supports_tools=false` and omits `tool_choice` on no-tool turns.
 - MCP `deepr_consult_experts` accepts `synthesis_backend=api|local|plan`.
   MCP `deepr_query_expert` accepts `backend=api|local|plan`. The default
   `api` path is OpenAI unless the caller explicitly sets `provider=anthropic`.
@@ -57,8 +57,8 @@ cost ledger.
   through the owned-capacity backend seam, with live metered fallback disabled,
   no research trigger, and a `readonly_chat_artifact` attached to the result.
 - `AnthropicProvider` is still a research provider. Expert chat uses the
-  narrower native `AnthropicExpertChatBackend` because chat turns need a
-  different request/result/cost contract than research jobs.
+  narrower native `AnthropicExpertChatBackend` because chat turns and text
+  streams need a different request/result/cost contract than research jobs.
 
 ## 2026 Provider Findings
 
@@ -256,8 +256,9 @@ and an Anthropic model.
 ## Cost And Security Rules
 
 - API backend requires a positive budget and an approved scoped key or local
-  operator confirmation. Anthropic API query chat is non-agentic only until
-  tool and streaming support have explicit backend capability checks.
+  operator confirmation. Anthropic API query chat supports non-agentic text
+  streaming, but remains non-agentic until tool support has explicit backend
+  capability checks.
 - Local and plan backends allow `budget=0` and must set
   `live_metered_fallback=false`.
 - No backend may fall through to another capacity tier without an explicit
@@ -314,7 +315,8 @@ side-effect policy.
 7. Add Anthropic expert chat in non-agentic mode.
    (done 2026-06-30: MCP `deepr_query_expert backend=api
    provider=anthropic` selects a native Anthropic Messages backend, omits
-   OpenAI-only sampling params, disables tools/streaming/prompt cache controls,
+   OpenAI-only sampling params, disables tools and prompt-cache controls,
+   supports native non-agentic text streaming with final usage settlement,
    rejects `agentic=true`, and records Anthropic usage buckets through the
    chat cost ledger)
 8. Add agentic tools per backend only when the backend declares support and the

--- a/src/deepr/experts/chat_backends.py
+++ b/src/deepr/experts/chat_backends.py
@@ -169,7 +169,7 @@ class AnthropicExpertChatBackend:
     provider = "anthropic"
     metered = True
     supports_tools = False
-    supports_streaming = False
+    supports_streaming = True
     supports_prompt_cache = False
 
     def __init__(self, client: Any, *, model: str) -> None:
@@ -195,8 +195,19 @@ class AnthropicExpertChatBackend:
             stop_reason=stop_reason,
         )
 
-    def stream(self, request: ExpertChatRequest) -> AsyncIterator[ExpertChatStreamChunk]:
-        raise ExpertChatUnsupportedFeature("anthropic expert-chat backend does not support streaming yet")
+    async def stream(self, request: ExpertChatRequest) -> AsyncIterator[ExpertChatStreamChunk]:
+        if request.tools:
+            raise ExpertChatUnsupportedFeature("anthropic expert-chat backend does not support tools yet")
+
+        model = request.model if request.model.startswith("claude-") else self.model
+        params = self._build_params(request, model=model)
+        async with self.client.messages.stream(**params) as stream:
+            async for text_delta in stream.text_stream:
+                yield ExpertChatStreamChunk(text_delta=str(text_delta), raw_chunk=text_delta)
+            final_message = await stream.get_final_message()
+            usage = getattr(final_message, "usage", None)
+            if usage is not None:
+                yield ExpertChatStreamChunk(usage=usage, raw_chunk=final_message)
 
     def _build_params(self, request: ExpertChatRequest, *, model: str) -> dict[str, Any]:
         extra = dict(request.extra)

--- a/tests/unit/test_experts/test_chat_backends.py
+++ b/tests/unit/test_experts/test_chat_backends.py
@@ -212,6 +212,7 @@ async def test_anthropic_chat_backend_uses_native_messages_shape_and_usage():
     assert backend.provider == "anthropic"
     assert backend.metered is True
     assert backend.supports_tools is False
+    assert backend.supports_streaming is True
     assert captured == {
         "model": "claude-sonnet-4-6",
         "max_tokens": 123,
@@ -222,6 +223,76 @@ async def test_anthropic_chat_backend_uses_native_messages_shape_and_usage():
     assert result.usage.input_tokens == 11
     assert result.provider_request_id == "req_123"
     assert result.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_chat_backend_streams_text_and_final_usage():
+    captured: dict[str, object] = {}
+
+    class AsyncTextStream:
+        def __init__(self, chunks):
+            self._chunks = list(chunks)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._chunks:
+                raise StopAsyncIteration
+            return self._chunks.pop(0)
+
+    class FakeStream:
+        def __init__(self):
+            self.text_stream = AsyncTextStream(["hel", "lo"])
+
+        async def get_final_message(self):
+            return SimpleNamespace(
+                usage=SimpleNamespace(
+                    input_tokens=9,
+                    output_tokens=2,
+                    cache_creation_input_tokens=1,
+                    cache_read_input_tokens=3,
+                )
+            )
+
+    class FakeStreamManager:
+        async def __aenter__(self):
+            return FakeStream()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    class FakeMessages:
+        def stream(self, **kwargs):
+            captured.update(kwargs)
+            return FakeStreamManager()
+
+    client = SimpleNamespace(messages=FakeMessages())
+    backend = AnthropicExpertChatBackend(client, model="claude-sonnet-4-6")
+
+    chunks = [
+        chunk
+        async for chunk in backend.stream(
+            ExpertChatRequest(
+                model="claude-sonnet-4-6",
+                messages=[
+                    {"role": "system", "content": "You are careful."},
+                    {"role": "user", "content": "q"},
+                ],
+                extra={"temperature": 0.2, "max_tokens": 123},
+            )
+        )
+    ]
+
+    assert captured == {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 123,
+        "messages": [{"role": "user", "content": "q"}],
+        "system": "You are careful.",
+    }
+    assert [chunk.text_delta for chunk in chunks] == ["hel", "lo", ""]
+    assert chunks[-1].usage.input_tokens == 9
+    assert chunks[-1].usage.output_tokens == 2
 
 
 @pytest.mark.asyncio
@@ -237,6 +308,25 @@ async def test_anthropic_chat_backend_rejects_tools():
                 tools=[{"type": "function", "function": {"name": "lookup"}}],
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_chat_backend_stream_rejects_tools():
+    client = SimpleNamespace(messages=SimpleNamespace())
+    backend = AnthropicExpertChatBackend(client, model="claude-sonnet-4-6")
+
+    with pytest.raises(ExpertChatUnsupportedFeature, match="does not support tools"):
+        chunks = [
+            chunk
+            async for chunk in backend.stream(
+                ExpertChatRequest(
+                    model="claude-sonnet-4-6",
+                    messages=[{"role": "user", "content": "q"}],
+                    tools=[{"type": "function", "function": {"name": "lookup"}}],
+                )
+            )
+        ]
+        assert chunks == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add non-agentic Anthropic expert-chat streaming through the native Messages stream helper.
- Emit normalized text deltas and final usage chunks so streamed Anthropic turns can use the existing cost settlement path.
- Keep Anthropic tools and prompt-cache controls disabled, and update docs to distinguish text streaming from full tool parity.

## Validation

- `python -m pytest tests/unit/test_experts/test_chat_backends.py tests/unit/test_experts/test_chat_budget.py tests/unit/test_experts/test_chat_token_cost.py -q`
- `ruff check src/deepr tests/unit/test_experts/test_chat_backends.py`
- `ruff format --check src/deepr tests/unit/test_experts/test_chat_backends.py`
- `python scripts/check_docs_consistency.py`
- `python scripts/check_file_sizes.py`
- `python scripts/check_ratchets.py`
- `mypy --strict --no-warn-unused-ignores --ignore-missing-imports src/deepr/core src/deepr/providers src/deepr/mcp`
- `python -m pytest tests/unit/ --ignore=tests/data -q --tb=short --cov=deepr --cov-report=term-missing`

Full unit result: 7094 passed, 8 skipped, branch coverage 84.12 percent.
