### PR TITLE
chore: refresh AWS toolchain patches

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -326,9 +326,10 @@ reliable product, not a four-language architecture diagram.
 
 ## Current Status (v2.38.3)
 
-**v2.38.3 addition:** the development lock now uses Hypothesis 6.161.7, the
-current compatible release discovered by the final dependency audit after
-v2.38.2 was published. No runtime behavior or paid-capacity boundary changed.
+**v2.38.3 addition:** the development lock now uses Hypothesis 6.161.7, AWS CLI
+1.45.57, and Boto3 1.43.57, the current compatible releases discovered by the
+final dependency audits after v2.38.2 was published. No runtime behavior or
+paid-capacity boundary changed.
 
 **v2.38.2 additions:** budget history now reads the strict canonical ledger
 instead of an empty legacy side counter; budget and cost displays distinguish

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   found the same-day upstream patch. The frozen direct dependency graph is
   current within declared compatibility, with no runtime or cost-boundary
   change.
+- Refreshed AWS CLI from 1.45.56 to 1.45.57 and Boto3 from 1.43.56 to
+  1.43.57 after the release-time currency check found same-day patches.
 
 ## [2.38.2] - 2026-07-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,8 @@ scrape = [
 
 # AWS worker runtime. Exact pins make the deployment lock authoritative.
 aws = [
-    "awscli==1.45.56",
-    "boto3==1.43.56",
+    "awscli==1.45.57",
+    "boto3==1.43.57",
 ]
 
 # Full install with all features

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.45.56"
+version = "1.45.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -259,9 +259,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/de/6a612e7d0cdf1aeb94590ce9d2b69b907cfef9d146399776288e513becb9/awscli-1.45.56.tar.gz", hash = "sha256:c27acf5e627986c5969d189fef37429e171e207a167e00407b59a7d8f27ac6a6", size = 1903077, upload-time = "2026-07-24T19:31:44.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/a6/f4269d8372bf33eb1b0f10a1e0e4be95f4940355f6a6cada1e8072dcf80c/awscli-1.45.57.tar.gz", hash = "sha256:dbb5b036ed56ccdc9cf1baa02cdbed636f3bd4de746de4c90a6b5defcd91706b", size = 1902985, upload-time = "2026-07-27T19:31:05.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/de/967bd6956a46fed168de86b205e47e30cd7f5e4a59c14d30b199352e9501/awscli-1.45.56-py3-none-any.whl", hash = "sha256:f1794946c91887c54afef5b7db87d986e1646513460c5cef9b993716841352ab", size = 4667102, upload-time = "2026-07-24T19:31:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/28/814b4132e22bb18c1bf9f9229733c078c93cb73117fc25648f693fa25425/awscli-1.45.57-py3-none-any.whl", hash = "sha256:9340119019da77ca45a8743dc0d70cc5d7e3510b2c08352901d669135972380c", size = 4667102, upload-time = "2026-07-27T19:31:02.081Z" },
 ]
 
 [[package]]
@@ -427,30 +427,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.56"
+version = "1.43.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/05/23e1aa8c9e4b0399a61e7fd65c4f9cc0625121f24760e37471f776404abb/boto3-1.43.56.tar.gz", hash = "sha256:57c90df9fb026f2e6ae22530861198130203733c5c9ec4e5cca3a4037f5a8db4", size = 112673, upload-time = "2026-07-24T19:31:48.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/30/324319a914752e4021358ccf8252c04364eb8358f9d41d9c3f021959b363/boto3-1.43.57.tar.gz", hash = "sha256:549c95e45f9b04cf0c69727632dbdda23b84dcd3d0ed7981c6aaff72ef9cb5af", size = 112690, upload-time = "2026-07-27T19:31:09.32Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/57/3a960c9f581c00f2a591901b46e035ff79ab3956d16607f12306b3b8d483/boto3-1.43.56-py3-none-any.whl", hash = "sha256:feb699d4ab241ef5c1b80bb58277be2aaad365cd4b672d7817e0bc59ee45131b", size = 140026, upload-time = "2026-07-24T19:31:47.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a4/2c4ee25556a997a81ea01073962cf8351da3707412c584d053b3861d09e8/boto3-1.43.57-py3-none-any.whl", hash = "sha256:115ed9cac409d9b57e2437b52fdb4286660d12a2bd44a0f48d530e68623d09a7", size = 140028, upload-time = "2026-07-27T19:31:07.226Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.56"
+version = "1.43.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/cc/7f84a5d3071fe878380e9f610ab36ca87b8cbbc4aa81ba2727f90e1f3ea3/botocore-1.43.56.tar.gz", hash = "sha256:6c01f85f0ff9863076f4c761e74ee3aa96c5ccc1ad09fc1efd62ef8f2d22bf57", size = 15733117, upload-time = "2026-07-24T19:31:38.125Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/92/1f8a454cf90bcb0c0e32a25817441cb7f3702fdd76710d7018abad12a2fc/botocore-1.43.57.tar.gz", hash = "sha256:001a5653bebc03b862bde2da63bad4adb0b30072a3f247aba4daae5aa097b546", size = 15739550, upload-time = "2026-07-27T19:30:57.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl", hash = "sha256:aafc741f1b10f6fd63253eaf6ea029680c1ff436d87e1b8969d62aefa0c76976", size = 15418773, upload-time = "2026-07-24T19:31:34.758Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7a/1cfe9c296df0fa6e0143c8622b10f21fa8fb9cce25450e9a8e5cf6523e4b/botocore-1.43.57-py3-none-any.whl", hash = "sha256:319c6d79f66c3f3f2b538f7dcdc90e410a15a7bfced1db06479134947e629482", size = 15424433, upload-time = "2026-07-27T19:30:55.08Z" },
 ]
 
 [[package]]
@@ -979,7 +979,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=23.0.0,<26.0.0" },
     { name = "aiohttp", specifier = ">=3.14.1,<4.0.0" },
     { name = "anthropic", specifier = ">=0.40.0,<1.0.0" },
-    { name = "awscli", marker = "extra == 'aws'", specifier = "==1.45.56" },
+    { name = "awscli", marker = "extra == 'aws'", specifier = "==1.45.57" },
     { name = "azure-ai-agents", marker = "extra == 'azure-foundry'", specifier = ">=1.0.0b4" },
     { name = "azure-ai-projects", marker = "extra == 'azure-foundry'", specifier = ">=1.0.0b4" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.12.0,<2.0.0" },
@@ -988,7 +988,7 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19.0,<13.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'docs'", specifier = ">=4.12.0,<5.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.5.1" },
-    { name = "boto3", marker = "extra == 'aws'", specifier = "==1.43.56" },
+    { name = "boto3", marker = "extra == 'aws'", specifier = "==1.43.57" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.5.0,<2.0.0" },
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "colorama", specifier = ">=0.4.6,<1.0.0" },


### PR DESCRIPTION
## What changed

- Updated the optional AWS CLI pin from 1.45.56 to 1.45.57.
- Updated the optional Boto3 pin from 1.43.56 to 1.43.57.
- Regenerated the frozen lock, including Botocore 1.43.57.
- Updated the v2.38.3 roadmap and changelog entries.

## Why

The final release-time direct-dependency audit found same-day AWS patch releases after the previous v2.38.3 CI run. Folding them into the pending release keeps the declared direct dependency graph current.

## Impact

This changes only the optional AWS toolchain and release documentation. It does not change runtime routing, provider cost authority, or the paid-capacity boundary. Paid API dispatch remains persistently frozen.

## Validation

- `uv lock --check`
- `uv tree --outdated --depth 1 --all-groups --frozen`
- AWS CLI 1.45.57, Boto3 1.43.57, Botocore 1.43.57 import and version checks
- `pytest tests/unit/test_deploy -q`: 35 passed
- `pre-commit run --all-files`: all hooks passed
- documentation consistency, file-size, complexity, security, and paid-boundary ratchets passed
