### PR TITLE
chore: refresh frontend Globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/blisspixel/deepr/actions/workflows/ci.yml/badge.svg)](https://github.com/blisspixel/deepr/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.38.3-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.38.3)
+[![Version](https://img.shields.io/badge/version-2.38.4-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.38.4)
 
 **Persistent domain experts built from bounded, auditable research.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -324,7 +324,11 @@ reliable product, not a four-language architecture diagram.
 
 ---
 
-## Current Status (v2.38.3)
+## Current Status (v2.38.4)
+
+**v2.38.4 addition:** the frontend development lock now uses Globals 17.8.0,
+the current compatible release found by the final npm registry audit. No
+runtime behavior or paid-capacity boundary changed.
 
 **v2.38.3 addition:** the development lock now uses Hypothesis 6.161.7, AWS CLI
 1.45.57, and Boto3 1.43.57, the current compatible releases discovered by the

--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -452,7 +452,7 @@ The minimum account checklist is:
    invoice drift.
 
 Provider billing export import and provider account hard-limit verification are
-not shipped in v2.38.3. Until they are, reconcile exports outside the tracked
+not shipped in v2.38.4. Until they are, reconcile exports outside the tracked
 repository and keep paid dispatch frozen whenever a charge cannot be explained.
 
 ## Costing Deep Dive

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.38.4] - 2026-07-27
+
+### Changed
+
+- Refreshed the frontend Globals development dependency from 17.7.0 to 17.8.0
+  after the final npm registry audit found the compatible release. Runtime
+  behavior and paid-capacity boundaries are unchanged.
+
 ## [2.38.3] - 2026-07-27
 
 ### Changed

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -156,7 +156,7 @@ That's it! You're ready to use Deepr.
 
 ```bash
 # Download the wheel for the selected release, then install it locally.
-python -m pip install ./deepr_research-2.38.3-py3-none-any.whl
+python -m pip install ./deepr_research-2.38.4-py3-none-any.whl
 deepr --version
 ```
 

--- a/docs/MCP_A2A_INTEROP_CHECKLIST.md
+++ b/docs/MCP_A2A_INTEROP_CHECKLIST.md
@@ -1,6 +1,6 @@
 # MCP and A2A Interop Checklist
 
-Status: current with Deepr v2.38.3. Last reviewed: 2026-07-27.
+Status: current with Deepr v2.38.4. Last reviewed: 2026-07-27.
 
 Use this checklist when connecting Deepr experts to another agent host through
 MCP or A2A. It is a compact integration review, not the command guide. For

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,6 +1,6 @@
 # Model Selection Guide
 
-Status: current with Deepr v2.38.3. Last reviewed: 2026-07-27.
+Status: current with Deepr v2.38.4. Last reviewed: 2026-07-27.
 
 The source of truth for model IDs, pricing estimates, context windows, and
 routing metadata is [src/deepr/providers/registry.py](../src/deepr/providers/registry.py).

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,6 +1,6 @@
 # Supported Surface
 
-Status: v2.38.3 current main, 2026-07-27. This document defines what users and host
+Status: v2.38.4 current main, 2026-07-27. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
 data remains portable if development stops.
 
@@ -586,7 +586,7 @@ source text through the verified absorb path.
   but users choose when to provide keys and when to allow paid tools. Use a
   dedicated provider project, the smallest available account hard limit or
   disabled paid overage, monitored provider alerts, and regular billing-export
-  reconciliation. Deepr v2.38.3 does not verify those account controls or
+  reconciliation. Deepr v2.38.4 does not verify those account controls or
   import provider invoices, and cannot govern another application using the
   same credential.
 - Local Ollama capacity is only as available as the local machine and admitted

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -6,7 +6,7 @@
 
 Transform research from isolated queries into cumulative understanding. Build systems that learn and improve over time.
 
-## Current State (v2.38.3)
+## Current State (v2.38.4)
 
 What works today:
 - Bounded single-job provider research where exact pricing and finite request,

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,6 +1,6 @@
 # Deepr Threat Model
 
-Status: current with Deepr v2.38.3. Last reviewed: 2026-07-27.
+Status: current with Deepr v2.38.4. Last reviewed: 2026-07-27.
 
 This document is the repository-scoped threat model for Deepr. It is intended
 for security reviews, design reviews, and future bug discovery. It should stay

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepr-research"
-version = "2.38.3"
+version = "2.38.4"
 description = "Research automation platform that replicates human research team workflows using AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/deepr/web/frontend/package-lock.json
+++ b/src/deepr/web/frontend/package-lock.json
@@ -69,7 +69,7 @@
         "eslint": "^10.8.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
-        "globals": "^17.7.0",
+        "globals": "^17.8.0",
         "playwright": "^1.62.0",
         "postcss": "^8.5.23",
         "tailwindcss": "^4.3.3",
@@ -4165,9 +4165,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/deepr/web/frontend/package.json
+++ b/src/deepr/web/frontend/package.json
@@ -77,7 +77,7 @@
     "eslint": "^10.8.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "playwright": "^1.62.0",
     "postcss": "^8.5.23",
     "tailwindcss": "^4.3.3",

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "deepr-research"
-version = "2.38.3"
+version = "2.38.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## What changed

- Updated the frontend Globals development dependency from 17.7.0 to 17.8.0.
- Regenerated the npm lock.
- Refreshed package and release-facing version metadata to 2.38.4.

## Why

The final npm registry audit found Globals 17.8.0 as a compatible update. TypeScript 6.0.3 remains the newest version accepted by the current TypeScript ESLint parser peer range.

## Impact

This is a development-tooling dependency refresh. It does not change provider routing, cost authority, or paid-capacity boundaries. Paid API dispatch remains persistently frozen.

## Validation

- frontend lint passed
- 38 frontend tests passed
- TypeScript type check passed
- Vite production build passed
- npm audit reports zero known vulnerabilities
- no compatible npm dependency is outdated
- frozen Python direct dependencies are current
- all pre-commit, documentation, file-size, complexity, security, and paid-boundary gates passed
