### PR TITLE
fix: keep release versions aligned

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -326,9 +326,11 @@ reliable product, not a four-language architecture diagram.
 
 ## Current Status (v2.38.4)
 
-**v2.38.4 addition:** the frontend development lock now uses Globals 17.8.0,
-the current compatible release found by the final npm registry audit. No
-runtime behavior or paid-capacity boundary changed.
+**v2.38.4 additions:** the frontend development lock now uses Globals 17.8.0,
+the current compatible release found by the final npm registry audit. Package
+metadata, the exported version, and `deepr --version` now have a blocking
+release invariant after the final artifact smoke test caught a stale exported
+version. No runtime behavior or paid-capacity boundary changed.
 
 **v2.38.3 addition:** the development lock now uses Hypothesis 6.161.7, AWS CLI
 1.45.57, and Boto3 1.43.57, the current compatible releases discovered by the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refreshed the frontend Globals development dependency from 17.7.0 to 17.8.0
   after the final npm registry audit found the compatible release. Runtime
   behavior and paid-capacity boundaries are unchanged.
+- Corrected the exported package and CLI version to 2.38.4 and added a release
+  invariant that fails when project metadata, the package export, and actual
+  `deepr --version` output disagree.
+- Isolated map-reduce orchestration tests from the durable paid-call reservation
+  store so concurrent test scheduling cannot consume shared budget state. The
+  production reservation gate and its dedicated tests are unchanged.
 
 ## [2.38.3] - 2026-07-27
 

--- a/src/deepr/__init__.py
+++ b/src/deepr/__init__.py
@@ -5,7 +5,7 @@ Keep package import lightweight by lazily importing heavy modules.
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "2.38.3"
+__version__ = "2.38.4"
 __author__ = "Nick Seal"
 
 if TYPE_CHECKING:

--- a/tests/unit/test_cli/test_main_entrypoint.py
+++ b/tests/unit/test_cli/test_main_entrypoint.py
@@ -2,8 +2,14 @@
 
 import importlib
 import io
+import tomllib
+from pathlib import Path
 
 from click.testing import CliRunner
+
+import deepr
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class _FakeCLI:
@@ -84,3 +90,15 @@ def test_root_no_color_option_applies_policy(monkeypatch):
     assert result.exit_code == 0
     assert calls == ["applied"]
     assert "--no-color" in result.output
+
+
+def test_cli_version_matches_project_metadata():
+    project = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    expected = project["project"]["version"]
+    main_module = importlib.import_module("deepr.cli.main")
+
+    result = CliRunner().invoke(main_module.cli, ["--version"])
+
+    assert result.exit_code == 0
+    assert deepr.__version__ == expected
+    assert result.output.strip() == f"Deepr, version {expected}"

--- a/tests/unit/test_experts/test_map_reduce.py
+++ b/tests/unit/test_experts/test_map_reduce.py
@@ -198,8 +198,6 @@ class TestIngest:
 
     @pytest.mark.asyncio
     async def test_large_document_processed(self):
-        mock_client = AsyncMock()
-
         # Map response (returned for every map call)
         map_response = MagicMock()
         map_response.choices = [MagicMock()]
@@ -210,13 +208,17 @@ class TestIngest:
         reduce_response.choices = [MagicMock()]
         reduce_response.choices[0].message.content = "Condensed document summary"
 
-        # Use a function to return map responses for any number of chunks, then reduce
-        call_count = {"n": 0}
-        ingester = MapReduceIngester(client=mock_client, chunk_size=50)
-        # Pre-calculate chunk count to set up exact side_effect
+        ingester = MapReduceIngester(chunk_size=50)
         chunks = ingester._split_document("x" * 200)
-        responses = [map_response] * len(chunks) + [reduce_response]
-        mock_client.chat.completions.create = AsyncMock(side_effect=responses)
+
+        async def complete_by_operation(*, operation: str, **_kwargs):
+            if operation == "map-chunk":
+                return map_response
+            if operation == "reduce-document":
+                return reduce_response
+            raise AssertionError(f"unexpected operation: {operation}")
+
+        ingester._complete_bounded = AsyncMock(side_effect=complete_by_operation)
 
         docs = [{"filename": "big.md", "content": "x" * 200}]
 
@@ -224,11 +226,10 @@ class TestIngest:
         assert len(result) == 1
         assert result[0]["filename"] == "big.md"
         assert "Condensed" in result[0]["content"]
+        assert ingester._complete_bounded.await_count == len(chunks) + 1
 
     @pytest.mark.asyncio
     async def test_mixed_document_sizes(self):
-        mock_client = AsyncMock()
-
         map_response = MagicMock()
         map_response.choices = [MagicMock()]
         map_response.choices[0].message.content = json.dumps({"facts": ["F1"]})
@@ -237,11 +238,17 @@ class TestIngest:
         reduce_response.choices = [MagicMock()]
         reduce_response.choices[0].message.content = "Summary"
 
-        ingester = MapReduceIngester(client=mock_client, chunk_size=50)
-        # Pre-calculate chunk count for the big doc
+        ingester = MapReduceIngester(chunk_size=50)
         chunks = ingester._split_document("x" * 100)
-        responses = [map_response] * len(chunks) + [reduce_response]
-        mock_client.chat.completions.create = AsyncMock(side_effect=responses)
+
+        async def complete_by_operation(*, operation: str, **_kwargs):
+            if operation == "map-chunk":
+                return map_response
+            if operation == "reduce-document":
+                return reduce_response
+            raise AssertionError(f"unexpected operation: {operation}")
+
+        ingester._complete_bounded = AsyncMock(side_effect=complete_by_operation)
 
         docs = [
             {"filename": "small.md", "content": "Small"},
@@ -252,13 +259,12 @@ class TestIngest:
         assert len(result) == 2
         assert result[0]["content"] == "Small"  # Passed through
         assert result[1]["content"] == "Summary"  # Processed
+        assert ingester._complete_bounded.await_count == len(chunks) + 1
 
     @pytest.mark.asyncio
     async def test_all_map_failures_fallback(self):
-        mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=Exception("Fail"))
-
-        ingester = MapReduceIngester(client=mock_client, chunk_size=50)
+        ingester = MapReduceIngester(chunk_size=50)
+        ingester._complete_bounded = AsyncMock(side_effect=Exception("Fail"))
         docs = [{"filename": "doc.md", "content": "x" * 100}]
 
         result = await ingester.ingest(docs, "domain")


### PR DESCRIPTION
## Summary

- align the exported package and CLI version with project metadata at 2.38.4
- add a unit invariant covering metadata, package export, and actual CLI output
- document the release correction

## Validation

- 9,685 unit tests passed, 9 skipped
- strict mypy passed across 137 files
- pre-commit and all code-health ratchets passed
- frontend lint, 38 tests, build, and npm audit passed
- fresh wheel metadata, package export, and CLI all report 2.38.4
- no paid provider calls