### PR TITLE
fix: harden cost and lifecycle boundaries

### DIFF
--- a/src/deepr/cli/commands/costs.py
+++ b/src/deepr/cli/commands/costs.py
@@ -570,6 +570,13 @@ def costs_doctor(drift_threshold: float, rebuild: bool):
     # Ledger storage sanity
     health = ledger.get_health()
     checks.append(("Ledger writable", bool(health.get("writable")), str(health.get("path", ledger_path))))
+    checks.append(
+        (
+            "Ledger accounting ready",
+            bool(health.get("accounting_ready")),
+            str(health.get("error") or health.get("path", ledger_path)),
+        )
+    )
 
     # Reconciliation drift check (dashboard is legacy mirror, ledger is canonical append-only)
     dashboard_total = sum(e.cost for e in dashboard.entries)

--- a/src/deepr/core/costs.py
+++ b/src/deepr/core/costs.py
@@ -4,9 +4,19 @@ import logging
 import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from math import isfinite
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _validated_money(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a finite non-negative number")
+    numeric = float(value)
+    if not isfinite(numeric) or numeric < 0:
+        raise ValueError(f"{field_name} must be a finite non-negative number")
+    return numeric
 
 
 @dataclass
@@ -250,9 +260,9 @@ class CostController:
             max_daily_cost: Maximum daily spending
             max_monthly_cost: Maximum monthly spending
         """
-        self.max_cost_per_job = max_cost_per_job
-        self.max_daily_cost = max_daily_cost
-        self.max_monthly_cost = max_monthly_cost
+        self.max_cost_per_job = _validated_money(max_cost_per_job, field_name="max_cost_per_job")
+        self.max_daily_cost = _validated_money(max_daily_cost, field_name="max_daily_cost")
+        self.max_monthly_cost = _validated_money(max_monthly_cost, field_name="max_monthly_cost")
 
         self._lock = threading.Lock()
         self.daily_spending = 0.0
@@ -269,26 +279,33 @@ class CostController:
         Returns:
             (allowed, reason) - reason is None if allowed
         """
+        min_cost = _validated_money(estimate.min_cost, field_name="estimate.min_cost")
+        max_cost = _validated_money(estimate.max_cost, field_name="estimate.max_cost")
+        expected_cost = _validated_money(estimate.expected_cost, field_name="estimate.expected_cost")
+        if not min_cost <= expected_cost <= max_cost:
+            raise ValueError("cost estimate must satisfy min_cost <= expected_cost <= max_cost")
+        self.reset_if_needed()
+
         # Check per-job limit
-        if estimate.max_cost > self.max_cost_per_job:
+        if max_cost > self.max_cost_per_job:
             return False, (
-                f"Job may cost ${estimate.max_cost:.2f}, exceeds limit of "
+                f"Job may cost ${max_cost:.2f}, exceeds limit of "
                 f"${self.max_cost_per_job:.2f}. Use --cost-sensitive or reduce scope."
             )
 
         # Check daily limit
-        if self.daily_spending + estimate.expected_cost > self.max_daily_cost:
+        if self.daily_spending + expected_cost > self.max_daily_cost:
             return False, (
                 f"Daily spending (${self.daily_spending:.2f}) + estimated cost "
-                f"(${estimate.expected_cost:.2f}) exceeds daily limit of "
+                f"(${expected_cost:.2f}) exceeds daily limit of "
                 f"${self.max_daily_cost:.2f}"
             )
 
         # Check monthly limit
-        if self.monthly_spending + estimate.expected_cost > self.max_monthly_cost:
+        if self.monthly_spending + expected_cost > self.max_monthly_cost:
             return False, (
                 f"Monthly spending (${self.monthly_spending:.2f}) + estimated cost "
-                f"(${estimate.expected_cost:.2f}) exceeds monthly limit of "
+                f"(${expected_cost:.2f}) exceeds monthly limit of "
                 f"${self.max_monthly_cost:.2f}"
             )
 
@@ -301,6 +318,7 @@ class CostController:
         recorded just after midnight (UTC) goes into the new day's
         bucket, not yesterday's.
         """
+        actual_cost = _validated_money(actual_cost, field_name="actual_cost")
         self.reset_if_needed()
         with self._lock:
             self.daily_spending += actual_cost

--- a/src/deepr/evals/benchmark_budget.py
+++ b/src/deepr/evals/benchmark_budget.py
@@ -44,20 +44,23 @@ class BenchmarkSpendGuard:
         ledger: CostLedger | None = None,
         reservation_store: ResearchReservationStore | None = None,
     ) -> None:
-        if not math.isfinite(budget) or budget <= 0:
+        if isinstance(budget, bool) or not isinstance(budget, (int, float)) or not math.isfinite(budget) or budget <= 0:
             raise BenchmarkBudgetExceeded("Benchmark runtime budget must be finite and greater than zero")
         config = load_config()
         self.budget = float(budget)
         self.run_id = run_id or uuid.uuid4().hex
         self._ledger = ledger or CostLedger()
-        self._store = reservation_store or ResearchReservationStore()
         self._max_daily = float(config.get("max_daily_cost", 25.0))
         self._max_monthly = float(config.get("max_monthly_cost", 200.0))
         self._lock = threading.Lock()
         self._scheduled_cost = 0.0
         self._sequence = 0
-        if not self._ledger.get_health()["writable"]:
+        health = self._ledger.get_health()
+        if not health["writable"]:
             raise BenchmarkBudgetExceeded("Canonical cost ledger is not writable")
+        if not health.get("accounting_ready", False):
+            raise BenchmarkBudgetExceeded("Canonical cost ledger is not accounting-ready")
+        self._store = reservation_store or ResearchReservationStore()
 
     @property
     def scheduled_cost(self) -> float:
@@ -75,7 +78,12 @@ class BenchmarkSpendGuard:
         metadata: dict[str, object] | None = None,
     ) -> BenchmarkCostReservation:
         """Durably reserve one call before it is submitted."""
-        if not math.isfinite(cost_ceiling) or cost_ceiling < 0:
+        if (
+            isinstance(cost_ceiling, bool)
+            or not isinstance(cost_ceiling, (int, float))
+            or not math.isfinite(cost_ceiling)
+            or cost_ceiling < 0
+        ):
             raise BenchmarkBudgetExceeded("Benchmark call ceiling must be finite and non-negative")
         with self._lock:
             projected = self._scheduled_cost + cost_ceiling

--- a/src/deepr/experts/budget_manager.py
+++ b/src/deepr/experts/budget_manager.py
@@ -9,7 +9,17 @@ Requirements: 5.2 - Extract monthly budget tracking logic
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from math import isfinite
 from typing import Any
+
+
+def _validated_money(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a finite non-negative number")
+    numeric = float(value)
+    if not isfinite(numeric) or numeric < 0:
+        raise ValueError(f"{field_name} must be a finite non-negative number")
+    return numeric
 
 
 @dataclass
@@ -38,8 +48,18 @@ class BudgetManager:
 
     def __post_init__(self):
         """Initialize reset date if not set."""
+        self.monthly_budget = _validated_money(self.monthly_budget, field_name="monthly_budget")
+        self.monthly_spending = _validated_money(self.monthly_spending, field_name="monthly_spending")
+        self.total_spending = _validated_money(self.total_spending, field_name="total_spending")
         if isinstance(self.reset_date, str):
             self.reset_date = datetime.fromisoformat(self.reset_date)
+        if self.reset_date is not None and not isinstance(self.reset_date, datetime):
+            raise ValueError("reset_date must be an ISO-8601 datetime")
+        if self.reset_date is not None and (self.reset_date.tzinfo is None or self.reset_date.utcoffset() is None):
+            # Earlier profile versions could persist this UTC month boundary
+            # without an offset. Preserve those profiles without allowing a
+            # naive/aware comparison to crash budget admission.
+            self.reset_date = self.reset_date.replace(tzinfo=UTC)
         if self.reset_date is None:
             self._initialize_reset_date()
 
@@ -104,6 +124,7 @@ class BudgetManager:
         Returns:
             Tuple of (can_spend, reason_message)
         """
+        amount = _validated_money(amount, field_name="amount")
         self.check_and_reset_if_needed()
 
         if amount <= 0:
@@ -127,6 +148,7 @@ class BudgetManager:
             operation: Type of operation (refresh, research, etc.)
             details: Optional details about the operation
         """
+        amount = _validated_money(amount, field_name="amount")
         self.check_and_reset_if_needed()
 
         self.monthly_spending += amount

--- a/src/deepr/experts/consult_lifecycle.py
+++ b/src/deepr/experts/consult_lifecycle.py
@@ -260,6 +260,12 @@ def load_consult_lifecycle_events(*, trace_id: str | None = None, path: Path | N
     if trace_id is not None:
         _validate_trace_id(trace_id)
     target = _journal_path(path)
+    try:
+        exists = target.exists()
+    except (OSError, RuntimeError) as exc:
+        raise ConsultLifecycleStorageError("journal lookup", partial_write_possible=False) from exc
+    if not exists:
+        return []
     ensure_journal_parent(target)
     with _bounded_journal_lock(target, _DEFAULT_LOCK_TIMEOUT_SECONDS):
         events = _read_events_unlocked(target)
@@ -732,9 +738,11 @@ class ConsultLifecycle:
             if latest_state not in RESUMABLE_STATES:
                 raise ConsultLifecycleTransitionError(f"Lifecycle {trace_id} cannot resume from {latest_state.value}")
             normalized_bounds = _normalize_bounds(first["bounds"])
-            normalized_progress = _normalize_progress(progress or latest["progress"], normalized_bounds)
+            progress_value = latest["progress"] if progress is None else progress
+            normalized_progress = _normalize_progress(progress_value, normalized_bounds)
             cls._require_monotonic_progress(latest["progress"], normalized_progress)
-            normalized_capacity = _normalize_capacity(capacity or latest["capacity"])
+            capacity_value = latest["capacity"] if capacity is None else capacity
+            normalized_capacity = _normalize_capacity(capacity_value)
             latest_capacity = _normalize_capacity(_as_mapping(latest["capacity"], "latest capacity"))
             try:
                 _validate_capacity_transition(latest_capacity, normalized_capacity)
@@ -815,12 +823,14 @@ class ConsultLifecycle:
                 raise ConsultLifecycleTransitionError("Heartbeat events must remain running")
             if event_type is LifecycleEventType.STATE_TRANSITION and state is LifecycleState.RUNNING:
                 raise ConsultLifecycleTransitionError("Use heartbeat for a running event")
-            normalized_progress = _normalize_progress(progress or latest["progress"], self.bounds)
+            progress_value = latest["progress"] if progress is None else progress
+            normalized_progress = _normalize_progress(progress_value, self.bounds)
             self._require_monotonic_progress(latest["progress"], normalized_progress)
             cost_stopped = Decimal(str(normalized_progress["cost_usd_observed"])) > Decimal(
                 str(self.bounds["max_cost_usd"])
             )
-            normalized_capacity = _normalize_capacity(capacity or latest["capacity"])
+            capacity_value = latest["capacity"] if capacity is None else capacity
+            normalized_capacity = _normalize_capacity(capacity_value)
             latest_capacity = _normalize_capacity(_as_mapping(latest["capacity"], "latest capacity"))
             try:
                 _validate_capacity_transition(latest_capacity, normalized_capacity)

--- a/src/deepr/experts/loop_runs.py
+++ b/src/deepr/experts/loop_runs.py
@@ -117,10 +117,14 @@ def known_exception_cost(exception: BaseException) -> float:
     return known
 
 
-def _parse_dt(value: Any) -> datetime | None:
-    if not value:
+def _parse_dt(value: Any, *, field_name: str) -> datetime | None:
+    if value is None:
         return None
-    return datetime.fromisoformat(str(value))
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be an ISO-8601 datetime string")
+    parsed = datetime.fromisoformat(value)
+    _validate_aware_datetime(parsed, field_name=field_name)
+    return parsed
 
 
 def _dt_to_str(value: datetime | None) -> str | None:
@@ -135,6 +139,33 @@ def _string_list(value: Any) -> list[str]:
 
 def _dict_or_empty(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def _validate_nonnegative_int(value: object, *, field_name: str, positive: bool = False) -> None:
+    minimum = 1 if positive else 0
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        requirement = "positive" if positive else "non-negative"
+        raise ValueError(f"{field_name} must be a {requirement} integer")
+
+
+def _validate_finite_number(
+    value: object,
+    *,
+    field_name: str,
+    nonnegative: bool,
+) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        requirement = "finite non-negative number" if nonnegative else "finite number"
+        raise ValueError(f"{field_name} must be a {requirement}")
+    numeric = float(value)
+    if not isfinite(numeric) or (nonnegative and numeric < 0):
+        requirement = "finite non-negative number" if nonnegative else "finite number"
+        raise ValueError(f"{field_name} must be a {requirement}")
+
+
+def _validate_aware_datetime(value: object, *, field_name: str) -> None:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must include a UTC offset")
 
 
 @dataclass(frozen=True)
@@ -192,9 +223,12 @@ class ExpertLoopRun:
     def __post_init__(self) -> None:
         self._validate_identity_fields()
         self._validate_numeric_fields()
+        self._validate_timestamps()
         self._validate_stop_reason()
 
     def _validate_identity_fields(self) -> None:
+        if isinstance(self.schema_version, bool) or not isinstance(self.schema_version, int):
+            raise ValueError("schema_version must be an integer")
         if self.schema_version != LOOP_RUN_SCHEMA_VERSION:
             raise ValueError(f"unsupported loop-run schema version: {self.schema_version}")
         for field_name in ("run_id", "expert_name", "loop_type", "goal", "trigger"):
@@ -202,16 +236,24 @@ class ExpertLoopRun:
                 raise ValueError(f"{field_name} is required")
 
     def _validate_numeric_fields(self) -> None:
-        if self.iteration_count < 0:
-            raise ValueError("iteration_count must be non-negative")
-        if self.max_iterations is not None and self.max_iterations < 1:
-            raise ValueError("max_iterations must be positive when set")
-        if self.budget_limit is not None and self.budget_limit < 0:
-            raise ValueError("budget_limit must be non-negative when set")
-        if self.budget_spent < 0:
-            raise ValueError("budget_spent must be non-negative")
-        if self.accepted_changes < 0 or self.rejected_changes < 0:
-            raise ValueError("change counts must be non-negative")
+        _validate_nonnegative_int(self.iteration_count, field_name="iteration_count")
+        if self.max_iterations is not None:
+            _validate_nonnegative_int(self.max_iterations, field_name="max_iterations", positive=True)
+        if self.budget_limit is not None:
+            _validate_finite_number(self.budget_limit, field_name="budget_limit", nonnegative=True)
+        _validate_finite_number(self.budget_spent, field_name="budget_spent", nonnegative=True)
+        _validate_nonnegative_int(self.accepted_changes, field_name="accepted_changes")
+        _validate_nonnegative_int(self.rejected_changes, field_name="rejected_changes")
+        if self.verifier_score is not None:
+            _validate_finite_number(self.verifier_score, field_name="verifier_score", nonnegative=False)
+        if self.verifier_threshold is not None:
+            _validate_finite_number(self.verifier_threshold, field_name="verifier_threshold", nonnegative=False)
+
+    def _validate_timestamps(self) -> None:
+        _validate_aware_datetime(self.started_at, field_name="started_at")
+        _validate_aware_datetime(self.updated_at, field_name="updated_at")
+        if self.finished_at is not None:
+            _validate_aware_datetime(self.finished_at, field_name="finished_at")
 
     def _validate_stop_reason(self) -> None:
         if self.is_terminal and self.stop_reason is None:
@@ -269,21 +311,21 @@ class ExpertLoopRun:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ExpertLoopRun:
         return cls(
-            schema_version=int(data.get("schema_version", LOOP_RUN_SCHEMA_VERSION)),
+            schema_version=data.get("schema_version", LOOP_RUN_SCHEMA_VERSION),
             run_id=str(data["run_id"]),
             expert_name=str(data["expert_name"]),
             loop_type=str(data["loop_type"]),
             goal=str(data["goal"]),
             trigger=str(data["trigger"]),
             status=LoopRunStatus(str(data.get("status", LoopRunStatus.PENDING.value))),
-            started_at=_parse_dt(data.get("started_at")) or _utc_now(),
-            updated_at=_parse_dt(data.get("updated_at")) or _utc_now(),
-            finished_at=_parse_dt(data.get("finished_at")),
-            iteration_count=int(data.get("iteration_count", 0) or 0),
-            max_iterations=int(data["max_iterations"]) if data.get("max_iterations") is not None else None,
+            started_at=_parse_dt(data.get("started_at"), field_name="started_at") or _utc_now(),
+            updated_at=_parse_dt(data.get("updated_at"), field_name="updated_at") or _utc_now(),
+            finished_at=_parse_dt(data.get("finished_at"), field_name="finished_at"),
+            iteration_count=data.get("iteration_count", 0),
+            max_iterations=data.get("max_iterations"),
             state_artifact_path=str(data.get("state_artifact_path", "")),
-            budget_limit=float(data["budget_limit"]) if data.get("budget_limit") is not None else None,
-            budget_spent=float(data.get("budget_spent", 0.0) or 0.0),
+            budget_limit=data.get("budget_limit"),
+            budget_spent=data.get("budget_spent", 0.0),
             capacity_source=str(data.get("capacity_source", "")),
             backend_profile_id=str(data.get("backend_profile_id", "")),
             trace_id=str(data.get("trace_id", "")),
@@ -296,13 +338,11 @@ class ExpertLoopRun:
             verifier_id=str(data.get("verifier_id", "")),
             verifier_version=str(data.get("verifier_version", "")),
             verifier_outcome=str(data.get("verifier_outcome", "")),
-            verifier_score=float(data["verifier_score"]) if data.get("verifier_score") is not None else None,
-            verifier_threshold=float(data["verifier_threshold"])
-            if data.get("verifier_threshold") is not None
-            else None,
+            verifier_score=data.get("verifier_score"),
+            verifier_threshold=data.get("verifier_threshold"),
             verifier_evidence_refs=_string_list(data.get("verifier_evidence_refs")),
-            accepted_changes=int(data.get("accepted_changes", 0) or 0),
-            rejected_changes=int(data.get("rejected_changes", 0) or 0),
+            accepted_changes=data.get("accepted_changes", 0),
+            rejected_changes=data.get("rejected_changes", 0),
             stop_reason=LoopStopReason(str(data["stop_reason"])) if data.get("stop_reason") else None,
             failure_reason=str(data.get("failure_reason", "")),
             next_action=_dict_or_empty(data.get("next_action")),
@@ -330,8 +370,7 @@ class ExpertLoopRunStore:
         loop_type: str | None = None,
         limit: int = 20,
     ) -> list[ExpertLoopRun]:
-        if limit < 1:
-            raise ValueError("limit must be positive")
+        _validate_nonnegative_int(limit, field_name="limit", positive=True)
         latest: dict[str, ExpertLoopRun] = {}
         for run in self._iter_snapshots():
             latest[run.run_id] = run

--- a/src/deepr/experts/research_reservation_store.py
+++ b/src/deepr/experts/research_reservation_store.py
@@ -31,6 +31,15 @@ class ActiveResearchReservation:
     created_at: datetime
 
 
+def _validated_money(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a finite non-negative number")
+    numeric = float(value)
+    if not isfinite(numeric) or numeric < 0:
+        raise ValueError(f"{field_name} must be a finite non-negative number")
+    return numeric
+
+
 class ResearchReservationStore:
     """Serialize research reservations across API, web, and worker processes."""
 
@@ -91,6 +100,9 @@ class ResearchReservationStore:
         max_monthly_cost: float,
     ) -> None:
         """Atomically hold cost after checking fresh ledger and active holds."""
+        reserved_cost = _validated_money(reserved_cost, field_name="reserved_cost")
+        max_daily_cost = _validated_money(max_daily_cost, field_name="max_daily_cost")
+        max_monthly_cost = _validated_money(max_monthly_cost, field_name="max_monthly_cost")
         now = datetime.now(UTC)
         ledger = CostLedger()
         with closing(self._connect()) as connection, connection:
@@ -211,6 +223,7 @@ class ResearchReservationStore:
 
     def settle(self, reservation_id: str, actual_cost: float, record: Callable[[], None]) -> str:
         """Write the ledger event and close its hold under one process lock."""
+        actual_cost = _validated_money(actual_cost, field_name="actual_cost")
         with closing(self._connect()) as connection, connection:
             connection.execute("BEGIN IMMEDIATE")
             row = connection.execute(

--- a/src/deepr/observability/cost_ledger.py
+++ b/src/deepr/observability/cost_ledger.py
@@ -485,11 +485,30 @@ class CostLedger:
         except OSError as e:
             error = str(e)
 
-        events = self.get_events()
+        accounting_ready = False
+        events: list[CostLedgerEvent] = []
+        if writable:
+            try:
+                events = self.with_locked_accounting_events(list)
+                accounting_ready = True
+            except (
+                CostLedgerDurabilityError,
+                CostLedgerIdempotencyConflict,
+                CostLedgerLockTimeout,
+                CostLedgerReadError,
+                OSError,
+            ) as exc:
+                error = error or f"{type(exc).__name__}: {exc}"
+        if not accounting_ready:
+            try:
+                events = self.get_events()
+            except (CostLedgerLockTimeout, OSError) as exc:
+                error = error or f"{type(exc).__name__}: {exc}"
         return {
             "path": str(self.ledger_path),
             "exists": self.ledger_path.exists(),
             "writable": writable,
+            "accounting_ready": accounting_ready,
             "event_count": len(events),
             "total_cost_usd": sum(e.cost_usd for e in events),
             "latest_timestamp": events[-1].timestamp.isoformat() if events else None,
@@ -550,7 +569,10 @@ def _validated_timestamp(value: object) -> datetime:
         return _utc_now()
     if not isinstance(value, str):
         raise ValueError("timestamp must be an ISO-8601 string")
-    return datetime.fromisoformat(value)
+    timestamp = datetime.fromisoformat(value)
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        raise ValueError("timestamp must include a UTC offset")
+    return timestamp
 
 
 def _reject_json_constant(value: str) -> None:

--- a/tests/unit/test_backends/test_plan_quota_cli_runner.py
+++ b/tests/unit/test_backends/test_plan_quota_cli_runner.py
@@ -233,8 +233,7 @@ class TestRunCli:
         # Keep the direct child alive until the descendant overflows so the
         # parent pipe still has a writer when the byte ceiling is crossed.
         descendant_code = (
-            "import sys,time; time.sleep(0.2); sys.stdout.buffer.write(b'x' * 2048); "
-            "sys.stdout.flush(); time.sleep(30)"
+            "import sys,time; time.sleep(0.2); sys.stdout.buffer.write(b'x' * 2048); sys.stdout.flush(); time.sleep(30)"
         )
         direct_child_code = (
             "import subprocess,sys; "

--- a/tests/unit/test_cli/test_costs_dashboard.py
+++ b/tests/unit/test_cli/test_costs_dashboard.py
@@ -406,6 +406,7 @@ class TestCostsDoctor:
         mock_ledger.get_health.return_value = {
             "path": "data/costs/cost_ledger.jsonl",
             "writable": True,
+            "accounting_ready": True,
             "event_count": 1,
         }
         mock_ledger.get_total_cost.return_value = 1.0
@@ -429,6 +430,7 @@ class TestCostsDoctor:
         mock_ledger.get_health.return_value = {
             "path": "data/costs/cost_ledger.jsonl",
             "writable": True,
+            "accounting_ready": True,
             "event_count": 1,
         }
         mock_ledger.get_total_cost.return_value = 2.0
@@ -442,3 +444,27 @@ class TestCostsDoctor:
         assert result.exit_code == 0
         assert "FAIL" in result.output
         assert "drift=$" in result.output
+
+    def test_costs_doctor_detects_ledger_that_is_not_accounting_ready(self, runner):
+        mock_dash = MagicMock(spec=CostDashboard)
+        mock_dash.storage_path = Path("data/costs/cost_log.json")
+        mock_dash.entries = []
+        mock_ledger = MagicMock()
+        mock_ledger.get_health.return_value = {
+            "path": "data/costs/cost_ledger.jsonl",
+            "writable": True,
+            "accounting_ready": False,
+            "error": "CostLedgerReadError: malformed event",
+        }
+        mock_ledger.get_total_cost.return_value = 0.0
+
+        with (
+            patch("deepr.cli.commands.costs.CostDashboard", return_value=mock_dash),
+            patch("deepr.cli.commands.costs.CostLedger", return_value=mock_ledger),
+        ):
+            result = runner.invoke(cli, ["costs", "doctor"])
+
+        assert result.exit_code == 0
+        assert "Ledger accounting ready" in result.output
+        assert "malformed event" in result.output
+        assert "FAIL" in result.output

--- a/tests/unit/test_core/test_costs.py
+++ b/tests/unit/test_core/test_costs.py
@@ -190,6 +190,12 @@ class TestCostController:
         assert ctrl.max_daily_cost == 50.0
         assert ctrl.max_monthly_cost == 500.0
 
+    @pytest.mark.parametrize("value", [True, -0.01, float("nan"), float("inf"), "1.0"])
+    @pytest.mark.parametrize("field_name", ["max_cost_per_job", "max_daily_cost", "max_monthly_cost"])
+    def test_init_rejects_invalid_limits(self, field_name, value):
+        with pytest.raises(ValueError, match=field_name):
+            CostController(**{field_name: value})
+
     def test_check_cost_limit_allowed(self):
         ctrl = CostController()
         est = CostEstimate(min_cost=0.01, max_cost=1.0, expected_cost=0.5, model="m", reasoning="r")
@@ -220,6 +226,40 @@ class TestCostController:
         assert allowed is False
         assert "monthly limit" in reason.lower()
 
+    @pytest.mark.parametrize("field_name", ["min_cost", "max_cost", "expected_cost"])
+    @pytest.mark.parametrize("value", [True, -0.01, float("nan"), float("inf"), "1.0"])
+    def test_check_cost_limit_rejects_invalid_estimate_money(self, field_name, value):
+        ctrl = CostController()
+        values = {"min_cost": 0.1, "max_cost": 1.0, "expected_cost": 0.5}
+        values[field_name] = value
+        estimate = CostEstimate(**values, model="m", reasoning="r")
+
+        with pytest.raises(ValueError, match=f"estimate.{field_name}"):
+            ctrl.check_cost_limit(estimate)
+
+    def test_check_cost_limit_rejects_inconsistent_estimate_range(self):
+        ctrl = CostController()
+        estimate = CostEstimate(min_cost=1.0, max_cost=2.0, expected_cost=0.5, model="m", reasoning="r")
+
+        with pytest.raises(ValueError, match="min_cost <= expected_cost <= max_cost"):
+            ctrl.check_cost_limit(estimate)
+
+    def test_check_cost_limit_resets_stale_daily_spending_before_admission(self):
+        ctrl = CostController(max_daily_cost=1.0)
+        ctrl.daily_spending = 1.0
+        estimate = CostEstimate(min_cost=0.1, max_cost=0.5, expected_cost=0.25, model="m", reasoning="r")
+        now = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+        ctrl.last_reset = now - timedelta(days=1)
+
+        with patch("deepr.core.costs.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+            allowed, reason = ctrl.check_cost_limit(estimate)
+
+        assert allowed is True
+        assert reason is None
+        assert ctrl.daily_spending == 0.0
+
     def test_record_cost(self):
         ctrl = CostController()
         ctrl.record_cost(5.0)
@@ -228,6 +268,16 @@ class TestCostController:
         ctrl.record_cost(3.0)
         assert ctrl.daily_spending == 8.0
         assert ctrl.monthly_spending == 8.0
+
+    @pytest.mark.parametrize("value", [True, -0.01, float("nan"), float("inf"), "1.0"])
+    def test_record_cost_rejects_invalid_money_without_mutating(self, value):
+        ctrl = CostController()
+
+        with pytest.raises(ValueError, match="actual_cost"):
+            ctrl.record_cost(value)
+
+        assert ctrl.daily_spending == 0.0
+        assert ctrl.monthly_spending == 0.0
 
     def test_reset_if_needed_daily(self):
         ctrl = CostController()

--- a/tests/unit/test_cost_ledger.py
+++ b/tests/unit/test_cost_ledger.py
@@ -12,6 +12,7 @@ import pytest
 from deepr.observability.cost_ledger import (
     CostLedger,
     CostLedgerDurabilityError,
+    CostLedgerEvent,
     CostLedgerIdempotencyConflict,
     CostLedgerLockTimeout,
     CostLedgerReadError,
@@ -303,8 +304,34 @@ def test_health_reports_file_and_counts(tmp_path: Path):
 
     assert health["exists"] is True
     assert health["writable"] is True
+    assert health["accounting_ready"] is True
     assert health["event_count"] == 1
     assert health["total_cost_usd"] == 0.5
+
+
+def test_health_reports_writable_corrupt_ledger_as_not_accounting_ready(tmp_path: Path):
+    path = tmp_path / "cost_ledger.jsonl"
+    path.write_text("{}\n", encoding="utf-8")
+    ledger = CostLedger(ledger_path=path)
+
+    health = ledger.get_health()
+
+    assert health["writable"] is True
+    assert health["accounting_ready"] is False
+    assert health["event_count"] == 0
+    assert "malformed event" in health["error"]
+
+
+def test_cost_ledger_event_requires_timezone_aware_timestamp():
+    with pytest.raises(ValueError, match="UTC offset"):
+        CostLedgerEvent.from_dict(
+            {
+                "timestamp": "2026-07-15T12:00:00",
+                "operation": "research",
+                "provider": "openai",
+                "cost_usd": 0.1,
+            }
+        )
 
 
 def _record_live_attribution_shape(ledger: CostLedger) -> None:

--- a/tests/unit/test_eval/test_benchmark_budget.py
+++ b/tests/unit/test_eval/test_benchmark_budget.py
@@ -76,6 +76,25 @@ def test_refund_releases_unsubmitted_call_without_ledger_event(isolated_costs):
 
 
 def test_invalid_or_unbounded_runtime_budget_is_rejected(isolated_costs):
-    for budget in (0, -1, float("inf"), float("nan")):
+    for budget in (True, 0, -1, float("inf"), float("nan")):
         with pytest.raises(BenchmarkBudgetExceeded, match="finite and greater than zero"):
             BenchmarkSpendGuard(budget)
+
+
+def test_guard_rejects_invalid_call_ceiling(isolated_costs):
+    guard = BenchmarkSpendGuard(1.0)
+
+    with pytest.raises(BenchmarkBudgetExceeded, match="finite and non-negative"):
+        guard.reserve(provider="openai", model="openai/test", cost_ceiling=True, operation="benchmark")
+
+
+def test_guard_blocks_writable_but_corrupt_canonical_ledger(isolated_costs):
+    path = isolated_costs / "costs" / "cost_ledger.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+    ledger = CostLedger(ledger_path=path)
+
+    with pytest.raises(BenchmarkBudgetExceeded, match="not accounting-ready"):
+        BenchmarkSpendGuard(1.0, ledger=ledger)
+
+    assert not (path.parent / "research_reservations.db").exists()

--- a/tests/unit/test_experts/test_chat_budget.py
+++ b/tests/unit/test_experts/test_chat_budget.py
@@ -204,7 +204,6 @@ async def test_standard_research_does_not_reach_owned_fallback_after_metered_gat
 
 
 async def test_standard_research_uses_durable_admission_when_enabled(monkeypatch):
-    from deepr.experts import chat as chat_module
     from deepr.experts import chat_capacity
     from deepr.experts.research_reservation_store import ResearchReservationStore
 

--- a/tests/unit/test_experts/test_composed_managers.py
+++ b/tests/unit/test_experts/test_composed_managers.py
@@ -6,7 +6,9 @@ with ExpertProfile and that delegation works correctly.
 Requirements: 5.1, 5.2, 5.3 - Composed manager integration
 """
 
-from datetime import UTC
+from datetime import UTC, datetime
+
+import pytest
 
 from deepr.experts import ActivityTracker, BudgetManager, ExpertProfile
 
@@ -174,6 +176,37 @@ class TestBudgetManagerStandalone:
         assert manager.monthly_spending == 3.0
         assert manager.total_spending == 3.0
         assert len(manager.refresh_history) == 1
+
+    @pytest.mark.parametrize("value", [True, -0.01, float("nan"), float("inf"), "1.0"])
+    @pytest.mark.parametrize("field_name", ["monthly_budget", "monthly_spending", "total_spending"])
+    def test_budget_manager_rejects_invalid_persisted_money(self, field_name, value):
+        with pytest.raises(ValueError, match=field_name):
+            BudgetManager(**{field_name: value})
+
+    @pytest.mark.parametrize("value", [True, -0.01, float("nan"), float("inf"), "1.0"])
+    def test_budget_manager_rejects_invalid_spend_without_mutating(self, value):
+        manager = BudgetManager()
+
+        with pytest.raises(ValueError, match="amount"):
+            manager.can_spend(value)
+        with pytest.raises(ValueError, match="amount"):
+            manager.record_spending(value, "test")
+
+        assert manager.monthly_spending == 0.0
+        assert manager.total_spending == 0.0
+        assert manager.refresh_history == []
+
+    def test_budget_manager_normalizes_legacy_naive_reset_date_to_utc(self):
+        reset_date = datetime(2099, 1, 1)
+
+        manager = BudgetManager(reset_date=reset_date)
+
+        assert manager.reset_date == reset_date.replace(tzinfo=UTC)
+        assert manager.check_and_reset_if_needed() is False
+
+    def test_budget_manager_rejects_invalid_reset_date(self):
+        with pytest.raises(ValueError, match="reset_date"):
+            BudgetManager(reset_date=object())
 
     def test_budget_manager_serialization(self):
         """Should serialize and deserialize correctly."""

--- a/tests/unit/test_experts/test_consult_lifecycle.py
+++ b/tests/unit/test_experts/test_consult_lifecycle.py
@@ -96,6 +96,13 @@ def _assert_no_content_fields(value: Any) -> None:
             _assert_no_content_fields(child)
 
 
+def test_loading_missing_journal_is_read_only(tmp_path: Path) -> None:
+    path = tmp_path / "missing" / "consult_lifecycle_events.jsonl"
+
+    assert load_consult_lifecycle_events(path=path) == []
+    assert not path.parent.exists()
+
+
 def test_start_heartbeat_and_finish_append_bounded_events(tmp_path: Path) -> None:
     path = tmp_path / "consult_lifecycle_events.jsonl"
     lifecycle = _start(path)
@@ -257,6 +264,22 @@ def test_bounds_progress_and_capacity_identity_fail_closed(tmp_path: Path) -> No
         lifecycle.transition("failed", phase="synthesis", reason_code="Provider failed: secret")
     with pytest.raises(ConsultLifecycleTransitionError, match="finish requires"):
         lifecycle.finish("interrupted", reason_code="host_interrupted")
+
+
+def test_explicit_empty_progress_and_capacity_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "empty_fields.jsonl"
+    lifecycle = _start(path)
+
+    with pytest.raises(ValueError, match="progress must contain exactly"):
+        lifecycle.heartbeat(phase="perspectives", progress={})
+    with pytest.raises(ValueError, match="capacity must contain exactly"):
+        lifecycle.heartbeat(phase="perspectives", capacity={})
+
+    lifecycle.transition("waiting_capacity", phase="preflight", reason_code="local_capacity_busy")
+    with pytest.raises(ValueError, match="progress must contain exactly"):
+        ConsultLifecycle.resume(trace_id=lifecycle.trace_id, path=path, progress={})
+    with pytest.raises(ValueError, match="capacity must contain exactly"):
+        ConsultLifecycle.resume(trace_id=lifecycle.trace_id, path=path, capacity={})
 
 
 @pytest.mark.parametrize("value", [-1.0, float("inf"), float("nan")])

--- a/tests/unit/test_experts/test_loop_runs.py
+++ b/tests/unit/test_experts/test_loop_runs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -59,6 +60,62 @@ def test_loop_run_validates_required_fields():
             goal=" ",
             trigger="scheduled",
         )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("schema_version", True),
+        ("iteration_count", True),
+        ("iteration_count", -1),
+        ("max_iterations", 0),
+        ("budget_limit", float("nan")),
+        ("budget_spent", float("inf")),
+        ("accepted_changes", 1.5),
+        ("rejected_changes", True),
+        ("verifier_score", float("nan")),
+        ("verifier_threshold", float("inf")),
+    ],
+)
+def test_loop_run_rejects_malformed_numeric_fields(field_name, value):
+    with pytest.raises(ValueError, match=field_name):
+        replace(_run(), **{field_name: value})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("schema_version", "1"),
+        ("iteration_count", "1"),
+        ("max_iterations", True),
+        ("budget_limit", "2.0"),
+        ("budget_spent", False),
+        ("accepted_changes", "2"),
+        ("rejected_changes", 1.5),
+        ("verifier_score", "0.8"),
+        ("verifier_threshold", float("nan")),
+    ],
+)
+def test_loop_run_from_dict_does_not_coerce_malformed_numeric_fields(field_name, value):
+    payload = _run().to_dict()
+    payload[field_name] = value
+
+    with pytest.raises(ValueError, match=field_name):
+        ExpertLoopRun.from_dict(payload)
+
+
+@pytest.mark.parametrize("field_name", ["started_at", "updated_at", "finished_at"])
+def test_loop_run_rejects_timezone_naive_timestamps(field_name):
+    with pytest.raises(ValueError, match=field_name):
+        replace(_run(), **{field_name: datetime(2026, 7, 15, 12, 0)})
+
+
+def test_loop_run_from_dict_rejects_timezone_naive_timestamp():
+    payload = _run().to_dict()
+    payload["updated_at"] = "2026-07-15T12:00:00"
+
+    with pytest.raises(ValueError, match="updated_at"):
+        ExpertLoopRun.from_dict(payload)
 
 
 def test_terminal_loop_run_requires_typed_stop_reason():
@@ -156,6 +213,26 @@ def test_store_ignores_corrupt_lines(tmp_path):
     path.write_text(path.read_text(encoding="utf-8") + "not json\n", encoding="utf-8")
 
     assert len(store.list_runs()) == 1
+
+
+def test_store_ignores_snapshot_with_non_finite_metrics(tmp_path):
+    path = tmp_path / "loop_runs.jsonl"
+    store = ExpertLoopRunStore("Platform Expert", path=path)
+    original = _run()
+    store.append(original)
+    malformed = original.to_dict()
+    malformed["budget_spent"] = float("nan")
+    path.write_text(path.read_text(encoding="utf-8") + json.dumps(malformed) + "\n", encoding="utf-8")
+
+    assert store.list_runs() == [original]
+
+
+@pytest.mark.parametrize("limit", [True, 0, -1, 1.5])
+def test_store_rejects_non_positive_or_non_integer_limit(tmp_path, limit):
+    store = ExpertLoopRunStore("Platform Expert", path=tmp_path / "loop_runs.jsonl")
+
+    with pytest.raises(ValueError, match="limit"):
+        store.list_runs(limit=limit)
 
 
 def test_record_loop_run_appends_snapshot():

--- a/tests/unit/test_experts/test_research_cost_gate.py
+++ b/tests/unit/test_experts/test_research_cost_gate.py
@@ -135,6 +135,38 @@ def test_active_reservation_check_binds_job_and_reserved_cost() -> None:
     )
 
 
+@pytest.mark.parametrize("field_name", ["reserved_cost", "max_daily_cost", "max_monthly_cost"])
+@pytest.mark.parametrize("value", [True, -0.01, float("nan"), float("inf"), "1.0"])
+def test_durable_store_rejects_invalid_reservation_money(field_name, value, tmp_path) -> None:
+    store = ResearchReservationStore(tmp_path / "reservations.db")
+    values = {"reserved_cost": 0.5, "max_daily_cost": 1.0, "max_monthly_cost": 5.0}
+    values[field_name] = value
+
+    with pytest.raises(ValueError, match=field_name):
+        store.reserve(reservation_id="reservation", job_id="job", **values)
+
+    assert store.active_reservations() == []
+
+
+@pytest.mark.parametrize("value", [True, -0.01, float("nan"), float("inf"), "1.0"])
+def test_durable_store_rejects_invalid_settlement_before_callback(value, tmp_path) -> None:
+    store = ResearchReservationStore(tmp_path / "reservations.db")
+    store.reserve(
+        reservation_id="reservation",
+        job_id="job",
+        reserved_cost=0.5,
+        max_daily_cost=1.0,
+        max_monthly_cost=5.0,
+    )
+    record = MagicMock()
+
+    with pytest.raises(ValueError, match="actual_cost"):
+        store.settle("reservation", value, record)
+
+    record.assert_not_called()
+    assert store.state("reservation") == "active"
+
+
 def test_parallel_reservations_cannot_overcommit_daily_limit() -> None:
     manager = CostSafetyManager()
     barrier = Barrier(2)

--- a/tests/unit/test_experts/test_skills_executor.py
+++ b/tests/unit/test_experts/test_skills_executor.py
@@ -338,8 +338,8 @@ class TestSkillExecutorExecuteTool:
     @pytest.mark.asyncio
     async def test_metered_mcp_tool_writes_durable_ledger(self, tmp_path):
         """Paid skill tools reserve, mark dispatch, and settle the tier cost."""
-        from deepr.observability.cost_ledger import CostLedger
         from deepr.experts.research_reservation_store import ResearchReservationStore
+        from deepr.observability.cost_ledger import CostLedger
 
         tool = _make_mcp_tool(name="search", cost_tier="low")
         skill = _make_skill(tmp_path, tools=[tool])


### PR DESCRIPTION
## Summary

- reject non-finite, negative, boolean, and malformed money before cost admission, mutation, reservation, or settlement
- distinguish a writable cost ledger from one safe for canonical accounting, and block benchmark work when accounting is not ready
- harden expert loop numeric and timestamp contracts so malformed snapshots cannot poison rollups
- preserve omitted lifecycle fields while rejecting explicit empty payloads, and keep missing-journal reads side-effect free
- reset stale daily cost counters before admission and validate loop query limits
- clean three pre-existing unit-test lint issues exposed by the pinned pre-commit hooks

## Root causes

Several deterministic boundaries relied on Python comparisons whose behavior is fail-open for NaN and permissive for booleans. Ledger health checked writability but not whether strict accounting could safely parse and durably read the canonical file. Lifecycle updates used truthiness instead of an explicit None check, which made malformed empty mappings indistinguishable from omitted values. Loop snapshots coerced malformed numeric data and accepted timezone-naive timestamps.

## Verification

- focused boundary suite: 284 passed
- downstream loop and cost suite: 225 passed
- property suite: 167 passed
- full unit suite with branch coverage: 8,660 passed, 9 skipped, 84.81 percent coverage
- strict blocking mypy islands: 124 source files clean
- ruff lint and format: passed
- file-size, C901, security-lint, and docs consistency ratchets: passed
- pre-commit all files: passed
- refreshed codegraph: 1,460 files, 25,955 edges, all graph checks passed

No paid provider calls were made.