### PR TITLE
fix: persist legacy cost accounting roots

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -608,10 +608,16 @@ memory surface. This order is dependency-based, not calendar-based:
      the shared operator wallet, zero is a freeze, and `deepr budget freeze` /
      `unfreeze` provide a manual kill switch. A reported cost above its exact
      reservation freezes paid API capacity before another process can reserve.
-   - [x] **Headroom reservations** (2026-07-25): the durable transaction proves
+    - [x] **Headroom reservations** (2026-07-25): the durable transaction proves
      settled + every active hold + the new worst-case ceiling against each
      window. Dispatch rechecks the aggregate under the same policy lock, so
-     positive cap reductions and newly recorded spend stop old holds too.
+      positive cap reductions and newly recorded spend stop old holds too.
+    - [x] **Package-independent legacy accounting** (2026-07-28): validated
+      checkout ledger and reservation roots are persisted in an append-only
+      registry under the canonical home root. Installed wheels and editable
+      source therefore retain the same known accounting set, and a missing
+      registered artifact blocks authority instead of reporting zero. Doctor
+      health names the primary write path and every contributing read path.
    - [x] **Weekly cap** (2026-07-25): `DEEPR_MAX_COST_PER_WEEK` joins
      job/day/month in `core/cost_caps.py`; the hierarchy is normalized as
      per-job <= day <= week <= month and the tightest authority wins.
@@ -638,11 +644,17 @@ memory surface. This order is dependency-based, not calendar-based:
      before enabling any autonomous server-side tool loop. Grok search and
      legacy deep-research chat remain gated because a token cap does not bound
      their autonomous tool bill.
-   - [ ] **One parent graph budget before paid fan-out**: reserve the sum of all
+    - [ ] **One parent graph budget before paid fan-out**: reserve the sum of all
      runnable child envelopes before enqueue, give each child a non-increasing
      slice, count every expected success/failure/timeout, retry only failed
      branches, and report incomplete fan-in as partial. Composed docs, team,
-     campaign, and other paid fan-out remain gated until this contract ships.
+      campaign, and other paid fan-out remain gated until this contract ships.
+    - [ ] **Canonical cost-state consolidation before paid recovery**: migrate
+      every registered legacy ledger and reservation database under locks,
+      preserve recoverable source evidence, and bind paid authorization to a
+      stable cost-state identity containing root, policy, source, and digest
+      status. Any incomplete migration or identity drift must keep paid
+      authority at zero.
    - [ ] **Remaining audit follow-up** (`.agent/cost-audit-2026-07-25.json`):
      finish threshold delivery, provider-specific authenticated account-control
      verification, batch-auto attribution, prep-campaign resume identity,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -447,6 +447,11 @@ provider API.
 ### Audit Logging
 
 The append-only cost ledger records bounded spend decisions and settlement.
+New writes use one home-anchored cost root. Validated legacy checkout ledgers
+and reservation stores are strict read-only contributors recorded in an
+append-only home registry, so installed and editable processes use the same
+accounting set. Missing registered state is an error, never zero spend. The
+health contract reports the primary write path and all accounting read paths.
 Experimental HTTP MCP has a separate schema-validated remote-call audit. A
 general security-audit event model exists, but authentication, permission,
 research, expert, and configuration call sites are not yet wired to one

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,9 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved new cost writes to the stable per-user cost root and made strict
   accounting include the legacy source-checkout ledger and reservation store.
   Absolute relocation remains available through `DEEPR_COST_DATA_DIR`.
-  Long-lived processes rediscover late legacy state, exact duplicate events are
-  counted once, conflicts and malformed state fail closed, and cross-root
-  reservation or job identity collisions block authority.
+  Validated checkout roots are recorded in an append-only registry under the
+  per-user cost root, so installed wheels retain the same accounting sources
+  after leaving the checkout. Missing registered ledgers or reservation stores,
+  conflicting or malformed state, and cross-root reservation or job identity
+  collisions block authority. Health output names the sole write path and every
+  contributing read path with event and cost totals.
 - Unified CLI, REST, MCP, and dashboard cost status around one locked exposure
   snapshot containing settled spend, active holds, unresolved post-dispatch
   holds, effective caps, headroom, and freeze state. Unknown state is rendered

--- a/docs/design/no-surprise-spend-authority.md
+++ b/docs/design/no-surprise-spend-authority.md
@@ -110,6 +110,17 @@ Unknown money state reports zero authorizable headroom and blocks paid work.
 Derived dashboard preferences are not spend authority and must not be labeled
 as limits unless they are clamped through the shared resolver.
 
+The canonical write root is `~/.deepr/costs` unless an absolute
+`DEEPR_COST_DATA_DIR` explicitly isolates a deployment. During legacy
+migration, a validated checkout can contribute read-only ledger and reservation
+state. Each discovered artifact is durably appended to
+`accounting_sources.jsonl` under the canonical root before it is trusted. A
+wheel later launched outside the checkout reads that registry instead of
+depending on package location or current directory. A registered artifact that
+is missing, malformed, or unreadable makes accounting incomplete and blocks
+paid work. Health output distinguishes the primary write path from every
+accounting read path and its contribution.
+
 For later invoice reconciliation, supported central metered calls preserve a
 local client correlation ID, a provider HTTP request ID when exposed, and a
 separate provider object ID. The extractor is bounded and reads only declared
@@ -175,6 +186,9 @@ though its provider-invoice cost is `$0`. See
    shipped. Keep paid authority blocked until provider-specific authenticated
    source and credential-identity adapters can prove hard-limit or overage-off
    posture.
+7. Consolidate registered legacy roots into one lock-protected canonical state
+   and bind any future paid authorization to a stable cost-state manifest.
+   Root, policy, digest, or migration-status drift must invalidate authority.
 
 Implementation note, 2026-07-25: the shared wallet, job/day/week/month
 hierarchy, manual freeze, durable aggregate reservations, pre-dispatch
@@ -191,6 +205,11 @@ delivery, provider-specific authenticated account-control adapters, and
 external-spend detection are not shipped. A provider account can still accrue
 charges through another application, a shared or compromised credential, a
 vendor-side pricing change, or taxes outside Deepr's usage ledger.
+
+Implementation note, 2026-07-28: validated legacy accounting roots persist in
+an append-only home registry shared by editable and installed processes.
+Missing registered state is unknown and fail-closed. Canonical consolidation
+and a cost-state identity remain required before paid authority can be enabled.
 
 Each phase is independently fail-closed. A later phase may improve
 availability, reporting, or efficiency, but it must not weaken an earlier

--- a/src/deepr/cli/commands/costs.py
+++ b/src/deepr/cli/commands/costs.py
@@ -646,12 +646,26 @@ def _tracking_integrity_checks(dashboard, ledger, ledger_path: Path, drift_thres
 
     # Ledger storage sanity
     health = ledger.get_health()
-    checks.append(("Ledger writable", bool(health.get("writable")), str(health.get("path", ledger_path))))
+    write_path = str(health.get("primary_write_path") or health.get("path", ledger_path))
+    read_paths = [str(path) for path in health.get("accounting_read_paths", [])]
+    checks.append(("Ledger writable", bool(health.get("writable")), write_path))
     checks.append(
         (
             "Ledger accounting ready",
             bool(health.get("accounting_ready")),
-            str(health.get("error") or health.get("path", ledger_path)),
+            str(health.get("error") or f"write={write_path}; reads={', '.join(read_paths) or 'UNKNOWN'}"),
+        )
+    )
+    source_details = "; ".join(
+        f"{source.get('path')} ({int(source.get('event_count', 0))} events, "
+        f"${float(source.get('total_cost_usd', 0.0)):.4f})"
+        for source in health.get("accounting_sources", [])
+    )
+    checks.append(
+        (
+            "Accounting source coverage",
+            bool(health.get("accounting_complete")) and bool(read_paths),
+            source_details or str(health.get("error") or "UNKNOWN: no accounting roots resolved"),
         )
     )
 

--- a/src/deepr/experts/research_reservation_store.py
+++ b/src/deepr/experts/research_reservation_store.py
@@ -15,6 +15,7 @@ from deepr.observability.cost_ledger import (
     CostLedger,
     CostLedgerEvent,
     default_cost_data_dir,
+    registered_cost_artifact_paths,
     well_known_cost_data_dirs,
 )
 
@@ -65,21 +66,8 @@ class ResearchReservationStore:
 
     def __init__(self, path: Path | None = None, *, lock_timeout_seconds: float = 5.0) -> None:
         using_default_path = path is None and not os.environ.get("DEEPR_COST_DATA_DIR", "").strip()
+        self._using_default_path = using_default_path
         self.path = path or default_cost_data_dir() / "research_reservations.db"
-        self._candidate_sibling_paths: tuple[Path, ...] = ()
-        if using_default_path:
-            siblings: list[Path] = []
-            for root in well_known_cost_data_dirs():
-                candidate = root / "research_reservations.db"
-                try:
-                    if candidate.resolve() != self.path.resolve():
-                        siblings.append(candidate)
-                except OSError:
-                    continue
-            # Keep stable candidate paths even before their databases exist.
-            # A long-lived process must see legacy state created later by a
-            # concurrently rolling older process.
-            self._candidate_sibling_paths = tuple(siblings)
         if (
             isinstance(lock_timeout_seconds, bool)
             or not isinstance(lock_timeout_seconds, (int, float))
@@ -102,13 +90,35 @@ class ResearchReservationStore:
         connection.execute(f"PRAGMA busy_timeout = {int(self._lock_timeout_seconds * 1000)}")
         return connection
 
+    def _sibling_reservation_paths(self) -> tuple[Path, ...]:
+        if not self._using_default_path:
+            return ()
+        siblings: list[Path] = []
+        for root in well_known_cost_data_dirs():
+            candidate = root / "research_reservations.db"
+            try:
+                if candidate.resolve() != self.path.resolve():
+                    siblings.append(candidate)
+            except OSError as error:
+                raise ResearchReservationStoreError("legacy reservation state cannot be resolved") from error
+        return tuple(siblings)
+
     def _reservation_paths(self) -> tuple[Path, ...]:
         """Rediscover stable reservation databases for every authority read."""
         paths = [self.path]
-        for candidate in self._candidate_sibling_paths:
+        required = (
+            {path.resolve() for path in registered_cost_artifact_paths("research_reservations.db")}
+            if self._using_default_path
+            else set()
+        )
+        for candidate in self._sibling_reservation_paths():
             try:
                 if candidate.exists():
                     paths.append(candidate)
+                elif candidate.resolve() in required:
+                    raise ResearchReservationStoreError("registered reservation state is missing")
+            except ResearchReservationStoreError:
+                raise
             except OSError as error:
                 raise ResearchReservationStoreError("legacy reservation state cannot be located") from error
         return tuple(paths)

--- a/src/deepr/observability/cost_ledger.py
+++ b/src/deepr/observability/cost_ledger.py
@@ -6,6 +6,7 @@ import logging
 import os
 import threading
 import time
+import tomllib
 from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
@@ -14,9 +15,15 @@ from math import isfinite
 from pathlib import Path
 from typing import Any, TypeVar
 
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
 _REQUIRED_EVENT_FIELDS = frozenset({"timestamp", "operation", "provider", "cost_usd"})
+_ACCOUNTING_SOURCE_REGISTRY = "accounting_sources.jsonl"
+_ACCOUNTING_SOURCE_ARTIFACTS = frozenset({"cost_ledger.jsonl", "research_reservations.db"})
+_ACCOUNTING_SOURCE_SCHEMA_VERSION = 1
 
 
 class CostLedgerLockTimeout(TimeoutError):
@@ -91,9 +98,147 @@ def _source_checkout_cost_data_dir() -> Path | None:
         root = Path(__file__).resolve().parents[3]
     except (IndexError, OSError):
         return None
-    if not (root / "pyproject.toml").is_file() or not (root / "src" / "deepr").is_dir():
+    if not _is_deepr_checkout(root):
         return None
     return root / "data" / "costs"
+
+
+def _is_deepr_checkout(root: Path) -> bool:
+    """Accept only a checkout whose package metadata identifies Deepr."""
+    pyproject = root / "pyproject.toml"
+    if not pyproject.is_file() or not (root / "src" / "deepr").is_dir():
+        return False
+    try:
+        with pyproject.open("rb") as handle:
+            project = tomllib.load(handle).get("project", {})
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    return isinstance(project, dict) and project.get("name") == "deepr-research"
+
+
+def _cwd_checkout_cost_data_dir() -> Path | None:
+    """Find a validated checkout when installed code runs below its root."""
+    try:
+        current = Path.cwd().resolve()
+    except OSError:
+        return None
+    for root in (current, *current.parents):
+        if _is_deepr_checkout(root):
+            return root / "data" / "costs"
+    return None
+
+
+def _discover_checkout_cost_data_dirs() -> tuple[Path, ...]:
+    """Discover one checkout without making CWD the canonical write root."""
+    source_checkout = _source_checkout_cost_data_dir()
+    if source_checkout is not None:
+        return (source_checkout,)
+    cwd_checkout = _cwd_checkout_cost_data_dir()
+    return (cwd_checkout,) if cwd_checkout is not None else ()
+
+
+def _accounting_source_registry_path() -> Path:
+    return default_cost_data_dir() / _ACCOUNTING_SOURCE_REGISTRY
+
+
+def _normalized_registered_root(value: object) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise CostLedgerReadError("accounting source registry contains an invalid root")
+    root = Path(value)
+    if not root.is_absolute():
+        raise CostLedgerReadError("accounting source registry contains a relative root")
+    try:
+        return root.resolve()
+    except OSError as exc:
+        raise CostLedgerReadError("accounting source registry root cannot be resolved") from exc
+
+
+def _parse_accounting_source_record(line: str) -> tuple[Path, str]:
+    document = _loads_strict_json(line)
+    if set(document) != {"schema_version", "registered_at", "root", "artifact"}:
+        raise CostLedgerReadError("accounting source registry contains a malformed record")
+    if document.get("schema_version") != _ACCOUNTING_SOURCE_SCHEMA_VERSION:
+        raise CostLedgerReadError("accounting source registry schema is unsupported")
+    artifact = document.get("artifact")
+    if artifact not in _ACCOUNTING_SOURCE_ARTIFACTS:
+        raise CostLedgerReadError("accounting source registry contains an unknown artifact")
+    registered_at = document.get("registered_at")
+    if not isinstance(registered_at, str):
+        raise CostLedgerReadError("accounting source registry contains an invalid timestamp")
+    _validated_timestamp(registered_at)
+    return _normalized_registered_root(document.get("root")), str(artifact)
+
+
+def _read_registered_cost_sources() -> dict[Path, set[str]]:
+    """Read the append-only home registry strictly."""
+    if os.environ.get("DEEPR_COST_DATA_DIR", "").strip():
+        return {}
+    registry = _accounting_source_registry_path()
+    if not registry.exists():
+        return {}
+    sources: dict[Path, set[str]] = {}
+    try:
+        with registry.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                root, artifact = _parse_accounting_source_record(line)
+                sources.setdefault(root, set()).add(artifact)
+    except CostLedgerReadError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise CostLedgerReadError("accounting source registry is unreadable") from exc
+    return sources
+
+
+def _register_cost_source(root: Path, artifact: str) -> None:
+    """Persist a discovered legacy artifact before relying on it."""
+    if os.environ.get("DEEPR_COST_DATA_DIR", "").strip():
+        return
+    if artifact not in _ACCOUNTING_SOURCE_ARTIFACTS:
+        raise ValueError("unsupported accounting source artifact")
+    try:
+        resolved_root = root.resolve()
+        canonical_root = default_cost_data_dir().resolve()
+    except OSError as exc:
+        raise CostLedgerReadError("accounting source root cannot be resolved") from exc
+    if resolved_root == canonical_root or not (resolved_root / artifact).is_file():
+        return
+    registry = _accounting_source_registry_path()
+    try:
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        with FileLock(str(registry.with_name(f"{registry.name}.lock")), timeout=5.0, thread_local=False):
+            registered = _read_registered_cost_sources()
+            if artifact in registered.get(resolved_root, set()):
+                return
+            record = {
+                "schema_version": _ACCOUNTING_SOURCE_SCHEMA_VERSION,
+                "registered_at": _utc_now().isoformat(),
+                "root": str(resolved_root),
+                "artifact": artifact,
+            }
+            with registry.open("a", encoding="utf-8", newline="\n") as handle:
+                handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+    except FileLockTimeout as exc:
+        raise CostLedgerLockTimeout("accounting source registry lock timed out") from exc
+    except CostLedgerReadError:
+        raise
+    except OSError as exc:
+        raise CostLedgerDurabilityError("accounting source registry could not be persisted") from exc
+
+
+def registered_cost_artifact_paths(artifact: str) -> tuple[Path, ...]:
+    """Return every persisted legacy artifact path required for accounting."""
+    if artifact not in _ACCOUNTING_SOURCE_ARTIFACTS:
+        raise ValueError("unsupported accounting source artifact")
+    return tuple(
+        root / artifact
+        for root, artifacts in sorted(_read_registered_cost_sources().items(), key=lambda item: str(item[0]).casefold())
+        if artifact in artifacts
+    )
 
 
 def well_known_cost_data_dirs() -> tuple[Path, ...]:
@@ -101,9 +246,12 @@ def well_known_cost_data_dirs() -> tuple[Path, ...]:
     if os.environ.get("DEEPR_COST_DATA_DIR", "").strip():
         return (default_cost_data_dir(),)
     candidates = [default_cost_data_dir()]
-    source_checkout = _source_checkout_cost_data_dir()
-    if source_checkout is not None:
-        candidates.append(source_checkout)
+    discovered = _discover_checkout_cost_data_dirs()
+    for root in discovered:
+        for artifact in _ACCOUNTING_SOURCE_ARTIFACTS:
+            _register_cost_source(root, artifact)
+        candidates.append(root)
+    candidates.extend(_read_registered_cost_sources())
     unique: list[Path] = []
     seen: set[Path] = set()
     for candidate in candidates:
@@ -196,22 +344,9 @@ class CostLedger:
         lock_timeout_seconds: float | None = None,
     ):
         using_default_path = ledger_path is None and not os.environ.get("DEEPR_COST_DATA_DIR", "").strip()
+        self._using_default_path = using_default_path
         self.ledger_path = ledger_path or default_cost_data_dir() / "cost_ledger.jsonl"
         self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
-        # New default writes always use the home-anchored ledger. Strict reads
-        # include any source-checkout legacy ledger. Keep the candidate even
-        # before it exists so a long-lived process sees rolling-upgrade state.
-        # Explicit ledger_path and DEEPR_COST_DATA_DIR remain isolated.
-        self._candidate_sibling_ledger_paths: tuple[Path, ...] = ()
-        if using_default_path:
-            siblings: list[Path] = []
-            for candidate in well_known_ledger_paths():
-                try:
-                    if candidate.resolve() != self.ledger_path.resolve():
-                        siblings.append(candidate)
-                except OSError:
-                    continue
-            self._candidate_sibling_ledger_paths = tuple(siblings)
         self._lock = threading.Lock()
         self._lock_timeout_seconds = _validated_lock_timeout(lock_timeout_seconds)
         self._idempotency_keys: set[str] = set()
@@ -277,13 +412,35 @@ class CostLedger:
                 finally:
                     fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
+    def _sibling_ledger_paths(self) -> tuple[Path, ...]:
+        """Rediscover checkout and persisted roots for every authority read."""
+        if not self._using_default_path:
+            return ()
+        siblings: list[Path] = []
+        for candidate in well_known_ledger_paths():
+            try:
+                if candidate.resolve() != self.ledger_path.resolve():
+                    siblings.append(candidate)
+            except OSError as exc:
+                raise CostLedgerReadError("cost ledger location could not be resolved") from exc
+        return tuple(siblings)
+
     def _accounting_ledger_paths(self) -> tuple[Path, ...]:
         """Rediscover existing sibling ledgers without creating them."""
         paths = [self.ledger_path]
-        for candidate in self._candidate_sibling_ledger_paths:
+        required = (
+            {path.resolve() for path in registered_cost_artifact_paths("cost_ledger.jsonl")}
+            if self._using_default_path
+            else set()
+        )
+        for candidate in self._sibling_ledger_paths():
             try:
                 if candidate.exists():
                     paths.append(candidate)
+                elif candidate.resolve() in required:
+                    raise CostLedgerReadError("registered cost ledger is missing")
+            except CostLedgerReadError:
+                raise
             except OSError as exc:
                 raise CostLedgerReadError("cost ledger location could not be inspected") from exc
         return tuple(paths)
@@ -292,10 +449,19 @@ class CostLedger:
     def _accounting_locks(self, *, deadline: float | None = None) -> Iterator[tuple[Path, ...]]:
         """Lock canonical and existing legacy ledgers in one stable order."""
         lock_candidates = [self.ledger_path]
-        for candidate in self._candidate_sibling_ledger_paths:
+        required = (
+            {path.resolve() for path in registered_cost_artifact_paths("cost_ledger.jsonl")}
+            if self._using_default_path
+            else set()
+        )
+        for candidate in self._sibling_ledger_paths():
             try:
                 if candidate.exists() or candidate.parent.exists():
                     lock_candidates.append(candidate)
+                elif candidate.resolve() in required:
+                    raise CostLedgerReadError("registered cost ledger is missing")
+            except CostLedgerReadError:
+                raise
             except OSError as exc:
                 raise CostLedgerReadError("cost ledger location could not be inspected") from exc
         paths = sorted(
@@ -658,10 +824,26 @@ class CostLedger:
 
         accounting_ready = False
         events: list[CostLedgerEvent] = []
+        accounting_paths: tuple[Path, ...] = ()
+        source_contributions: list[dict[str, Any]] = []
         if writable:
             try:
-                events = self.with_locked_accounting_events(list)
-                accounting_ready = True
+                with self._thread_lock():
+                    with self._accounting_locks() as accounting_paths:
+                        for path in accounting_paths:
+                            if path.exists():
+                                self._require_durable_file(path)
+                        events = self._get_accounting_events_unlocked(paths=accounting_paths)
+                        for path in accounting_paths:
+                            path_events = self._read_ledger_file(path)
+                            source_contributions.append(
+                                {
+                                    "path": str(path),
+                                    "event_count": len(path_events),
+                                    "total_cost_usd": sum(event.cost_usd for event in path_events),
+                                }
+                            )
+                        accounting_ready = True
             except (
                 CostLedgerDurabilityError,
                 CostLedgerIdempotencyConflict,
@@ -673,10 +855,19 @@ class CostLedger:
         if not accounting_ready:
             try:
                 events = self.get_events()
-            except (CostLedgerLockTimeout, OSError) as exc:
+            except (
+                CostLedgerIdempotencyConflict,
+                CostLedgerLockTimeout,
+                CostLedgerReadError,
+                OSError,
+            ) as exc:
                 error = error or f"{type(exc).__name__}: {exc}"
         return {
             "path": str(self.ledger_path),
+            "primary_write_path": str(self.ledger_path),
+            "accounting_read_paths": [str(path) for path in accounting_paths],
+            "accounting_sources": source_contributions,
+            "accounting_complete": accounting_ready,
             "exists": self.ledger_path.exists(),
             "writable": writable,
             "accounting_ready": accounting_ready,

--- a/tests/unit/test_cli/test_costs_dashboard.py
+++ b/tests/unit/test_cli/test_costs_dashboard.py
@@ -553,6 +553,10 @@ class TestCostsDoctor:
         mock_ledger = MagicMock()
         mock_ledger.get_health.return_value = {
             "path": "data/costs/cost_ledger.jsonl",
+            "primary_write_path": "data/costs/cost_ledger.jsonl",
+            "accounting_read_paths": ["data/costs/cost_ledger.jsonl"],
+            "accounting_sources": [{"path": "data/costs/cost_ledger.jsonl", "event_count": 1, "total_cost_usd": 1.0}],
+            "accounting_complete": True,
             "writable": True,
             "accounting_ready": True,
             "event_count": 1,
@@ -580,6 +584,10 @@ class TestCostsDoctor:
         mock_ledger = MagicMock()
         mock_ledger.get_health.return_value = {
             "path": "data/costs/cost_ledger.jsonl",
+            "primary_write_path": "data/costs/cost_ledger.jsonl",
+            "accounting_read_paths": ["data/costs/cost_ledger.jsonl"],
+            "accounting_sources": [{"path": "data/costs/cost_ledger.jsonl", "event_count": 1, "total_cost_usd": 2.0}],
+            "accounting_complete": True,
             "writable": True,
             "accounting_ready": True,
             "event_count": 1,

--- a/tests/unit/test_observability/test_ledger_location.py
+++ b/tests/unit/test_observability/test_ledger_location.py
@@ -139,6 +139,136 @@ def test_default_ledger_unions_well_known_locations(tmp_path: Path, monkeypatch:
     assert total == pytest.approx(7.0)
 
 
+def test_registered_legacy_ledger_survives_installed_layout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPR_COST_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    legacy_root = tmp_path / "checkout" / "data" / "costs"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: legacy_root)
+
+    CostLedger(ledger_path=legacy_root / "cost_ledger.jsonl").record_event(
+        operation="research_completion",
+        provider="openai",
+        cost_usd=38.52,
+        idempotency_key="persistent-legacy-ledger",
+    )
+    source_health = CostLedger().get_health()
+    assert source_health["total_cost_usd"] == pytest.approx(38.52)
+    assert source_health["primary_write_path"] == str(fake_home / ".deepr" / "costs" / "cost_ledger.jsonl")
+    assert source_health["accounting_complete"] is True
+    assert {item["path"] for item in source_health["accounting_sources"]} == {
+        str(fake_home / ".deepr" / "costs" / "cost_ledger.jsonl"),
+        str(legacy_root / "cost_ledger.jsonl"),
+    }
+
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: None)
+    monkeypatch.setattr(ledger_module, "_cwd_checkout_cost_data_dir", lambda: None)
+    monkeypatch.chdir(outside)
+    assert CostLedger().get_total_cost() == pytest.approx(38.52)
+
+
+def test_missing_registered_legacy_ledger_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPR_COST_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    legacy_root = tmp_path / "checkout" / "data" / "costs"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: legacy_root)
+
+    legacy_path = legacy_root / "cost_ledger.jsonl"
+    CostLedger(ledger_path=legacy_path).record_event(
+        operation="research_completion",
+        provider="openai",
+        cost_usd=1.0,
+        idempotency_key="missing-registered-ledger",
+    )
+    assert CostLedger().get_total_cost() == pytest.approx(1.0)
+    legacy_path.unlink()
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: None)
+    monkeypatch.setattr(ledger_module, "_cwd_checkout_cost_data_dir", lambda: None)
+
+    with pytest.raises(CostLedgerReadError, match="registered cost ledger is missing"):
+        CostLedger().get_total_cost()
+    health = CostLedger().get_health()
+    assert health["accounting_complete"] is False
+    assert "registered cost ledger is missing" in health["error"]
+
+
+def test_malformed_accounting_source_registry_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPR_COST_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    registry = fake_home / ".deepr" / "costs" / "accounting_sources.jsonl"
+    registry.parent.mkdir(parents=True)
+    registry.write_text('{"schema_version":1,"root":"relative"}\n', encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: None)
+    monkeypatch.setattr(ledger_module, "_cwd_checkout_cost_data_dir", lambda: None)
+
+    with pytest.raises(CostLedgerReadError, match="registry"):
+        CostLedger().get_total_cost()
+
+
+def test_installed_layout_registers_validated_checkout_from_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPR_COST_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    checkout = tmp_path / "checkout"
+    nested = checkout / ".agent" / "smoke"
+    nested.mkdir(parents=True)
+    (checkout / "src" / "deepr").mkdir(parents=True)
+    (checkout / "pyproject.toml").write_text('[project]\nname = "deepr-research"\n', encoding="utf-8")
+    legacy_root = checkout / "data" / "costs"
+    CostLedger(ledger_path=legacy_root / "cost_ledger.jsonl").record_event(
+        operation="research_completion",
+        provider="openai",
+        cost_usd=2.5,
+        idempotency_key="wheel-cwd-ledger",
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: None)
+    monkeypatch.chdir(nested)
+
+    assert CostLedger().get_total_cost() == pytest.approx(2.5)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+    assert CostLedger().get_total_cost() == pytest.approx(2.5)
+
+
+def test_installed_layout_ignores_unvalidated_cwd_data(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPR_COST_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    arbitrary = tmp_path / "arbitrary"
+    legacy_root = arbitrary / "data" / "costs"
+    CostLedger(ledger_path=legacy_root / "cost_ledger.jsonl").record_event(
+        operation="research_completion",
+        provider="openai",
+        cost_usd=4.0,
+        idempotency_key="unvalidated-cwd-ledger",
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: None)
+    monkeypatch.chdir(arbitrary)
+
+    assert CostLedger().get_total_cost() == 0.0
+
+
 def test_strict_accounting_rejects_malformed_sibling_ledger(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -314,6 +444,33 @@ def test_canonical_reservations_count_legacy_source_checkout_holds(
         )
 
 
+def test_registered_legacy_reservation_survives_installed_layout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPR_COST_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    legacy_root = tmp_path / "checkout" / "data" / "costs"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: legacy_root)
+    legacy = ResearchReservationStore(legacy_root / "research_reservations.db")
+    _seed_reservation(
+        legacy,
+        reservation_id="registered-legacy-hold",
+        job_id="registered-legacy-job",
+        reserved_cost=0.75,
+    )
+    assert ResearchReservationStore().active_cost() == pytest.approx(0.75)
+
+    monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: None)
+    monkeypatch.setattr(ledger_module, "_cwd_checkout_cost_data_dir", lambda: None)
+    assert ResearchReservationStore().active_cost() == pytest.approx(0.75)
+
+    legacy.path.unlink()
+    with pytest.raises(ResearchReservationStoreError, match="registered reservation state is missing"):
+        ResearchReservationStore().active_cost()
+
+
 def test_long_lived_store_discovers_and_settles_late_legacy_hold(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -410,7 +567,9 @@ def test_explicit_reservation_path_stays_isolated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("DEEPR_COST_DATA_DIR", raising=False)
+    fake_home = tmp_path / "home"
     legacy_root = tmp_path / "checkout" / "data" / "costs"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
     monkeypatch.setattr(ledger_module, "_source_checkout_cost_data_dir", lambda: legacy_root)
     legacy = ResearchReservationStore(legacy_root / "research_reservations.db")
     _seed_reservation(


### PR DESCRIPTION
## What

- Persists every validated legacy cost ledger and reservation database in an append-only registry under the canonical home cost root.
- Makes installed wheels and editable source use the same known accounting set, independent of package location and current directory.
- Fails closed when a registered ledger or reservation database is missing, malformed, or unreadable.
- Reports the sole write path and every accounting read contributor with event and dollar totals.
- Records canonical cost-state consolidation as a required gate before any future paid recovery.

## Why

The first v2.39.0 release smoke found that editable source saw the checkout ledger while an installed wheel outside the checkout saw only the empty home ledger. That made the same displayed path report either $38.52 for July or $0.00 depending on package layout. Paid dispatch remained frozen, but the incomplete accounting would become critical if paid authority were later enabled.

## Runtime evidence

- Editable source: lifetime $41.793757, July $38.5240805, active holds $0.00
- Installed wheel launched outside the checkout: identical totals and accounting roots
- Effective paid ceiling: $0.00
- Persistent registry: exactly the real checkout ledger and reservation database

## Verification

- Full unit suite: 9,802 passed, 9 skipped, 0 failed
- Branch coverage: 85.11%, above the blocking 80% minimum
- Targeted ledger, reservation, CLI, and wheel-layout regressions: passed
- Ruff check and 593-file format check: passed
- Strict blocking mypy scope: passed
- File-size, complexity, security, and documentation ratchets: passed
- Gitleaks full-history scan: passed