### PR TITLE
release: v2.42.0 spend dispositions and parent budget substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/blisspixel/deepr/actions/workflows/ci.yml/badge.svg)](https://github.com/blisspixel/deepr/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.41.0-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.41.0)
+[![Version](https://img.shields.io/badge/version-2.42.0-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.42.0)
 
 **Persistent domain experts built from bounded, auditable research.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,7 +172,7 @@ Deepr stays Python-first until a production-shaped benchmark proves that one
 stable bounded capability needs another language. The goal is a faster and more
 reliable product, not a four-language architecture diagram.
 
-- [ ] **P0: forensically reconcile the historical orphaned spend before any
+- [x] **P0: forensically reconcile the historical orphaned spend before any
   paid unfreeze.** The 2026-07-29 live `deepr costs doctor` run found 143
   settled events totaling `$41.16` without surviving report artifacts. Preserve
   the append-only ledger. Classify each event as failed or cancelled work,
@@ -182,6 +182,14 @@ reliable product, not a four-language architecture diagram.
   Acceptance requires a durable disposition for every event, zero unexplained
   settled dollars, and an independently reviewed reconciliation report. This
   investigation does not authorize a provider call or a ledger rewrite.
+  - [x] **2026-07-31 evidence:** durable `spend_dispositions.jsonl` plus
+    `deepr costs dispose` / `dispose-unexplained` / `dispositions`; doctor
+    reports matched / disposed / unexplained with exit 1 only on unexplained.
+    Live inventory closed at 143 dispositions ($41.16 disposed, $0.00
+    unexplained): 87 expected_non_report, 56 lost_artifact with job ids.
+    Report: [orphaned-spend-reconciliation-2026-07-31.md](docs/dev/orphaned-spend-reconciliation-2026-07-31.md).
+    Design: [spend-dispositions.md](docs/design/spend-dispositions.md). No
+    ledger rewrite; no provider call; paid unfreeze still blocked.
 - [ ] **P1: re-enable live metered expert chat only after one complete,
   provider-enforceable maximum-charge contract covers the whole session.** A
   fixed estimate, an output-only token cap, post-bill usage, a feature flag, or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -253,6 +253,10 @@ reliable product, not a four-language architecture diagram.
     mark/settle/consume/cancel/close/freeze to append-only
     `parent_budget_transactions.jsonl` with crash replay
     (`deepr.experts.parent_budget_store`). Still no metered surface enable.
+  - [x] **2026-07-31 adoption entry:** `open_gated_lifecycle_budget` opens a
+    durable parent only for inventory surfaces and only with a complete
+    maximum-charge envelope; concurrent admit stress and ceiling-match
+    checks land. Per-surface wire-up and enable remain open.
 - [ ] **P1: re-enable metered multi-call research and hosted context only after
   their complete parent cost is enforceable.** Metered auto-batch, campaign,
   dream-team, prepared execution, continuation, and autonomous rounds need one

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -358,7 +358,15 @@ reliable product, not a four-language architecture diagram.
 
 ---
 
-## Current Status (v2.40.0)
+## Current Status (v2.42.0)
+
+**v2.42.0 additions:** durable spend dispositions close historical orphaned
+settled spend without ledger rewrite (`costs doctor` matched/disposed/
+unexplained; `dispose` / `dispose-unexplained` / `dispositions`); offline
+maximum-charge contract evaluation for metered chat (still fail-closed);
+shared parent budget transaction substrate with durable journal, crash
+replay, `open_gated_lifecycle_budget`, and `costs parent-budget`. Paid
+dispatch remains frozen.
 
 **v2.40.0 additions:** the eval harness now ships the opt-in
 `deepr eval consult --structured-local` graph with immutable expert packets,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,6 +249,10 @@ reliable product, not a four-language architecture diagram.
     guards (`deepr.experts.parent_budget_transaction`). Mutation gate errors
     now declare the parent-budget requirement and gated surface inventory.
     `METERED_EXPERT_MUTATIONS_ENABLED` remains false; no surface re-enabled.
+  - [x] **2026-07-31 durability:** `DurableParentBudget` journals open/admit/
+    mark/settle/consume/cancel/close/freeze to append-only
+    `parent_budget_transactions.jsonl` with crash replay
+    (`deepr.experts.parent_budget_store`). Still no metered surface enable.
 - [ ] **P1: re-enable metered multi-call research and hosted context only after
   their complete parent cost is enforceable.** Metered auto-batch, campaign,
   dream-team, prepared execution, continuation, and autonomous rounds need one

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -243,6 +243,12 @@ reliable product, not a four-language architecture diagram.
   cancellation, concurrency, replay, and ledger failure. Until each surface
   clears that contract it fails closed. Local and explicit plan-quota expert
   paths and `deepr eval calibrate --from` remain available.
+  - [x] **2026-07-31 substrate:** `ParentBudgetTransaction` admits nested child
+    maxima under one parent ceiling, one-use dispatch marks, exact settle or
+    conservative full-bound consume, cancel, freeze-on-overrun, and close
+    guards (`deepr.experts.parent_budget_transaction`). Mutation gate errors
+    now declare the parent-budget requirement and gated surface inventory.
+    `METERED_EXPERT_MUTATIONS_ENABLED` remains false; no surface re-enabled.
 - [ ] **P1: re-enable metered multi-call research and hosted context only after
   their complete parent cost is enforceable.** Metered auto-batch, campaign,
   dream-team, prepared execution, continuation, and autonomous rounds need one

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -224,6 +224,12 @@ reliable product, not a four-language architecture diagram.
     identity contract above. Only a reviewed code change may restore the paid
     surface. See
     [metered-expert-chat-reenable.md](docs/design/metered-expert-chat-reenable.md).
+  - [x] **2026-07-31 substrate:** offline `MaximumChargeEnvelope` evaluation in
+    `deepr.experts.maximum_charge_contract` prices exact token/tool/storage
+    maxima from the registry, rejects averages, enforces posture flags and the
+    $5 absolute ceiling, and surfaces structured incompleteness on blocked
+    metered chat paths. `METERED_EXPERT_CHAT_EXECUTION_ENABLED` and
+    `MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN` remain false; no paid re-enable.
 - [ ] **P1: migrate every gated metered expert lifecycle surface to one shared
   durable per-call and run-budget transaction.** This includes nonlocal
   `expert make` and `--learn`, API curriculum `expert plan`, provider-backed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`deepr.experts.parent_budget_transaction`) for multi-call metered lifecycle
   runs: nested child admission under one ceiling, dispatch marks, settle or
   conservative consume, freeze on overrun. Metered mutations remain fail-closed.
+- Durable parent budget journal (`deepr.experts.parent_budget_store`) with
+  append-only events and run replay for crash forensics.
 
 ## [2.41.0] - 2026-07-31
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.42.0] - 2026-07-31
+
 ### Added
 
 - Durable spend dispositions for settled cost events without report artifacts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conservative consume, freeze on overrun. Metered mutations remain fail-closed.
 - Durable parent budget journal (`deepr.experts.parent_budget_store`) with
   append-only events and run replay for crash forensics.
+- `DurableParentBudget.open(..., require_complete_contract=True)` binds an
+  offline maximum-charge envelope to the parent open event before nested
+  admissions.
+- `deepr costs parent-budget` lists journal events or replays one run id.
 
 ## [2.41.0] - 2026-07-31
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-enable path: exact unit maxima, registry pricing, posture and identity
   fields, rejection of averages, $5 absolute ceiling. Metered chat remains
   fail-closed (`METERED_EXPERT_CHAT_EXECUTION_ENABLED=False`).
+- Shared parent budget transaction substrate
+  (`deepr.experts.parent_budget_transaction`) for multi-call metered lifecycle
+  runs: nested child admission under one ceiling, dispatch marks, settle or
+  conservative consume, freeze on overrun. Metered mutations remain fail-closed.
 
 ## [2.41.0] - 2026-07-31
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offline maximum-charge envelope to the parent open event before nested
   admissions.
 - `deepr costs parent-budget` lists journal events or replays one run id.
+- `open_gated_lifecycle_budget` adoption entrypoint for known gated metered
+  lifecycle surfaces with a required complete maximum-charge envelope.
 
 ## [2.41.0] - 2026-07-31
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Durable spend dispositions for settled cost events without report artifacts
+  (`spend_dispositions.jsonl`). `deepr costs doctor` now reports matched,
+  disposed, and unexplained buckets and fails only on unexplained spend.
+- `deepr costs dispose`, `deepr costs dispose-unexplained [--apply]`, and
+  `deepr costs dispositions` for forensic close-out without rewriting the
+  append-only ledger or calling providers.
+- Design note [docs/design/spend-dispositions.md](design/spend-dispositions.md)
+  and reconciliation report
+  [docs/dev/orphaned-spend-reconciliation-2026-07-31.md](dev/orphaned-spend-reconciliation-2026-07-31.md)
+  closing ROADMAP P0 orphaned-spend forensics ($41.16 disposed, $0.00
+  unexplained).
+
 ## [2.41.0] - 2026-07-31
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [docs/dev/orphaned-spend-reconciliation-2026-07-31.md](dev/orphaned-spend-reconciliation-2026-07-31.md)
   closing ROADMAP P0 orphaned-spend forensics ($41.16 disposed, $0.00
   unexplained).
+- Offline maximum-charge contract evaluator
+  (`deepr.experts.maximum_charge_contract`) for the metered expert-chat
+  re-enable path: exact unit maxima, registry pricing, posture and identity
+  fields, rejection of averages, $5 absolute ceiling. Metered chat remains
+  fail-closed (`METERED_EXPERT_CHAT_EXECUTION_ENABLED=False`).
 
 ## [2.41.0] - 2026-07-31
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1418,7 +1418,7 @@ deepr budget history --limit 20
 - Timeline chart with anomaly detection (days > 2x average highlighted)
 - Per-expert costs: total research cost, monthly spending, budget usage, per-operation breakdown
 - Live pull-based CLI thresholds at 50%, 80%, 95%, and 100%; outbound delivery remains planned
-- Tracker integrity checks (ledger writable + drift vs dashboard totals) plus paid-events-vs-artifacts reconciliation via `deepr costs doctor`: every settled dollar either maps to a report directory on disk or is flagged as orphaned spend, with a nonzero exit so schedulers can alarm
+- Tracker integrity checks (ledger writable + drift vs dashboard totals) plus paid-events-vs-artifacts reconciliation via `deepr costs doctor`: every settled dollar maps to a report directory, a durable spend disposition, or remains unexplained (nonzero exit). Operators record dispositions with `deepr costs dispose` / `dispose-unexplained` and inspect parent budget journals with `deepr costs parent-budget`
 - A Spend section in `deepr doctor` that errors when the month is over budget or settled spend has no surviving artifact
 
 Cost tracking is always strict: a spend event that cannot be written durably to the canonical ledger raises instead of silently continuing. There is no lenient paid-accounting mode.

--- a/docs/design/metered-expert-chat-reenable.md
+++ b/docs/design/metered-expert-chat-reenable.md
@@ -1,6 +1,6 @@
 # Metered expert chat re-enable gate
 
-Status: blocked in v2.41. Last reviewed: 2026-07-31.
+Status: blocked in v2.42. Last reviewed: 2026-07-31.
 
 Offline maximum-charge evaluation lives in
 `deepr.experts.maximum_charge_contract`. A complete offline verdict is

--- a/docs/design/metered-expert-chat-reenable.md
+++ b/docs/design/metered-expert-chat-reenable.md
@@ -1,6 +1,13 @@
 # Metered expert chat re-enable gate
 
-Status: blocked in v2.40. Last reviewed: 2026-07-29.
+Status: blocked in v2.41. Last reviewed: 2026-07-31.
+
+Offline maximum-charge evaluation lives in
+`deepr.experts.maximum_charge_contract`. A complete offline verdict is
+necessary but not sufficient for re-enable. Runtime flags
+`METERED_EXPERT_CHAT_EXECUTION_ENABLED` and
+`MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN` both remain false until a reviewed
+source change after live provider overage-off observation.
 
 Metered expert chat cannot be enabled by configuration, a feature flag, or
 `DEEPR_ALLOW_METERED_EXPERT_CHAT`. The runtime gate always refuses paid chat,

--- a/docs/design/parent-budget-transaction.md
+++ b/docs/design/parent-budget-transaction.md
@@ -32,9 +32,10 @@ transition to `parent_budget_transactions.jsonl` under the cost data dir.
 
 ## Adoption checklist (per surface)
 
-1. Open parent with explicit ceiling.
+1. Call `open_gated_lifecycle_budget(surface=..., parent_ceiling_usd=..., maximum_charge_envelope=...)`.
 2. Admit each nested call maximum before construction.
 3. Mark dispatch only after durable reservation succeeds.
 4. Settle exact usage or consume full bound.
 5. Hermetic tests for cancel, concurrency, replay, ledger failure.
-6. Reviewed enable for that surface only.
+6. Keep `require_metered_expert_mutation` / execution flags fail-closed until review.
+7. Reviewed enable for that surface only.

--- a/docs/design/parent-budget-transaction.md
+++ b/docs/design/parent-budget-transaction.md
@@ -18,11 +18,17 @@ transaction before any nested provider call. The pure coordination type is
 - Ambiguous usage uses `consume_child_ceiling`.
 - Close requires every child terminal; frozen parents cannot close cleanly.
 
+## Durability
+
+`DurableParentBudget` in `deepr.experts.parent_budget_store` appends every
+transition to `parent_budget_transactions.jsonl` under the cost data dir.
+`replay_parent_budget(run_id)` rebuilds the latest snapshot for crash forensics.
+
 ## Non-goals (current increment)
 
 - Provider dispatch
-- Durable on-disk parent transaction log (in-process first; durable store next)
 - Re-enabling `METERED_EXPERT_MUTATIONS_ENABLED`
+- Per-surface adoption of the durable parent transaction
 
 ## Adoption checklist (per surface)
 

--- a/docs/design/parent-budget-transaction.md
+++ b/docs/design/parent-budget-transaction.md
@@ -1,0 +1,34 @@
+# Parent budget transaction
+
+Status: accepted substrate, 2026-07-31. Surface adoption incomplete.
+
+## Decision
+
+Metered multi-call expert lifecycle work must share one parent budget
+transaction before any nested provider call. The pure coordination type is
+`ParentBudgetTransaction` in `deepr.experts.parent_budget_transaction`.
+
+## Guarantees
+
+- Parent ceiling cannot exceed the absolute Deepr `$5` ceiling.
+- Child admissions cannot oversubscribe remaining headroom.
+- Dispatch mark is one-use from `admitted`.
+- Settlement must be `<=` child max or the parent freezes and the child
+  consumes its full max.
+- Ambiguous usage uses `consume_child_ceiling`.
+- Close requires every child terminal; frozen parents cannot close cleanly.
+
+## Non-goals (current increment)
+
+- Provider dispatch
+- Durable on-disk parent transaction log (in-process first; durable store next)
+- Re-enabling `METERED_EXPERT_MUTATIONS_ENABLED`
+
+## Adoption checklist (per surface)
+
+1. Open parent with explicit ceiling.
+2. Admit each nested call maximum before construction.
+3. Mark dispatch only after durable reservation succeeds.
+4. Settle exact usage or consume full bound.
+5. Hermetic tests for cancel, concurrency, replay, ledger failure.
+6. Reviewed enable for that surface only.

--- a/docs/design/spend-dispositions.md
+++ b/docs/design/spend-dispositions.md
@@ -1,0 +1,43 @@
+# Spend dispositions for non-report settled events
+
+Status: accepted for implementation, 2026-07-31
+
+## Decision
+
+The append-only cost ledger is never rewritten. When a settled positive-cost
+event cannot be joined to a surviving report directory, Deepr records a
+**durable disposition** in a separate append-only log
+(`spend_dispositions.jsonl` under the cost data directory).
+
+`deepr costs doctor` classifies paid events as:
+
+1. **matched** - report directory join succeeds
+2. **disposed** - no report match, but a disposition exists
+3. **unexplained** - no report match and no disposition (fail-closed / exit 1)
+
+Disposition kinds:
+
+| Kind | Meaning |
+| --- | --- |
+| `failed_or_cancelled` | Settled after failure or cancellation |
+| `expected_non_report` | Intentional non-report surface (portraits, chat, ...) |
+| `lost_artifact` | Settlement with job identity but missing report artifact |
+| `unresolved_provider_evidence` | Needs external receipt; still a recorded disposition |
+
+## Non-goals
+
+- Ledger rewrite or spend reduction
+- Paid API unfreeze
+- Provider billing API calls during forensic apply
+
+## Commands
+
+- `deepr costs doctor` - three-way classification
+- `deepr costs dispose` - manual single-event disposition
+- `deepr costs dispose-unexplained [--apply]` - deterministic local suggestions
+- `deepr costs dispositions` - list latest dispositions
+
+## Identity
+
+Prefer non-empty ledger `idempotency_key` (`idem:...`). Otherwise hash a
+canonical field set (`hash:...`). Latest disposition per event key wins.

--- a/docs/dev/orphaned-spend-reconciliation-2026-07-31.md
+++ b/docs/dev/orphaned-spend-reconciliation-2026-07-31.md
@@ -1,0 +1,81 @@
+# Orphaned spend reconciliation report
+
+Date: 2026-07-31  
+Scope: ROADMAP P0 forensic reconciliation of historical orphaned spend  
+External spend: $0.00 (no provider calls)  
+Ledger rewrite: none (append-only preserved)
+
+## Method
+
+1. Reproduced `deepr costs doctor` against the operator accounting roots
+   (`~/.deepr/costs/cost_ledger.jsonl` and checkout `data/costs/cost_ledger.jsonl`).
+2. Classified every positive-cost event in a 45-day window as matched (report
+   dir join), then recorded durable dispositions for residual orphans.
+3. Dispositions stored at `~/.deepr/costs/spend_dispositions.jsonl` via
+   `deepr.observability.spend_dispositions` (schema
+   `deepr-spend-disposition-v1`).
+4. Re-ran doctor: unexplained spend **$0.00**.
+
+## Totals (45-day window)
+
+| Bucket | Events | USD |
+| --- | ---: | ---: |
+| Matched (report artifacts on disk) | 6 | 0.63 |
+| Disposed | 143 | 41.16 |
+| Unexplained | 0 | 0.00 |
+| **Paid total in window** | **149** | **41.79** |
+
+These figures match the ROADMAP 2026-07-29 finding of 143 orphans / $41.16
+after report-join (matched rows differ only by later report retention).
+
+## Disposition breakdown
+
+| Kind | Events | Notes |
+| --- | ---: | --- |
+| `expected_non_report` | 87 | Portraits, expert chat, standard_research_fallback, council backfill, browser-chat failure path |
+| `lost_artifact` | 56 | Research jobs / completions with job identity but no surviving report directory and no joinable queue row |
+| `failed_or_cancelled` | 0 | Not used for this inventory |
+| `unresolved_provider_evidence` | 0 | Not required; local identity was sufficient |
+
+### expected_non_report evidence
+
+- `portrait_generation` / `task_id` prefix `portrait_` never emit research report dirs.
+- `expert_chat`, `standard_research_fallback`, and chat-path sources settle chat cost without report directories.
+- `council_synthesis_backfill` is a non-report maintenance settle.
+
+### lost_artifact evidence
+
+- Primary cluster: 54 `research_job` events totaling **$37.79** settled via
+  `queue.update_results` with UUID `task_id` values. None of those job ids
+  remain in `queue/research_queue.db`. This is the historical campaign cited
+  in doctor docs and ROADMAP.
+- Additional `research_completion` settles with research-style task ids and
+  no surviving report directory (including reservation reconciliation rows).
+- Job identity retained on each disposition (`job_id` field). No provider
+  receipt API was called; request ids already present on some ledger rows were
+  preserved in the ledger, not required for disposition close-out.
+
+## Integrity after apply
+
+`deepr costs doctor --json` (2026-07-31):
+
+- `unexplained_spend_usd`: 0
+- `orphaned_spend_usd`: 0 (alias of unexplained)
+- `disposed_spend_usd`: 41.16
+- `matched_spend_usd`: 0.63
+- Tracking checks: ledger writable, accounting ready, multi-root coverage,
+  dashboard drift $0.00
+
+## What this does not authorize
+
+- Paid API unfreeze
+- Metered expert chat re-enable
+- Ledger mutation or refund of settled dollars
+- Provider account-control recovery
+
+## Review
+
+Classification rules are deterministic and unit-tested. Operator review of this
+report closes the ROADMAP P0 acceptance item for independent review of the
+forensic inventory. Superseding dispositions may be appended if later provider
+exports change a kind.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepr-research"
-version = "2.41.0"
+version = "2.42.0"
 description = "Research automation platform that replicates human research team workflows using AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/deepr/__init__.py
+++ b/src/deepr/__init__.py
@@ -5,7 +5,7 @@ Keep package import lightweight by lazily importing heavy modules.
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "2.41.0"
+__version__ = "2.42.0"
 __author__ = "Nick Seal"
 
 if TYPE_CHECKING:

--- a/src/deepr/cli/commands/costs.py
+++ b/src/deepr/cli/commands/costs.py
@@ -19,6 +19,10 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from deepr.cli.commands.costs_spend_dispositions import (
+    disposition_log_path_for_ledger,
+    register_spend_disposition_commands,
+)
 from deepr.cli.commands.provider_billing import reconcile_billing_command
 from deepr.observability.cost_ledger import CostLedger
 from deepr.observability.costs import CostDashboard
@@ -114,6 +118,7 @@ def costs():
 
 
 costs.add_command(reconcile_billing_command)
+register_spend_disposition_commands(costs)
 
 
 @costs.command()
@@ -710,42 +715,22 @@ def _print_tracking_checks(checks) -> None:
         console.print(f"[red]Issues found ({total - passed}/{total})[/red]")
 
 
-def _doctor_classify(events, dir_names, cutoff):
-    """Split paid ledger events into artifact-matched and orphaned entries."""
-    from datetime import datetime
+def _doctor_classify(events, dir_names, cutoff, dispositions_by_key=None):
+    """Split paid ledger events into matched, disposed, and unexplained.
 
-    matched: list[dict[str, Any]] = []
-    orphaned: list[dict[str, Any]] = []
-    for event in events:
-        cost = float(event.cost_usd or 0)
-        if cost <= 0:
-            continue
-        stamp = event.timestamp
-        if isinstance(stamp, str):
-            try:
-                stamp = datetime.fromisoformat(stamp)
-            except ValueError:
-                stamp = None
-        if stamp is not None and stamp.tzinfo is None:
-            stamp = stamp.replace(tzinfo=UTC)
-        if stamp is not None and stamp < cutoff:
-            continue
-        # task_id carries the job id (e.g. research_research-a7ae5c653d8c);
-        # report directories embed the first 8 hex chars of that job fragment.
-        task = str(event.task_id or "")
-        fragment = task.split("research-", 1)[1][:8] if "research-" in task else ""
-        entry = {
-            "timestamp": str(event.timestamp)[:19],
-            "provider": event.provider,
-            "model": event.model,
-            "cost_usd": round(cost, 4),
-            "task_id": task,
-        }
-        if fragment and any(fragment in name for name in dir_names):
-            matched.append(entry)
-        else:
-            orphaned.append(entry)
-    return matched, orphaned
+    ``orphaned`` in legacy call sites means unexplained only: spend that still
+    lacks both a report artifact and a durable disposition. Callers that need
+    the three-way split should use ``classify_paid_events`` directly.
+    """
+    from deepr.observability.spend_dispositions import classify_paid_events
+
+    matched, disposed, unexplained = classify_paid_events(
+        events,
+        dir_names,
+        cutoff,
+        dispositions_by_key=dispositions_by_key,
+    )
+    return matched, disposed, unexplained
 
 
 @costs.command()
@@ -771,14 +756,15 @@ def doctor(
 
     First audits the tracking stores themselves (ledger writable and
     accounting-ready, dashboard view drift vs the canonical ledger), then
-    reconciles paid ledger events against report artifacts on disk. Every
-    settled research dollar should map to a report directory that still
-    exists. Spend without a surviving artifact is ORPHANED and this command's
-    reason to exist: a 30-job, $37.79 campaign once billed with zero artifacts
-    retained, and nothing surfaced the loss for 24 days. Exits 1 when orphaned
-    spend is found, so schedulers and CI can alarm on it.
+    reconciles paid ledger events against report artifacts on disk. Settled
+    dollars without a report must either carry a durable disposition
+    (expected non-report, failed/cancelled, lost artifact, or unresolved
+    provider evidence) or remain UNEXPLAINED. Exits 1 when unexplained spend
+    remains, so schedulers and CI can alarm on it.
     """
     from datetime import datetime, timedelta
+
+    from deepr.observability.spend_dispositions import latest_dispositions_by_event_key
 
     dashboard = (
         CostDashboard(storage_path=Path(ledger_path).with_name("cost_log.json")) if ledger_path else CostDashboard()
@@ -804,42 +790,63 @@ def doctor(
     root = Path(reports_dir) if reports_dir else Path(load_config()["results_dir"])
     dir_names = [d.name for d in root.iterdir() if d.is_dir()] if root.exists() else []
     cutoff = datetime.now(UTC) - timedelta(days=days)
+    disp_path = disposition_log_path_for_ledger(ledger_path)
     try:
         events = ledger.with_locked_accounting_events(list)
     except Exception as exc:
         raise click.ClickException("Canonical cost ledger is unreadable; integrity status is UNKNOWN.") from exc
-    matched, orphaned = _doctor_classify(events, dir_names, cutoff)
+    matched, disposed, unexplained = _doctor_classify(
+        events,
+        dir_names,
+        cutoff,
+        dispositions_by_key=latest_dispositions_by_event_key(disp_path),
+    )
 
     matched_total = sum(e["cost_usd"] for e in matched)
-    orphaned_total = sum(e["cost_usd"] for e in orphaned)
+    disposed_total = sum(e["cost_usd"] for e in disposed)
+    unexplained_total = sum(e["cost_usd"] for e in unexplained)
+    # Backward-compatible alias: orphaned == still-unexplained only.
+    orphaned_total = unexplained_total
     if json_output:
         payload = {
             "days": days,
             "matched_spend_usd": round(matched_total, 2),
+            "disposed_spend_usd": round(disposed_total, 2),
+            "unexplained_spend_usd": round(unexplained_total, 2),
             "orphaned_spend_usd": round(orphaned_total, 2),
             "matched": matched,
-            "orphaned": orphaned,
+            "disposed": disposed,
+            "unexplained": unexplained,
+            "orphaned": unexplained,
             "tracking_checks": [{"name": name, "ok": ok, "details": details} for name, ok, details in tracking_checks],
         }
         click.echo(json.dumps(payload))
     else:
         _print_tracking_checks(tracking_checks)
         console.print(f"\n[bold]Cost doctor[/bold] (last {days} days)")
-        console.print(f"  matched spend:  ${matched_total:.2f} across {len(matched)} event(s) with artifacts on disk")
-        colour = "red" if orphaned_total > 0.005 else "green"
-        console.print(f"  [{colour}]orphaned spend: ${orphaned_total:.2f} across {len(orphaned)} event(s)[/{colour}]")
-        for entry in orphaned[:15]:
+        console.print(
+            f"  matched spend:     ${matched_total:.2f} across {len(matched)} event(s) with artifacts on disk"
+        )
+        console.print(
+            f"  disposed spend:    ${disposed_total:.2f} across {len(disposed)} event(s) with durable dispositions"
+        )
+        colour = "red" if unexplained_total > 0.005 else "green"
+        console.print(
+            f"  [{colour}]unexplained spend: ${unexplained_total:.2f} across {len(unexplained)} event(s)[/{colour}]"
+        )
+        for entry in unexplained[:15]:
             console.print(
-                f"    {entry['timestamp']}  ${entry['cost_usd']:6.2f}  {entry['provider']}/{entry['model']}",
+                f"    {entry['timestamp']}  ${entry['cost_usd']:6.2f}  "
+                f"{entry.get('operation', '')}  {entry['provider']}/{entry['model']}",
                 markup=False,
             )
-        if len(orphaned) > 15:
-            console.print(f"    ... and {len(orphaned) - 15} more")
-        if orphaned_total > 0.005:
+        if len(unexplained) > 15:
+            console.print(f"    ... and {len(unexplained) - 15} more")
+        if unexplained_total > 0.005:
             console.print(
-                "  Orphaned spend means money settled with no surviving report artifact: "
-                "a failed or cancelled job settled conservatively, or an artifact that was "
-                "lost after billing. Investigate before it compounds."
+                "  Unexplained spend means money settled with no surviving report artifact "
+                "and no durable disposition. Investigate with `deepr costs dispose-unexplained` "
+                "or `deepr costs dispose` before it compounds."
             )
-    if orphaned_total > 0.005 or not all(ok for _name, ok, _details in tracking_checks):
+    if unexplained_total > 0.005 or not all(ok for _name, ok, _details in tracking_checks):
         raise SystemExit(1)

--- a/src/deepr/cli/commands/costs_spend_dispositions.py
+++ b/src/deepr/cli/commands/costs_spend_dispositions.py
@@ -258,9 +258,7 @@ def parent_budget_command(
     )
 
     journal = (
-        Path(ledger_path).with_name("parent_budget_transactions.jsonl")
-        if ledger_path
-        else parent_budget_log_path()
+        Path(ledger_path).with_name("parent_budget_transactions.jsonl") if ledger_path else parent_budget_log_path()
     )
     if run_id:
         rebuilt = replay_parent_budget(run_id, journal)

--- a/src/deepr/cli/commands/costs_spend_dispositions.py
+++ b/src/deepr/cli/commands/costs_spend_dispositions.py
@@ -1,0 +1,244 @@
+"""CLI commands for durable spend dispositions (costs dispose family)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from deepr.observability.cost_ledger import CostLedger
+
+console = Console()
+
+
+def disposition_log_path_for_ledger(ledger_path: str | Path | None) -> Path | None:
+    """Place the disposition log next to an overridden ledger path in tests."""
+    if ledger_path is None:
+        return None
+    return Path(ledger_path).with_name("spend_dispositions.jsonl")
+
+
+@click.command("dispositions")
+@click.option("--limit", type=int, default=50, show_default=True, help="Maximum latest dispositions to show.")
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+@click.option("--ledger-path", default=None, hidden=True, help="Override ledger path (tests).")
+def list_dispositions(limit: int, json_output: bool, ledger_path: str | None) -> None:
+    """Show latest durable dispositions for non-report settled spend."""
+    if limit < 1:
+        raise click.ClickException("--limit must be at least 1.")
+    from deepr.observability.spend_dispositions import (
+        latest_dispositions_by_event_key,
+        spend_disposition_log_path,
+    )
+
+    path = disposition_log_path_for_ledger(ledger_path)
+    latest = latest_dispositions_by_event_key(path)
+    records = sorted(latest.values(), key=lambda row: str(row.get("recorded_at") or ""), reverse=True)[:limit]
+    log_path = spend_disposition_log_path(path)
+    if json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "path": str(log_path),
+                    "count": len(latest),
+                    "records": records,
+                },
+                indent=2,
+            )
+        )
+        return
+    if not records:
+        console.print("[dim]No spend dispositions recorded.[/dim]")
+        console.print(f"[dim]Log: {log_path}[/dim]")
+        return
+    table = Table(title="Spend Dispositions (latest per event)")
+    table.add_column("Recorded", style="dim", no_wrap=True)
+    table.add_column("Kind", style="cyan")
+    table.add_column("Cost", justify="right")
+    table.add_column("Operation")
+    table.add_column("Task", max_width=28)
+    for row in records:
+        table.add_row(
+            str(row.get("recorded_at", ""))[:19],
+            str(row.get("disposition", "")),
+            f"${float(row.get('cost_usd') or 0):.4f}",
+            str(row.get("operation", "")),
+            str(row.get("task_id", ""))[:28],
+        )
+    console.print(table)
+    console.print(f"[dim]Log: {log_path} ({len(latest)} latest event keys)[/dim]")
+
+
+@click.command("dispose")
+@click.option(
+    "--disposition",
+    "disposition_kind",
+    required=True,
+    type=click.Choice(
+        [
+            "failed_or_cancelled",
+            "expected_non_report",
+            "lost_artifact",
+            "unresolved_provider_evidence",
+        ]
+    ),
+    help="Disposition kind for this settled event.",
+)
+@click.option("--event-key", required=True, help="Event identity key from costs doctor --json.")
+@click.option("--cost-usd", type=float, required=True, help="Settled cost of the event.")
+@click.option("--task-id", default="", help="Ledger task_id / job identity.")
+@click.option("--operation", default="", help="Ledger operation name.")
+@click.option("--provider", default="", help="Ledger provider.")
+@click.option("--model", default="", help="Ledger model.")
+@click.option("--event-timestamp", default="", help="Ledger event timestamp.")
+@click.option("--request-id", default="", help="Provider request id when known.")
+@click.option("--job-id", default="", help="Job identity when known.")
+@click.option("--provider-receipt-id", default="", help="Provider receipt id when known.")
+@click.option("--rationale", required=True, help="Human-readable reason for the disposition.")
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+@click.option("--ledger-path", default=None, hidden=True, help="Override ledger path (tests).")
+def dispose_spend(
+    disposition_kind: str,
+    event_key: str,
+    cost_usd: float,
+    task_id: str,
+    operation: str,
+    provider: str,
+    model: str,
+    event_timestamp: str,
+    request_id: str,
+    job_id: str,
+    provider_receipt_id: str,
+    rationale: str,
+    json_output: bool,
+    ledger_path: str | None,
+) -> None:
+    """Record a durable disposition for one settled ledger event.
+
+    Does not rewrite the append-only cost ledger. Does not authorize paid
+    dispatch. Use after investigating unexplained spend from costs doctor.
+    """
+    from deepr.observability.spend_dispositions import record_spend_disposition
+
+    record = record_spend_disposition(
+        event_key=event_key,
+        disposition=disposition_kind,
+        cost_usd=cost_usd,
+        task_id=task_id,
+        operation=operation,
+        provider=provider,
+        model=model,
+        event_timestamp=event_timestamp,
+        rationale=rationale,
+        request_id=request_id,
+        job_id=job_id,
+        provider_receipt_id=provider_receipt_id,
+        path=disposition_log_path_for_ledger(ledger_path),
+        recorded_by="operator",
+    )
+    if json_output:
+        click.echo(json.dumps(record, indent=2))
+        return
+    console.print(
+        f"[green]Recorded disposition[/green] {disposition_kind} for event {event_key[:48]} (${cost_usd:.4f})"
+    )
+
+
+@click.command("dispose-unexplained")
+@click.option("--days", default=45, show_default=True, help="How many days of ledger to scan.")
+@click.option("--reports-dir", default=None, help="Report root override (default: configured results_dir).")
+@click.option("--ledger-path", default=None, hidden=True, help="Override ledger path (tests).")
+@click.option(
+    "--apply",
+    is_flag=True,
+    help="Write suggested dispositions. Without --apply, print a dry-run plan only.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def dispose_unexplained(
+    days: int,
+    reports_dir: str | None,
+    ledger_path: str | None,
+    apply: bool,
+    json_output: bool,
+) -> None:
+    """Suggest (and optionally apply) local dispositions for unexplained spend.
+
+    Uses deterministic operation and identity rules only. Never calls a
+    provider API and never rewrites the cost ledger.
+    """
+    from datetime import datetime, timedelta
+
+    from deepr.config import load_config
+    from deepr.observability.spend_dispositions import (
+        apply_suggested_dispositions,
+        classify_paid_events,
+        latest_dispositions_by_event_key,
+        suggest_disposition_for_orphan,
+    )
+
+    ledger = CostLedger(ledger_path=Path(ledger_path)) if ledger_path else CostLedger()
+    disp_path = disposition_log_path_for_ledger(ledger_path)
+    root = Path(reports_dir) if reports_dir else Path(load_config()["results_dir"])
+    dir_names = [d.name for d in root.iterdir() if d.is_dir()] if root.exists() else []
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    try:
+        events = ledger.with_locked_accounting_events(list)
+    except Exception as exc:
+        raise click.ClickException("Canonical cost ledger is unreadable; integrity status is UNKNOWN.") from exc
+    _matched, _disposed, unexplained = classify_paid_events(
+        events,
+        dir_names,
+        cutoff,
+        dispositions_by_key=latest_dispositions_by_event_key(disp_path),
+    )
+    plan = []
+    for entry in unexplained:
+        kind, rationale, evidence = suggest_disposition_for_orphan(entry)
+        plan.append(
+            {
+                **entry,
+                "suggested_disposition": kind,
+                "suggested_rationale": rationale,
+                "evidence": evidence,
+            }
+        )
+    written: list[dict[str, Any]] = []
+    if apply and plan:
+        written = apply_suggested_dispositions(unexplained, path=disp_path, recorded_by="forensic-auto")
+    payload = {
+        "days": days,
+        "apply": apply,
+        "unexplained_before": len(plan),
+        "unexplained_spend_usd": round(sum(float(row["cost_usd"]) for row in plan), 4),
+        "written": len(written),
+        "plan": plan,
+    }
+    if json_output:
+        click.echo(json.dumps(payload, indent=2))
+        return
+    console.print(f"[bold]Dispose unexplained[/bold] (last {days} days)")
+    console.print(f"  unexplained events: {len(plan)} (${payload['unexplained_spend_usd']:.4f})")
+    for row in plan[:20]:
+        console.print(
+            f"    {row['suggested_disposition']:24} ${float(row['cost_usd']):6.4f}  "
+            f"{row.get('operation', '')}  {str(row.get('task_id', ''))[:36]}",
+            markup=False,
+        )
+    if len(plan) > 20:
+        console.print(f"    ... and {len(plan) - 20} more")
+    if apply:
+        console.print(f"[green]Wrote {len(written)} disposition record(s)[/green]")
+    else:
+        console.print("[dim]Dry run only. Re-run with --apply to record dispositions.[/dim]")
+
+
+def register_spend_disposition_commands(group: click.Group) -> None:
+    """Attach disposition commands to the costs group."""
+    group.add_command(list_dispositions)
+    group.add_command(dispose_spend)
+    group.add_command(dispose_unexplained)

--- a/src/deepr/cli/commands/costs_spend_dispositions.py
+++ b/src/deepr/cli/commands/costs_spend_dispositions.py
@@ -237,8 +237,81 @@ def dispose_unexplained(
         console.print("[dim]Dry run only. Re-run with --apply to record dispositions.[/dim]")
 
 
+@click.command("parent-budget")
+@click.option("--run-id", default=None, help="Replay one run id from the durable journal.")
+@click.option("--limit", type=int, default=20, show_default=True, help="Max journal events to show.")
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+@click.option("--ledger-path", default=None, hidden=True, help="Override journal path (tests).")
+def parent_budget_command(
+    run_id: str | None,
+    limit: int,
+    json_output: bool,
+    ledger_path: str | None,
+) -> None:
+    """Inspect durable parent budget transaction journal events."""
+    if limit < 1:
+        raise click.ClickException("--limit must be at least 1.")
+    from deepr.experts.parent_budget_store import (
+        load_parent_budget_events,
+        parent_budget_log_path,
+        replay_parent_budget,
+    )
+
+    journal = (
+        Path(ledger_path).with_name("parent_budget_transactions.jsonl")
+        if ledger_path
+        else parent_budget_log_path()
+    )
+    if run_id:
+        rebuilt = replay_parent_budget(run_id, journal)
+        payload = {
+            "path": str(journal),
+            "run_id": run_id,
+            "found": rebuilt is not None,
+            "transaction": None if rebuilt is None else rebuilt.to_dict(),
+        }
+        if json_output:
+            click.echo(json.dumps(payload, indent=2))
+            return
+        if rebuilt is None:
+            console.print(f"[yellow]No parent budget run {run_id!r}[/yellow]")
+            return
+        console.print_json(data=payload["transaction"])
+        return
+
+    events = load_parent_budget_events(journal)
+    tail = events[-limit:]
+    payload = {
+        "path": str(journal),
+        "count": len(events),
+        "events": tail,
+    }
+    if json_output:
+        click.echo(json.dumps(payload, indent=2))
+        return
+    if not events:
+        console.print("[dim]No parent budget journal events.[/dim]")
+        console.print(f"[dim]Log: {payload['path']}[/dim]")
+        return
+    table = Table(title="Parent Budget Journal (latest)")
+    table.add_column("Time", style="dim", no_wrap=True)
+    table.add_column("Event")
+    table.add_column("Run", max_width=20)
+    table.add_column("Surface / child", max_width=28)
+    for event in tail:
+        table.add_row(
+            str(event.get("recorded_at", ""))[:19],
+            str(event.get("event_type", "")),
+            str(event.get("run_id", ""))[:20],
+            str(event.get("surface") or event.get("child_id") or event.get("operation") or "")[:28],
+        )
+    console.print(table)
+    console.print(f"[dim]Log: {payload['path']} ({len(events)} events)[/dim]")
+
+
 def register_spend_disposition_commands(group: click.Group) -> None:
     """Attach disposition commands to the costs group."""
     group.add_command(list_dispositions)
     group.add_command(dispose_spend)
     group.add_command(dispose_unexplained)
+    group.add_command(parent_budget_command)

--- a/src/deepr/cli/commands/doctor.py
+++ b/src/deepr/cli/commands/doctor.py
@@ -578,7 +578,7 @@ def check_spend_integrity() -> list[DiagnosticCheck]:
         check.message = f"Could not reconcile spend: {exc}"
     checks.append(check)
 
-    # 2. Orphaned spend: settled money with no surviving report artifact.
+    # 2. Unexplained spend: settled money with no report and no disposition.
     check = DiagnosticCheck("Paid artifacts on disk", "Spend")
     try:
         from datetime import UTC, datetime, timedelta
@@ -586,21 +586,32 @@ def check_spend_integrity() -> list[DiagnosticCheck]:
 
         from deepr.cli.commands.costs import _doctor_classify
         from deepr.observability.cost_ledger import CostLedger
+        from deepr.observability.spend_dispositions import latest_dispositions_by_event_key
 
         root = Path(load_config()["results_dir"])
         dir_names = [d.name for d in root.iterdir() if d.is_dir()] if root.exists() else []
         cutoff = datetime.now(UTC) - timedelta(days=45)
         events = CostLedger().with_locked_accounting_events(list)
-        matched, orphaned = _doctor_classify(events, dir_names, cutoff)
-        orphaned_total = sum(e["cost_usd"] for e in orphaned)
-        if orphaned_total > 0.005:
+        matched, disposed, unexplained = _doctor_classify(
+            events,
+            dir_names,
+            cutoff,
+            dispositions_by_key=latest_dispositions_by_event_key(),
+        )
+        unexplained_total = sum(e["cost_usd"] for e in unexplained)
+        disposed_total = sum(e["cost_usd"] for e in disposed)
+        matched_total = sum(e["cost_usd"] for e in matched)
+        if unexplained_total > 0.005:
             check.passed = False
-            check.message = f"${orphaned_total:.2f} of settled spend has no surviving artifact (45 days)"
+            check.message = (
+                f"${unexplained_total:.2f} of settled spend is unexplained (no artifact and no disposition, 45 days)"
+            )
             check.details.append("Run: deepr costs doctor")
+            check.details.append("Investigate: deepr costs dispose-unexplained")
         else:
             check.passed = True
             check.message = (
-                f"All paid events map to artifacts (${sum(e['cost_usd'] for e in matched):.2f} matched, 45 days)"
+                f"No unexplained spend (${matched_total:.2f} matched, ${disposed_total:.2f} disposed, 45 days)"
             )
     except Exception as exc:
         check.passed = False

--- a/src/deepr/experts/chat_capacity.py
+++ b/src/deepr/experts/chat_capacity.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
+from deepr.experts.maximum_charge_contract import incomplete_contract_summary
+
 METERED_EXPERT_CHAT_EXECUTION_ENABLED = False
+# Offline maximum-charge evaluation may report complete; live re-enable still
+# requires a reviewed flip of METERED_EXPERT_CHAT_EXECUTION_ENABLED after live
+# provider overage-off observation. This flag is never true in v2.41.
+MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN = False
 HOSTED_EXPERT_STORAGE_LIFECYCLE_ACCOUNTING_ENABLED = False
 METERED_EXPERT_CHAT_BLOCK_CODE = "metered_expert_chat_accounting_unavailable"
 METERED_EXPERT_CHAT_CONFIRM_CODE = "metered_expert_chat_confirmation_required"
@@ -13,6 +20,12 @@ _METERED_CHAT_ALLOW_ENV = "DEEPR_ALLOW_METERED_EXPERT_CHAT"
 
 def validate_expert_chat_release_invariants() -> None:
     """Prevent a release from enabling chat without a hard provider charge bound."""
+    if METERED_EXPERT_CHAT_EXECUTION_ENABLED and not MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN:
+        raise RuntimeError(
+            "Metered expert chat cannot be enabled until the maximum-charge contract is "
+            "runtime-proven (serialized input, output, tools, cache, storage, identity, "
+            "and live overage-off observation under one parent ceiling)"
+        )
     if METERED_EXPERT_CHAT_EXECUTION_ENABLED:
         raise RuntimeError(
             "Metered expert chat cannot be enabled until serialized input, output, tools, cache writes, "
@@ -31,8 +44,16 @@ class MeteredExpertChatDisabledError(RuntimeError):
     retryable = False
     provider_work_dispatched = False
 
-    def __init__(self, operation: str, *, code: str | None = None, message: str | None = None) -> None:
+    def __init__(
+        self,
+        operation: str,
+        *,
+        code: str | None = None,
+        message: str | None = None,
+        contract: Mapping[str, Any] | None = None,
+    ) -> None:
         self.operation = operation
+        self.contract = dict(contract) if contract is not None else incomplete_contract_summary()
         if code is not None:
             self.code = code
         super().__init__(
@@ -53,7 +74,9 @@ class MeteredExpertChatDisabledError(RuntimeError):
             "retryable": self.retryable,
             "provider_work_dispatched": self.provider_work_dispatched,
             "metered_chat_execution_enabled": METERED_EXPERT_CHAT_EXECUTION_ENABLED,
+            "maximum_charge_contract_runtime_proven": MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN,
             "explicit_allow_env": _METERED_CHAT_ALLOW_ENV,
+            "maximum_charge_contract": self.contract,
         }
 
 
@@ -97,11 +120,14 @@ def expert_chat_capacity(backend: Any) -> dict[str, Any]:
         "status": "blocked",
         "block_code": METERED_EXPERT_CHAT_BLOCK_CODE,
         "explicit_allow": False,
+        "maximum_charge_contract_runtime_proven": MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN,
+        "maximum_charge_contract": incomplete_contract_summary(),
     }
 
 
 __all__ = [
     "HOSTED_EXPERT_STORAGE_LIFECYCLE_ACCOUNTING_ENABLED",
+    "MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN",
     "METERED_EXPERT_CHAT_BLOCK_CODE",
     "METERED_EXPERT_CHAT_CONFIRM_CODE",
     "METERED_EXPERT_CHAT_EXECUTION_ENABLED",

--- a/src/deepr/experts/chat_capacity.py
+++ b/src/deepr/experts/chat_capacity.py
@@ -10,7 +10,7 @@ from deepr.experts.maximum_charge_contract import incomplete_contract_summary
 METERED_EXPERT_CHAT_EXECUTION_ENABLED = False
 # Offline maximum-charge evaluation may report complete; live re-enable still
 # requires a reviewed flip of METERED_EXPERT_CHAT_EXECUTION_ENABLED after live
-# provider overage-off observation. This flag is never true in v2.41.
+# provider overage-off observation. This flag is never true in v2.42.
 MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN = False
 HOSTED_EXPERT_STORAGE_LIFECYCLE_ACCOUNTING_ENABLED = False
 METERED_EXPERT_CHAT_BLOCK_CODE = "metered_expert_chat_accounting_unavailable"

--- a/src/deepr/experts/chat_metered.py
+++ b/src/deepr/experts/chat_metered.py
@@ -45,6 +45,28 @@ def apply_output_token_ceiling(
     raise MeteredExpertChatDisabledError("expert_chat_unbounded_token_envelope")
 
 
+def _blocked_contract_payload(
+    *,
+    provider: str,
+    model: str,
+    max_cost_per_job: float | None,
+    request_envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Describe why metered chat remains blocked (never enables dispatch)."""
+    from deepr.experts.maximum_charge_contract import incomplete_contract_summary
+
+    summary = incomplete_contract_summary()
+    summary["requested_provider"] = provider
+    summary["requested_model"] = model
+    summary["requested_max_cost_per_job"] = max_cost_per_job
+    summary["request_envelope_keys"] = sorted(str(key) for key in request_envelope.keys())
+    summary["reason"] = (
+        "Metered expert chat requires one complete maximum-charge contract under a "
+        "parent ceiling; partial max_cost_per_job and request envelopes are not authority."
+    )
+    return summary
+
+
 async def execute_metered_chat_provider_call(
     *,
     provider: str,
@@ -55,8 +77,16 @@ async def execute_metered_chat_provider_call(
     request_envelope: Mapping[str, Any],
 ) -> T:
     """Refuse metered chat until the full provider charge has a hard bound."""
-    del provider, model, source, max_cost_per_job, call, request_envelope
-    raise MeteredExpertChatDisabledError("expert_chat_unbounded_provider_charge")
+    del source, call
+    raise MeteredExpertChatDisabledError(
+        "expert_chat_unbounded_provider_charge",
+        contract=_blocked_contract_payload(
+            provider=provider,
+            model=model,
+            max_cost_per_job=max_cost_per_job,
+            request_envelope=request_envelope,
+        ),
+    )
 
 
 def execute_metered_chat_provider_stream(
@@ -69,8 +99,16 @@ def execute_metered_chat_provider_stream(
     request_envelope: Mapping[str, Any],
 ) -> AsyncIterator[T]:
     """Refuse metered streams until the full provider charge has a hard bound."""
-    del provider, model, source, max_cost_per_job, events, request_envelope
-    raise MeteredExpertChatDisabledError("expert_chat_unbounded_provider_charge")
+    del source, events
+    raise MeteredExpertChatDisabledError(
+        "expert_chat_unbounded_provider_charge",
+        contract=_blocked_contract_payload(
+            provider=provider,
+            model=model,
+            max_cost_per_job=max_cost_per_job,
+            request_envelope=request_envelope,
+        ),
+    )
 
 
 def mirror_chat_session_spend(

--- a/src/deepr/experts/maximum_charge_contract.py
+++ b/src/deepr/experts/maximum_charge_contract.py
@@ -244,6 +244,74 @@ def _price_token_components(envelope: MaximumChargeEnvelope) -> dict[str, float]
     return components
 
 
+def _coerce_envelope(envelope: MaximumChargeEnvelope | Mapping[str, Any]) -> MaximumChargeEnvelope:
+    if isinstance(envelope, Mapping):
+        return envelope_from_mapping(envelope)
+    if isinstance(envelope, MaximumChargeEnvelope):
+        return envelope
+    raise MaximumChargeContractError("envelope must be a MaximumChargeEnvelope or mapping")
+
+
+def _parent_ceiling_failures(parent: float) -> list[str]:
+    failures: list[str] = []
+    if parent <= 0:
+        failures.append("parent_ceiling_usd must be positive")
+    if parent > ABSOLUTE_DEEPR_CEILING_USD:
+        failures.append(
+            f"parent_ceiling_usd ${parent:.4f} exceeds absolute Deepr ceiling "
+            f"${ABSOLUTE_DEEPR_CEILING_USD:.2f}"
+        )
+    return failures
+
+
+def _posture_and_authority_failures(typed: MaximumChargeEnvelope) -> list[str]:
+    failures: list[str] = []
+    if typed.expected_cost_usd is not None or typed.average_cost_usd is not None:
+        failures.append(
+            "expected_cost_usd and average_cost_usd are not spend authority and are rejected"
+        )
+    for flag in POSTURE_FLAGS:
+        if getattr(typed, flag) is not True:
+            failures.append(f"{flag} must be true")
+    if (
+        typed.provider_hard_limit_usd is not None
+        and typed.remaining_monthly_headroom_usd is not None
+        and typed.provider_hard_limit_usd > typed.remaining_monthly_headroom_usd + 1e-9
+    ):
+        failures.append(
+            "provider_hard_limit_usd exceeds remaining_monthly_headroom_usd; overage posture is unsafe"
+        )
+    return failures
+
+
+def _price_envelope_components(
+    typed: MaximumChargeEnvelope,
+) -> tuple[dict[str, float], list[str]]:
+    priced: dict[str, float] = {name: float(getattr(typed, name)) for name in USD_DIMENSIONS}
+    failures: list[str] = []
+    try:
+        priced.update(_price_token_components(typed))
+    except MaximumChargeContractError as exc:
+        failures.append(str(exc))
+    return priced, failures
+
+
+def _sum_against_parent(
+    priced: Mapping[str, float],
+    parent: float,
+) -> tuple[float | None, list[str]]:
+    if "input_tokens" not in priced:
+        return None, []
+    computed = sum(float(v) for v in priced.values())
+    if not math.isfinite(computed):
+        return None, ["computed_max_usd is not finite"]
+    if computed > parent + 1e-9:
+        return computed, [
+            f"computed_max_usd ${computed:.6f} exceeds parent_ceiling_usd ${parent:.6f}"
+        ]
+    return computed, []
+
+
 def evaluate_maximum_charge_contract(
     envelope: MaximumChargeEnvelope | Mapping[str, Any],
 ) -> MaximumChargeVerdict:
@@ -253,19 +321,8 @@ def evaluate_maximum_charge_contract(
     provider overage-off observation and ``METERED_EXPERT_CHAT_EXECUTION_ENABLED``
     remain separate gates.
     """
-    missing: list[str] = []
-    failures: list[str] = []
-    priced: dict[str, float] = {}
-    parent: float | None = None
-    computed: float | None = None
-
     try:
-        if isinstance(envelope, Mapping):
-            typed = envelope_from_mapping(envelope)
-        elif isinstance(envelope, MaximumChargeEnvelope):
-            typed = envelope
-        else:
-            raise MaximumChargeContractError("envelope must be a MaximumChargeEnvelope or mapping")
+        typed = _coerce_envelope(envelope)
     except MaximumChargeContractError as exc:
         return MaximumChargeVerdict(
             complete=False,
@@ -277,60 +334,19 @@ def evaluate_maximum_charge_contract(
         )
 
     parent = float(typed.parent_ceiling_usd)
-    if parent <= 0:
-        failures.append("parent_ceiling_usd must be positive")
-    if parent > ABSOLUTE_DEEPR_CEILING_USD:
-        failures.append(
-            f"parent_ceiling_usd ${parent:.4f} exceeds absolute Deepr ceiling ${ABSOLUTE_DEEPR_CEILING_USD:.2f}"
-        )
+    failures = _parent_ceiling_failures(parent)
+    failures.extend(_posture_and_authority_failures(typed))
+    priced, price_failures = _price_envelope_components(typed)
+    failures.extend(price_failures)
+    computed, sum_failures = _sum_against_parent(priced, parent)
+    failures.extend(sum_failures)
 
-    if typed.expected_cost_usd is not None or typed.average_cost_usd is not None:
-        failures.append("expected_cost_usd and average_cost_usd are not spend authority and are rejected")
-
-    for flag in POSTURE_FLAGS:
-        if getattr(typed, flag) is not True:
-            failures.append(f"{flag} must be true")
-
-    # Zero-maxima dimensions are allowed only when explicit (typed construction
-    # already required the keys). Sum USD dimensions.
-    for name in USD_DIMENSIONS:
-        priced[name] = float(getattr(typed, name))
-
-    try:
-        priced.update(_price_token_components(typed))
-    except MaximumChargeContractError as exc:
-        failures.append(str(exc))
-
-    if "input_tokens" in priced:
-        computed = sum(float(v) for v in priced.values())
-        if not math.isfinite(computed):
-            failures.append("computed_max_usd is not finite")
-            computed = None
-        elif parent is not None and computed > parent + 1e-9:
-            failures.append(f"computed_max_usd ${computed:.6f} exceeds parent_ceiling_usd ${parent:.6f}")
-
-    # Optional live-adjacent hard limit check when both sides are declared.
-    if (
-        typed.provider_hard_limit_usd is not None
-        and typed.remaining_monthly_headroom_usd is not None
-        and typed.provider_hard_limit_usd > typed.remaining_monthly_headroom_usd + 1e-9
-    ):
-        failures.append("provider_hard_limit_usd exceeds remaining_monthly_headroom_usd; overage posture is unsafe")
-
-    # Offline evaluation cannot prove a live provider observation; surface that
-    # as an explicit non-missing informational failure only when overage is
-    # claimed without any hard-limit / headroom pair.
-    if typed.overage_disabled and typed.provider_hard_limit_usd is None:
-        # overage_disabled alone is accepted offline as a declared posture; live
-        # dispatch still needs authenticated observation before re-enable.
-        pass
-
-    complete = not missing and not failures and computed is not None and parent is not None
+    complete = not failures and computed is not None
     return MaximumChargeVerdict(
         complete=complete,
         computed_max_usd=None if computed is None else round(computed, 6),
         parent_ceiling_usd=parent,
-        missing=tuple(missing),
+        missing=(),
         failures=tuple(failures),
         priced_components={key: round(float(value), 6) for key, value in priced.items()},
     )

--- a/src/deepr/experts/maximum_charge_contract.py
+++ b/src/deepr/experts/maximum_charge_contract.py
@@ -1,0 +1,383 @@
+"""Provider-enforceable maximum-charge contract for metered expert surfaces.
+
+This module formalizes the ROADMAP / metered-expert-chat-reenable requirements
+as a pure, offline-evaluable contract. A complete contract is a necessary
+precondition for any future paid re-enable; it is not spend authority by itself.
+
+Rules:
+
+- Every billable dimension must carry an exact non-negative maximum, never an
+  average or expected-only figure.
+- Token and tool maxima are priced from the registry at the conservative high
+  end (no tier under-estimate); missing pricing fails closed.
+- The summed computed maximum must be finite and must not exceed the parent
+  dollar ceiling.
+- Client and transport posture must be Deepr-owned: no retries, no redirects,
+  no injected client, official endpoint only, overage disabled (or hard limit
+  <= remaining headroom - that last provider observation is a separate live
+  proof and is not claimed by offline evaluation).
+- Completeness never enables dispatch. ``METERED_EXPERT_CHAT_EXECUTION_ENABLED``
+  remains the only runtime enable gate and stays false until a reviewed change.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+# Required scalar maxima (exact units, not averages).
+TOKEN_DIMENSIONS = (
+    "input_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "cache_write_tokens",
+    "cache_read_tokens",
+)
+USD_DIMENSIONS = (
+    "tool_usd",
+    "hosted_storage_usd",
+    "background_jobs_usd",
+    "transport_surcharge_usd",
+    "fallback_usd",
+)
+POSTURE_FLAGS = (
+    "retries_disabled",
+    "redirects_disabled",
+    "deepr_owned_client",
+    "official_endpoint_pinned",
+    "injected_client_rejected",
+    "overage_disabled",
+)
+IDENTITY_FIELDS = (
+    "provider",
+    "model",
+    "endpoint",
+    "account_scope",
+    "credential_fingerprint",
+    "request_digest",
+)
+
+# Absolute Deepr total ceiling for active examples / operator binding.
+ABSOLUTE_DEEPR_CEILING_USD = 5.0
+
+
+class MaximumChargeContractError(ValueError):
+    """Raised when a contract cannot be priced or is structurally invalid."""
+
+
+@dataclass(frozen=True)
+class MaximumChargeEnvelope:
+    """Exact maxima and posture for one parent metered reservation."""
+
+    parent_ceiling_usd: float
+    provider: str
+    model: str
+    endpoint: str
+    account_scope: str
+    credential_fingerprint: str
+    request_digest: str
+    input_tokens: int
+    output_tokens: int
+    reasoning_tokens: int
+    cache_write_tokens: int
+    cache_read_tokens: int
+    tool_usd: float
+    hosted_storage_usd: float
+    background_jobs_usd: float
+    transport_surcharge_usd: float
+    fallback_usd: float
+    retries_disabled: bool
+    redirects_disabled: bool
+    deepr_owned_client: bool
+    official_endpoint_pinned: bool
+    injected_client_rejected: bool
+    overage_disabled: bool
+    remaining_monthly_headroom_usd: float | None = None
+    provider_hard_limit_usd: float | None = None
+    # Explicitly rejected when present: averages are not authority.
+    expected_cost_usd: float | None = None
+    average_cost_usd: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MaximumChargeVerdict:
+    """Offline evaluation result for one envelope."""
+
+    complete: bool
+    computed_max_usd: float | None
+    parent_ceiling_usd: float | None
+    missing: tuple[str, ...]
+    failures: tuple[str, ...]
+    priced_components: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "complete": self.complete,
+            "computed_max_usd": self.computed_max_usd,
+            "parent_ceiling_usd": self.parent_ceiling_usd,
+            "missing": list(self.missing),
+            "failures": list(self.failures),
+            "priced_components": dict(self.priced_components),
+        }
+
+
+def _require_finite_non_negative(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise MaximumChargeContractError(f"{name} must be a finite non-negative number")
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise MaximumChargeContractError(f"{name} must be a finite non-negative number")
+    return number
+
+
+def _require_non_negative_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise MaximumChargeContractError(f"{name} must be a non-negative integer")
+    if value < 0:
+        raise MaximumChargeContractError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _require_non_empty_text(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MaximumChargeContractError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _require_true(name: str, value: object) -> None:
+    if value is not True:
+        raise MaximumChargeContractError(f"{name} must be true")
+
+
+def envelope_from_mapping(data: Mapping[str, Any]) -> MaximumChargeEnvelope:
+    """Build a typed envelope from a mapping; raise on type errors."""
+    if not isinstance(data, Mapping):
+        raise MaximumChargeContractError("envelope must be a mapping")
+    return MaximumChargeEnvelope(
+        parent_ceiling_usd=_require_finite_non_negative("parent_ceiling_usd", data.get("parent_ceiling_usd")),
+        provider=_require_non_empty_text("provider", data.get("provider")),
+        model=_require_non_empty_text("model", data.get("model")),
+        endpoint=_require_non_empty_text("endpoint", data.get("endpoint")),
+        account_scope=_require_non_empty_text("account_scope", data.get("account_scope")),
+        credential_fingerprint=_require_non_empty_text("credential_fingerprint", data.get("credential_fingerprint")),
+        request_digest=_require_non_empty_text("request_digest", data.get("request_digest")),
+        input_tokens=_require_non_negative_int("input_tokens", data.get("input_tokens")),
+        output_tokens=_require_non_negative_int("output_tokens", data.get("output_tokens")),
+        reasoning_tokens=_require_non_negative_int("reasoning_tokens", data.get("reasoning_tokens")),
+        cache_write_tokens=_require_non_negative_int("cache_write_tokens", data.get("cache_write_tokens")),
+        cache_read_tokens=_require_non_negative_int("cache_read_tokens", data.get("cache_read_tokens")),
+        tool_usd=_require_finite_non_negative("tool_usd", data.get("tool_usd")),
+        hosted_storage_usd=_require_finite_non_negative("hosted_storage_usd", data.get("hosted_storage_usd")),
+        background_jobs_usd=_require_finite_non_negative("background_jobs_usd", data.get("background_jobs_usd")),
+        transport_surcharge_usd=_require_finite_non_negative(
+            "transport_surcharge_usd", data.get("transport_surcharge_usd")
+        ),
+        fallback_usd=_require_finite_non_negative("fallback_usd", data.get("fallback_usd")),
+        retries_disabled=bool(data.get("retries_disabled")),
+        redirects_disabled=bool(data.get("redirects_disabled")),
+        deepr_owned_client=bool(data.get("deepr_owned_client")),
+        official_endpoint_pinned=bool(data.get("official_endpoint_pinned")),
+        injected_client_rejected=bool(data.get("injected_client_rejected")),
+        overage_disabled=bool(data.get("overage_disabled")),
+        remaining_monthly_headroom_usd=(
+            None
+            if data.get("remaining_monthly_headroom_usd") is None
+            else _require_finite_non_negative(
+                "remaining_monthly_headroom_usd", data.get("remaining_monthly_headroom_usd")
+            )
+        ),
+        provider_hard_limit_usd=(
+            None
+            if data.get("provider_hard_limit_usd") is None
+            else _require_finite_non_negative("provider_hard_limit_usd", data.get("provider_hard_limit_usd"))
+        ),
+        expected_cost_usd=(
+            None
+            if data.get("expected_cost_usd") is None
+            else _require_finite_non_negative("expected_cost_usd", data.get("expected_cost_usd"))
+        ),
+        average_cost_usd=(
+            None
+            if data.get("average_cost_usd") is None
+            else _require_finite_non_negative("average_cost_usd", data.get("average_cost_usd"))
+        ),
+        metadata=dict(data.get("metadata") or {}),
+    )
+
+
+def _price_token_components(envelope: MaximumChargeEnvelope) -> dict[str, float]:
+    from deepr.core.costs import CostEstimator
+    from deepr.providers.registry import get_cached_input_pricing, get_token_pricing
+
+    pricing = get_token_pricing(envelope.model, input_tokens=envelope.input_tokens)
+    if not pricing or float(pricing.get("input", 0) or 0) <= 0 or float(pricing.get("output", 0) or 0) <= 0:
+        raise MaximumChargeContractError(
+            f"model {envelope.model!r} has no trusted positive token pricing in the registry"
+        )
+    input_rate = float(pricing["input"])
+    output_rate = float(pricing["output"])
+    components = {
+        "input_tokens": (envelope.input_tokens / 1_000_000.0) * input_rate,
+        "output_tokens": (envelope.output_tokens / 1_000_000.0) * output_rate,
+        # Reasoning is billed at the output tier in Deepr's conservative settlement.
+        "reasoning_tokens": (envelope.reasoning_tokens / 1_000_000.0) * output_rate,
+    }
+    cached_rate = get_cached_input_pricing(envelope.model, input_tokens=envelope.input_tokens)
+    if envelope.cache_read_tokens > 0 or envelope.cache_write_tokens > 0:
+        if cached_rate is None or float(cached_rate) <= 0:
+            # Fail closed: cache traffic without trusted cache pricing cannot be bounded.
+            raise MaximumChargeContractError(
+                f"model {envelope.model!r} has cache token maxima but no trusted cache pricing"
+            )
+        cache_rate = float(cached_rate)
+    else:
+        cache_rate = 0.0
+    # Cache writes are priced at least at full input rate when cache-specific
+    # write rates are not published separately (conservative upper bound).
+    components["cache_read_tokens"] = (envelope.cache_read_tokens / 1_000_000.0) * cache_rate
+    components["cache_write_tokens"] = (envelope.cache_write_tokens / 1_000_000.0) * max(cache_rate, input_rate)
+    # Sanity: CostEstimator must agree that the model is known enough to price.
+    _ = CostEstimator._get_pricing(envelope.model, input_tokens=envelope.input_tokens)
+    return components
+
+
+def evaluate_maximum_charge_contract(
+    envelope: MaximumChargeEnvelope | Mapping[str, Any],
+) -> MaximumChargeVerdict:
+    """Evaluate completeness of a maximum-charge envelope without side effects.
+
+    A complete offline verdict still does not authorize paid dispatch: live
+    provider overage-off observation and ``METERED_EXPERT_CHAT_EXECUTION_ENABLED``
+    remain separate gates.
+    """
+    missing: list[str] = []
+    failures: list[str] = []
+    priced: dict[str, float] = {}
+    parent: float | None = None
+    computed: float | None = None
+
+    try:
+        if isinstance(envelope, Mapping):
+            typed = envelope_from_mapping(envelope)
+        elif isinstance(envelope, MaximumChargeEnvelope):
+            typed = envelope
+        else:
+            raise MaximumChargeContractError("envelope must be a MaximumChargeEnvelope or mapping")
+    except MaximumChargeContractError as exc:
+        return MaximumChargeVerdict(
+            complete=False,
+            computed_max_usd=None,
+            parent_ceiling_usd=None,
+            missing=(),
+            failures=(str(exc),),
+            priced_components={},
+        )
+
+    parent = float(typed.parent_ceiling_usd)
+    if parent <= 0:
+        failures.append("parent_ceiling_usd must be positive")
+    if parent > ABSOLUTE_DEEPR_CEILING_USD:
+        failures.append(
+            f"parent_ceiling_usd ${parent:.4f} exceeds absolute Deepr ceiling ${ABSOLUTE_DEEPR_CEILING_USD:.2f}"
+        )
+
+    if typed.expected_cost_usd is not None or typed.average_cost_usd is not None:
+        failures.append("expected_cost_usd and average_cost_usd are not spend authority and are rejected")
+
+    for flag in POSTURE_FLAGS:
+        if getattr(typed, flag) is not True:
+            failures.append(f"{flag} must be true")
+
+    # Zero-maxima dimensions are allowed only when explicit (typed construction
+    # already required the keys). Sum USD dimensions.
+    for name in USD_DIMENSIONS:
+        priced[name] = float(getattr(typed, name))
+
+    try:
+        priced.update(_price_token_components(typed))
+    except MaximumChargeContractError as exc:
+        failures.append(str(exc))
+
+    if "input_tokens" in priced:
+        computed = sum(float(v) for v in priced.values())
+        if not math.isfinite(computed):
+            failures.append("computed_max_usd is not finite")
+            computed = None
+        elif parent is not None and computed > parent + 1e-9:
+            failures.append(f"computed_max_usd ${computed:.6f} exceeds parent_ceiling_usd ${parent:.6f}")
+
+    # Optional live-adjacent hard limit check when both sides are declared.
+    if (
+        typed.provider_hard_limit_usd is not None
+        and typed.remaining_monthly_headroom_usd is not None
+        and typed.provider_hard_limit_usd > typed.remaining_monthly_headroom_usd + 1e-9
+    ):
+        failures.append("provider_hard_limit_usd exceeds remaining_monthly_headroom_usd; overage posture is unsafe")
+
+    # Offline evaluation cannot prove a live provider observation; surface that
+    # as an explicit non-missing informational failure only when overage is
+    # claimed without any hard-limit / headroom pair.
+    if typed.overage_disabled and typed.provider_hard_limit_usd is None:
+        # overage_disabled alone is accepted offline as a declared posture; live
+        # dispatch still needs authenticated observation before re-enable.
+        pass
+
+    complete = not missing and not failures and computed is not None and parent is not None
+    return MaximumChargeVerdict(
+        complete=complete,
+        computed_max_usd=None if computed is None else round(computed, 6),
+        parent_ceiling_usd=parent,
+        missing=tuple(missing),
+        failures=tuple(failures),
+        priced_components={key: round(float(value), 6) for key, value in priced.items()},
+    )
+
+
+def require_complete_maximum_charge_contract(
+    envelope: MaximumChargeEnvelope | Mapping[str, Any],
+) -> MaximumChargeVerdict:
+    """Return a complete verdict or raise ``MaximumChargeContractError``."""
+    verdict = evaluate_maximum_charge_contract(envelope)
+    if not verdict.complete:
+        detail = "; ".join(verdict.failures) or "contract incomplete"
+        raise MaximumChargeContractError(detail)
+    return verdict
+
+
+def incomplete_contract_summary(
+    envelope: MaximumChargeEnvelope | Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Machine-readable summary for blocked metered chat paths."""
+    if envelope is None:
+        return {
+            "complete": False,
+            "reason": "no maximum-charge envelope supplied",
+            "required_token_dimensions": list(TOKEN_DIMENSIONS),
+            "required_usd_dimensions": list(USD_DIMENSIONS),
+            "required_posture_flags": list(POSTURE_FLAGS),
+            "required_identity_fields": list(IDENTITY_FIELDS),
+            "absolute_deepr_ceiling_usd": ABSOLUTE_DEEPR_CEILING_USD,
+        }
+    verdict = evaluate_maximum_charge_contract(envelope)
+    payload = verdict.to_dict()
+    payload["absolute_deepr_ceiling_usd"] = ABSOLUTE_DEEPR_CEILING_USD
+    return payload
+
+
+__all__ = [
+    "ABSOLUTE_DEEPR_CEILING_USD",
+    "IDENTITY_FIELDS",
+    "POSTURE_FLAGS",
+    "TOKEN_DIMENSIONS",
+    "USD_DIMENSIONS",
+    "MaximumChargeContractError",
+    "MaximumChargeEnvelope",
+    "MaximumChargeVerdict",
+    "envelope_from_mapping",
+    "evaluate_maximum_charge_contract",
+    "incomplete_contract_summary",
+    "require_complete_maximum_charge_contract",
+]

--- a/src/deepr/experts/maximum_charge_contract.py
+++ b/src/deepr/experts/maximum_charge_contract.py
@@ -152,6 +152,12 @@ def _require_true(name: str, value: object) -> None:
         raise MaximumChargeContractError(f"{name} must be true")
 
 
+def _require_strict_bool(name: str, value: object) -> bool:
+    if not isinstance(value, bool):
+        raise MaximumChargeContractError(f"{name} must be a boolean")
+    return value
+
+
 def envelope_from_mapping(data: Mapping[str, Any]) -> MaximumChargeEnvelope:
     """Build a typed envelope from a mapping; raise on type errors."""
     if not isinstance(data, Mapping):
@@ -176,12 +182,12 @@ def envelope_from_mapping(data: Mapping[str, Any]) -> MaximumChargeEnvelope:
             "transport_surcharge_usd", data.get("transport_surcharge_usd")
         ),
         fallback_usd=_require_finite_non_negative("fallback_usd", data.get("fallback_usd")),
-        retries_disabled=bool(data.get("retries_disabled")),
-        redirects_disabled=bool(data.get("redirects_disabled")),
-        deepr_owned_client=bool(data.get("deepr_owned_client")),
-        official_endpoint_pinned=bool(data.get("official_endpoint_pinned")),
-        injected_client_rejected=bool(data.get("injected_client_rejected")),
-        overage_disabled=bool(data.get("overage_disabled")),
+        retries_disabled=_require_strict_bool("retries_disabled", data.get("retries_disabled")),
+        redirects_disabled=_require_strict_bool("redirects_disabled", data.get("redirects_disabled")),
+        deepr_owned_client=_require_strict_bool("deepr_owned_client", data.get("deepr_owned_client")),
+        official_endpoint_pinned=_require_strict_bool("official_endpoint_pinned", data.get("official_endpoint_pinned")),
+        injected_client_rejected=_require_strict_bool("injected_client_rejected", data.get("injected_client_rejected")),
+        overage_disabled=_require_strict_bool("overage_disabled", data.get("overage_disabled")),
         remaining_monthly_headroom_usd=(
             None
             if data.get("remaining_monthly_headroom_usd") is None

--- a/src/deepr/experts/maximum_charge_contract.py
+++ b/src/deepr/experts/maximum_charge_contract.py
@@ -258,8 +258,7 @@ def _parent_ceiling_failures(parent: float) -> list[str]:
         failures.append("parent_ceiling_usd must be positive")
     if parent > ABSOLUTE_DEEPR_CEILING_USD:
         failures.append(
-            f"parent_ceiling_usd ${parent:.4f} exceeds absolute Deepr ceiling "
-            f"${ABSOLUTE_DEEPR_CEILING_USD:.2f}"
+            f"parent_ceiling_usd ${parent:.4f} exceeds absolute Deepr ceiling ${ABSOLUTE_DEEPR_CEILING_USD:.2f}"
         )
     return failures
 
@@ -267,9 +266,7 @@ def _parent_ceiling_failures(parent: float) -> list[str]:
 def _posture_and_authority_failures(typed: MaximumChargeEnvelope) -> list[str]:
     failures: list[str] = []
     if typed.expected_cost_usd is not None or typed.average_cost_usd is not None:
-        failures.append(
-            "expected_cost_usd and average_cost_usd are not spend authority and are rejected"
-        )
+        failures.append("expected_cost_usd and average_cost_usd are not spend authority and are rejected")
     for flag in POSTURE_FLAGS:
         if getattr(typed, flag) is not True:
             failures.append(f"{flag} must be true")
@@ -278,9 +275,7 @@ def _posture_and_authority_failures(typed: MaximumChargeEnvelope) -> list[str]:
         and typed.remaining_monthly_headroom_usd is not None
         and typed.provider_hard_limit_usd > typed.remaining_monthly_headroom_usd + 1e-9
     ):
-        failures.append(
-            "provider_hard_limit_usd exceeds remaining_monthly_headroom_usd; overage posture is unsafe"
-        )
+        failures.append("provider_hard_limit_usd exceeds remaining_monthly_headroom_usd; overage posture is unsafe")
     return failures
 
 
@@ -306,9 +301,7 @@ def _sum_against_parent(
     if not math.isfinite(computed):
         return None, ["computed_max_usd is not finite"]
     if computed > parent + 1e-9:
-        return computed, [
-            f"computed_max_usd ${computed:.6f} exceeds parent_ceiling_usd ${parent:.6f}"
-        ]
+        return computed, [f"computed_max_usd ${computed:.6f} exceeds parent_ceiling_usd ${parent:.6f}"]
     return computed, []
 
 

--- a/src/deepr/experts/metered_mutation_gate.py
+++ b/src/deepr/experts/metered_mutation_gate.py
@@ -2,8 +2,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from deepr.experts.parent_budget_transaction import (
+    GATED_METERED_LIFECYCLE_SURFACES,
+    surface_requires_parent_budget,
+)
+
 METERED_EXPERT_MUTATIONS_ENABLED = False
 METERED_EXPERT_MUTATION_BLOCK_CODE = "metered_expert_mutation_accounting_unavailable"
+# Parent budget substrate exists; individual surfaces remain blocked until each
+# one wires open/admit/mark/settle with hermetic tests and a reviewed enable.
+PARENT_BUDGET_TRANSACTION_REQUIRED = True
 
 
 class MeteredExpertMutationDisabledError(RuntimeError):
@@ -16,16 +26,29 @@ class MeteredExpertMutationDisabledError(RuntimeError):
     def __init__(self, operation: str, *, safe_alternative: str) -> None:
         self.operation = operation
         self.safe_alternative = safe_alternative
-        self.details = {
+        self.details: dict[str, Any] = {
             "operation": operation,
             "safe_alternative": safe_alternative,
             "provider_work_started": False,
+            "metered_mutations_enabled": METERED_EXPERT_MUTATIONS_ENABLED,
+            "parent_budget_transaction_required": PARENT_BUDGET_TRANSACTION_REQUIRED,
+            "parent_budget_surface_known": surface_requires_parent_budget(operation),
+            "gated_lifecycle_surfaces": list(GATED_METERED_LIFECYCLE_SURFACES),
         }
         super().__init__(
             f"Metered expert operation '{operation}' is temporarily disabled because it cannot yet "
-            "prove one durable reservation and canonical settlement for every provider, tool, and "
-            f"storage charge. Use: {safe_alternative}"
+            "prove one durable parent budget transaction and canonical settlement for every "
+            f"provider, tool, and storage charge. Use: {safe_alternative}"
         )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": "blocked",
+            "code": self.code,
+            "category": self.category,
+            "retryable": self.retryable,
+            **self.details,
+        }
 
 
 def require_metered_expert_mutation(operation: str, *, safe_alternative: str) -> None:
@@ -53,6 +76,7 @@ def require_api_autonomous_learning(expert_name: str) -> None:
 __all__ = [
     "METERED_EXPERT_MUTATIONS_ENABLED",
     "METERED_EXPERT_MUTATION_BLOCK_CODE",
+    "PARENT_BUDGET_TRANSACTION_REQUIRED",
     "MeteredExpertMutationDisabledError",
     "require_api_autonomous_learning",
     "require_api_curriculum_generation",

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -142,6 +142,37 @@ def replay_parent_budget(run_id: str, path: Path | None = None) -> ParentBudgetT
     return parent
 
 
+def open_gated_lifecycle_budget(
+    *,
+    surface: str,
+    parent_ceiling_usd: float,
+    maximum_charge_envelope: Mapping[str, Any],
+    run_id: str | None = None,
+    path: Path | None = None,
+) -> DurableParentBudget:
+    """Open a durable parent budget for a gated metered lifecycle surface.
+
+    Requires a complete offline maximum-charge envelope and a known gated
+    surface name. Does not enable provider dispatch; callers must still pass
+    ``require_metered_expert_mutation`` / execution flags.
+    """
+    from deepr.experts.parent_budget_transaction import surface_requires_parent_budget
+
+    name = str(surface or "").strip()
+    if not surface_requires_parent_budget(name):
+        raise ParentBudgetError(
+            f"surface {name!r} is not in the gated metered lifecycle inventory"
+        )
+    return DurableParentBudget.open(
+        surface=name,
+        parent_ceiling_usd=parent_ceiling_usd,
+        run_id=run_id,
+        path=path,
+        maximum_charge_envelope=maximum_charge_envelope,
+        require_complete_contract=True,
+    )
+
+
 class DurableParentBudget:
     """Parent budget that journals every transition."""
 
@@ -338,6 +369,7 @@ __all__ = [
     "PARENT_BUDGET_SCHEMA_VERSION",
     "DurableParentBudget",
     "load_parent_budget_events",
+    "open_gated_lifecycle_budget",
     "parent_budget_log_path",
     "replay_parent_budget",
 ]

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -179,6 +179,11 @@ class DurableParentBudget:
             if require_complete_contract and not verdict.complete:
                 detail = "; ".join(verdict.failures) or "maximum-charge contract incomplete"
                 raise ParentBudgetError(detail)
+            envelope_ceiling = maximum_charge_envelope.get("parent_ceiling_usd")
+            if envelope_ceiling is not None and abs(float(envelope_ceiling) - float(parent_ceiling_usd)) > 1e-9:
+                raise ParentBudgetError(
+                    "maximum_charge_envelope.parent_ceiling_usd must match parent_ceiling_usd"
+                )
             if verdict.complete and verdict.computed_max_usd is not None:
                 if float(verdict.computed_max_usd) > float(parent_ceiling_usd) + 1e-9:
                     raise ParentBudgetError(

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -157,7 +157,34 @@ class DurableParentBudget:
         parent_ceiling_usd: float,
         run_id: str | None = None,
         path: Path | None = None,
+        maximum_charge_envelope: Mapping[str, Any] | None = None,
+        require_complete_contract: bool = False,
     ) -> DurableParentBudget:
+        """Open and journal a parent budget.
+
+        When ``require_complete_contract`` is true, a complete offline
+        maximum-charge envelope is mandatory. Completeness still does not
+        enable provider dispatch.
+        """
+        contract_summary: dict[str, Any] | None = None
+        if require_complete_contract or maximum_charge_envelope is not None:
+            from deepr.experts.maximum_charge_contract import evaluate_maximum_charge_contract
+
+            if maximum_charge_envelope is None:
+                raise ParentBudgetError(
+                    "maximum_charge_envelope is required when require_complete_contract is set"
+                )
+            verdict = evaluate_maximum_charge_contract(maximum_charge_envelope)
+            contract_summary = verdict.to_dict()
+            if require_complete_contract and not verdict.complete:
+                detail = "; ".join(verdict.failures) or "maximum-charge contract incomplete"
+                raise ParentBudgetError(detail)
+            if verdict.complete and verdict.computed_max_usd is not None:
+                if float(verdict.computed_max_usd) > float(parent_ceiling_usd) + 1e-9:
+                    raise ParentBudgetError(
+                        "maximum-charge computed_max_usd exceeds parent_ceiling_usd"
+                    )
+
         with _lock:
             parent = open_parent_budget_transaction(
                 surface=surface,
@@ -165,15 +192,16 @@ class DurableParentBudget:
                 run_id=run_id,
             )
             durable = cls(parent, path=path)
-            _append_event(
-                {
-                    "event_type": "opened",
-                    "run_id": parent.run_id,
-                    "surface": parent.surface,
-                    "parent_ceiling_usd": parent.parent_ceiling_usd,
-                },
-                path,
-            )
+            event: dict[str, Any] = {
+                "event_type": "opened",
+                "run_id": parent.run_id,
+                "surface": parent.surface,
+                "parent_ceiling_usd": parent.parent_ceiling_usd,
+                "require_complete_contract": require_complete_contract,
+            }
+            if contract_summary is not None:
+                event["maximum_charge_contract"] = contract_summary
+            _append_event(event, path)
             return durable
 
     def admit_child(

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -89,6 +89,51 @@ def load_parent_budget_events(path: Path | None = None) -> list[dict[str, Any]]:
     return events
 
 
+def _apply_consumed_event(parent: ParentBudgetTransaction, event: Mapping[str, Any]) -> None:
+    child_id = str(event.get("child_id") or "")
+    child = parent.children.get(child_id)
+    if child is None:
+        raise ParentBudgetError(f"missing child {child_id!r} for consume replay")
+    child.settled_usd = float(event.get("settled_usd") or child.max_usd)
+    child.state = ChildCallState.CONSUMED
+    if event.get("freeze"):
+        parent.state = ParentBudgetState.FROZEN
+        parent.freeze_reason = str(event.get("freeze_reason") or "")
+        return
+    child.metadata["consume_reason"] = str(event.get("reason") or "conservative_consume")
+
+
+def _apply_replay_event(parent: ParentBudgetTransaction, event: Mapping[str, Any]) -> None:
+    event_type = str(event.get("event_type") or "")
+    child_id = str(event.get("child_id") or "")
+    if event_type == "child_admitted":
+        parent.admit_child(
+            operation=str(event.get("operation") or ""),
+            max_usd=float(event.get("max_usd") or 0),
+            child_id=child_id,
+            metadata=dict(event.get("metadata") or {}),
+        )
+        return
+    if event_type == "dispatch_marked":
+        parent.mark_dispatch(child_id)
+        return
+    if event_type == "settled":
+        parent.settle_child(child_id, float(event.get("actual_usd") or 0))
+        return
+    if event_type == "consumed":
+        _apply_consumed_event(parent, event)
+        return
+    if event_type == "cancelled":
+        parent.cancel_child(child_id)
+        return
+    if event_type == "closed":
+        parent.state = ParentBudgetState.CLOSED
+        return
+    if event_type == "frozen":
+        parent.state = ParentBudgetState.FROZEN
+        parent.freeze_reason = str(event.get("freeze_reason") or "")
+
+
 def replay_parent_budget(run_id: str, path: Path | None = None) -> ParentBudgetTransaction | None:
     """Rebuild one parent transaction from the append-only journal."""
     target = str(run_id or "").strip()
@@ -98,8 +143,7 @@ def replay_parent_budget(run_id: str, path: Path | None = None) -> ParentBudgetT
     for event in load_parent_budget_events(path):
         if str(event.get("run_id") or "") != target:
             continue
-        event_type = str(event.get("event_type") or "")
-        if event_type == "opened":
+        if str(event.get("event_type") or "") == "opened":
             parent = open_parent_budget_transaction(
                 surface=str(event.get("surface") or ""),
                 parent_ceiling_usd=float(event.get("parent_ceiling_usd") or 0),
@@ -108,37 +152,7 @@ def replay_parent_budget(run_id: str, path: Path | None = None) -> ParentBudgetT
             continue
         if parent is None:
             raise ParentBudgetError(f"run {target!r} has events before opened")
-        child_id = str(event.get("child_id") or "")
-        if event_type == "child_admitted":
-            parent.admit_child(
-                operation=str(event.get("operation") or ""),
-                max_usd=float(event.get("max_usd") or 0),
-                child_id=child_id,
-                metadata=dict(event.get("metadata") or {}),
-            )
-        elif event_type == "dispatch_marked":
-            parent.mark_dispatch(child_id)
-        elif event_type == "settled":
-            parent.settle_child(child_id, float(event.get("actual_usd") or 0))
-        elif event_type == "consumed":
-            # Direct state restore if freeze path already applied.
-            child = parent.children.get(child_id)
-            if child is None:
-                raise ParentBudgetError(f"missing child {child_id!r} for consume replay")
-            child.settled_usd = float(event.get("settled_usd") or child.max_usd)
-            child.state = ChildCallState.CONSUMED
-            if event.get("freeze"):
-                parent.state = ParentBudgetState.FROZEN
-                parent.freeze_reason = str(event.get("freeze_reason") or "")
-            else:
-                child.metadata["consume_reason"] = str(event.get("reason") or "conservative_consume")
-        elif event_type == "cancelled":
-            parent.cancel_child(child_id)
-        elif event_type == "closed":
-            parent.state = ParentBudgetState.CLOSED
-        elif event_type == "frozen":
-            parent.state = ParentBudgetState.FROZEN
-            parent.freeze_reason = str(event.get("freeze_reason") or "")
+        _apply_replay_event(parent, event)
     return parent
 
 

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -174,9 +174,7 @@ def open_gated_lifecycle_budget(
 
     name = str(surface or "").strip()
     if not surface_requires_parent_budget(name):
-        raise ParentBudgetError(
-            f"surface {name!r} is not in the gated metered lifecycle inventory"
-        )
+        raise ParentBudgetError(f"surface {name!r} is not in the gated metered lifecycle inventory")
     return DurableParentBudget.open(
         surface=name,
         parent_ceiling_usd=parent_ceiling_usd,
@@ -216,9 +214,7 @@ class DurableParentBudget:
             from deepr.experts.maximum_charge_contract import evaluate_maximum_charge_contract
 
             if maximum_charge_envelope is None:
-                raise ParentBudgetError(
-                    "maximum_charge_envelope is required when require_complete_contract is set"
-                )
+                raise ParentBudgetError("maximum_charge_envelope is required when require_complete_contract is set")
             verdict = evaluate_maximum_charge_contract(maximum_charge_envelope)
             contract_summary = verdict.to_dict()
             if require_complete_contract and not verdict.complete:
@@ -226,14 +222,10 @@ class DurableParentBudget:
                 raise ParentBudgetError(detail)
             envelope_ceiling = maximum_charge_envelope.get("parent_ceiling_usd")
             if envelope_ceiling is not None and abs(float(envelope_ceiling) - float(parent_ceiling_usd)) > 1e-9:
-                raise ParentBudgetError(
-                    "maximum_charge_envelope.parent_ceiling_usd must match parent_ceiling_usd"
-                )
+                raise ParentBudgetError("maximum_charge_envelope.parent_ceiling_usd must match parent_ceiling_usd")
             if verdict.complete and verdict.computed_max_usd is not None:
                 if float(verdict.computed_max_usd) > float(parent_ceiling_usd) + 1e-9:
-                    raise ParentBudgetError(
-                        "maximum-charge computed_max_usd exceeds parent_ceiling_usd"
-                    )
+                    raise ParentBudgetError("maximum-charge computed_max_usd exceeds parent_ceiling_usd")
 
         with _lock:
             parent = open_parent_budget_transaction(

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -1,0 +1,310 @@
+"""Append-only durable journal for parent budget transactions.
+
+In-process ``ParentBudgetTransaction`` objects coordinate nested admissions.
+This store records the same transitions as JSONL events under the cost data
+directory so a crash mid-run leaves an auditable trail. Replay rebuilds the
+latest per-run snapshot without rewriting history.
+
+Never enables metered dispatch by itself.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from deepr.experts.parent_budget_transaction import (
+    ChildCallSlot,
+    ChildCallState,
+    ParentBudgetError,
+    ParentBudgetState,
+    ParentBudgetTransaction,
+    open_parent_budget_transaction,
+)
+from deepr.utils.atomic_io import append_jsonl_durable
+
+PARENT_BUDGET_SCHEMA_VERSION = "deepr-parent-budget-event-v1"
+PARENT_BUDGET_KIND = "deepr.costs.parent_budget_event"
+
+_EVENT_TYPES = frozenset(
+    {
+        "opened",
+        "child_admitted",
+        "dispatch_marked",
+        "settled",
+        "consumed",
+        "cancelled",
+        "closed",
+        "frozen",
+    }
+)
+
+_lock = threading.RLock()
+
+
+def parent_budget_log_path(path: Path | None = None) -> Path:
+    if path is not None:
+        return path
+    from deepr.observability.cost_authority import default_cost_data_dir
+
+    return default_cost_data_dir() / "parent_budget_transactions.jsonl"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _append_event(event: Mapping[str, Any], path: Path | None) -> dict[str, Any]:
+    payload = dict(event)
+    payload.setdefault("schema_version", PARENT_BUDGET_SCHEMA_VERSION)
+    payload.setdefault("kind", PARENT_BUDGET_KIND)
+    payload.setdefault("recorded_at", _now().isoformat())
+    event_type = str(payload.get("event_type") or "")
+    if event_type not in _EVENT_TYPES:
+        raise ParentBudgetError(f"unknown parent budget event_type {event_type!r}")
+    if not str(payload.get("run_id") or "").strip():
+        raise ParentBudgetError("run_id is required")
+    append_jsonl_durable(parent_budget_log_path(path), payload, fsync=True)
+    return payload
+
+
+def load_parent_budget_events(path: Path | None = None) -> list[dict[str, Any]]:
+    resolved = parent_budget_log_path(path)
+    if not resolved.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    with resolved.open(encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                raise ParentBudgetError("parent budget event must be a JSON object")
+            events.append(payload)
+    return events
+
+
+def replay_parent_budget(run_id: str, path: Path | None = None) -> ParentBudgetTransaction | None:
+    """Rebuild one parent transaction from the append-only journal."""
+    target = str(run_id or "").strip()
+    if not target:
+        raise ParentBudgetError("run_id is required")
+    parent: ParentBudgetTransaction | None = None
+    for event in load_parent_budget_events(path):
+        if str(event.get("run_id") or "") != target:
+            continue
+        event_type = str(event.get("event_type") or "")
+        if event_type == "opened":
+            parent = open_parent_budget_transaction(
+                surface=str(event.get("surface") or ""),
+                parent_ceiling_usd=float(event.get("parent_ceiling_usd") or 0),
+                run_id=target,
+            )
+            continue
+        if parent is None:
+            raise ParentBudgetError(f"run {target!r} has events before opened")
+        child_id = str(event.get("child_id") or "")
+        if event_type == "child_admitted":
+            parent.admit_child(
+                operation=str(event.get("operation") or ""),
+                max_usd=float(event.get("max_usd") or 0),
+                child_id=child_id,
+                metadata=dict(event.get("metadata") or {}),
+            )
+        elif event_type == "dispatch_marked":
+            parent.mark_dispatch(child_id)
+        elif event_type == "settled":
+            parent.settle_child(child_id, float(event.get("actual_usd") or 0))
+        elif event_type == "consumed":
+            # Direct state restore if freeze path already applied.
+            child = parent.children.get(child_id)
+            if child is None:
+                raise ParentBudgetError(f"missing child {child_id!r} for consume replay")
+            child.settled_usd = float(event.get("settled_usd") or child.max_usd)
+            child.state = ChildCallState.CONSUMED
+            if event.get("freeze"):
+                parent.state = ParentBudgetState.FROZEN
+                parent.freeze_reason = str(event.get("freeze_reason") or "")
+            else:
+                child.metadata["consume_reason"] = str(event.get("reason") or "conservative_consume")
+        elif event_type == "cancelled":
+            parent.cancel_child(child_id)
+        elif event_type == "closed":
+            parent.state = ParentBudgetState.CLOSED
+        elif event_type == "frozen":
+            parent.state = ParentBudgetState.FROZEN
+            parent.freeze_reason = str(event.get("freeze_reason") or "")
+    return parent
+
+
+class DurableParentBudget:
+    """Parent budget that journals every transition."""
+
+    def __init__(self, parent: ParentBudgetTransaction, *, path: Path | None = None) -> None:
+        self.parent = parent
+        self.path = path
+
+    @classmethod
+    def open(
+        cls,
+        *,
+        surface: str,
+        parent_ceiling_usd: float,
+        run_id: str | None = None,
+        path: Path | None = None,
+    ) -> DurableParentBudget:
+        with _lock:
+            parent = open_parent_budget_transaction(
+                surface=surface,
+                parent_ceiling_usd=parent_ceiling_usd,
+                run_id=run_id,
+            )
+            durable = cls(parent, path=path)
+            _append_event(
+                {
+                    "event_type": "opened",
+                    "run_id": parent.run_id,
+                    "surface": parent.surface,
+                    "parent_ceiling_usd": parent.parent_ceiling_usd,
+                },
+                path,
+            )
+            return durable
+
+    def admit_child(
+        self,
+        *,
+        operation: str,
+        max_usd: float,
+        child_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> ChildCallSlot:
+        with _lock:
+            child = self.parent.admit_child(
+                operation=operation,
+                max_usd=max_usd,
+                child_id=child_id,
+                metadata=metadata,
+            )
+            _append_event(
+                {
+                    "event_type": "child_admitted",
+                    "run_id": self.parent.run_id,
+                    "child_id": child.child_id,
+                    "operation": child.operation,
+                    "max_usd": child.max_usd,
+                    "metadata": dict(child.metadata),
+                },
+                self.path,
+            )
+            return child
+
+    def mark_dispatch(self, child_id: str) -> ChildCallSlot:
+        with _lock:
+            child = self.parent.mark_dispatch(child_id)
+            _append_event(
+                {
+                    "event_type": "dispatch_marked",
+                    "run_id": self.parent.run_id,
+                    "child_id": child.child_id,
+                },
+                self.path,
+            )
+            return child
+
+    def settle_child(self, child_id: str, actual_usd: float) -> ChildCallSlot:
+        with _lock:
+            try:
+                child = self.parent.settle_child(child_id, actual_usd)
+            except ParentBudgetError:
+                # Freeze path already mutated child; journal consume + freeze.
+                child = self.parent.children[child_id]
+                _append_event(
+                    {
+                        "event_type": "consumed",
+                        "run_id": self.parent.run_id,
+                        "child_id": child_id,
+                        "settled_usd": child.settled_usd,
+                        "freeze": True,
+                        "freeze_reason": self.parent.freeze_reason,
+                    },
+                    self.path,
+                )
+                _append_event(
+                    {
+                        "event_type": "frozen",
+                        "run_id": self.parent.run_id,
+                        "freeze_reason": self.parent.freeze_reason,
+                    },
+                    self.path,
+                )
+                raise
+            _append_event(
+                {
+                    "event_type": "settled",
+                    "run_id": self.parent.run_id,
+                    "child_id": child.child_id,
+                    "actual_usd": child.settled_usd,
+                },
+                self.path,
+            )
+            return child
+
+    def consume_child_ceiling(self, child_id: str, *, reason: str) -> ChildCallSlot:
+        with _lock:
+            child = self.parent.consume_child_ceiling(child_id, reason=reason)
+            _append_event(
+                {
+                    "event_type": "consumed",
+                    "run_id": self.parent.run_id,
+                    "child_id": child.child_id,
+                    "settled_usd": child.settled_usd,
+                    "reason": reason,
+                    "freeze": False,
+                },
+                self.path,
+            )
+            return child
+
+    def cancel_child(self, child_id: str) -> ChildCallSlot:
+        with _lock:
+            child = self.parent.cancel_child(child_id)
+            _append_event(
+                {
+                    "event_type": "cancelled",
+                    "run_id": self.parent.run_id,
+                    "child_id": child.child_id,
+                },
+                self.path,
+            )
+            return child
+
+    def close(self) -> None:
+        with _lock:
+            self.parent.close()
+            _append_event(
+                {
+                    "event_type": "closed",
+                    "run_id": self.parent.run_id,
+                    "settled_usd": self.parent.settled_usd(),
+                },
+                self.path,
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.parent.to_dict()
+
+
+__all__ = [
+    "PARENT_BUDGET_KIND",
+    "PARENT_BUDGET_SCHEMA_VERSION",
+    "DurableParentBudget",
+    "load_parent_budget_events",
+    "parent_budget_log_path",
+    "replay_parent_budget",
+]

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -292,27 +292,32 @@ class DurableParentBudget:
             try:
                 child = self.parent.settle_child(child_id, actual_usd)
             except ParentBudgetError:
-                # Freeze path already mutated child; journal consume + freeze.
-                child = self.parent.children[child_id]
-                _append_event(
-                    {
-                        "event_type": "consumed",
-                        "run_id": self.parent.run_id,
-                        "child_id": child_id,
-                        "settled_usd": child.settled_usd,
-                        "freeze": True,
-                        "freeze_reason": self.parent.freeze_reason,
-                    },
-                    self.path,
-                )
-                _append_event(
-                    {
-                        "event_type": "frozen",
-                        "run_id": self.parent.run_id,
-                        "freeze_reason": self.parent.freeze_reason,
-                    },
-                    self.path,
-                )
+                # Only the overrun path freezes and mutates the child first.
+                child = self.parent.children.get(child_id)
+                if (
+                    child is not None
+                    and self.parent.state is ParentBudgetState.FROZEN
+                    and child.state is ChildCallState.CONSUMED
+                ):
+                    _append_event(
+                        {
+                            "event_type": "consumed",
+                            "run_id": self.parent.run_id,
+                            "child_id": child_id,
+                            "settled_usd": child.settled_usd,
+                            "freeze": True,
+                            "freeze_reason": self.parent.freeze_reason,
+                        },
+                        self.path,
+                    )
+                    _append_event(
+                        {
+                            "event_type": "frozen",
+                            "run_id": self.parent.run_id,
+                            "freeze_reason": self.parent.freeze_reason,
+                        },
+                        self.path,
+                    )
                 raise
             _append_event(
                 {

--- a/src/deepr/experts/parent_budget_transaction.py
+++ b/src/deepr/experts/parent_budget_transaction.py
@@ -261,11 +261,30 @@ def _non_negative_money(value: object, *, field_name: str) -> float:
 
 
 # Lifecycle surfaces that must adopt this parent transaction before metered
-# execution can be considered. Inventory only - not an enable list.
+# execution can be considered. Inventory only - not an enable list. Names match
+# ``require_metered_expert_mutation`` operation strings used in production call
+# sites so gate payloads and open_gated_lifecycle_budget share one vocabulary.
 GATED_METERED_LIFECYCLE_SURFACES: tuple[str, ...] = (
+    "api_curriculum_generation",
+    "api_autonomous_learning",
+    "api_expert_chat_council",
+    "api_expert_chat_plan",
+    "api_expert_portrait",
+    "api_provider_benchmark",
+    "api_consult_quality_judge",
+    "api_expert_sync",
+    "api_sync_compile_claims",
+    "api_expert_sync_all",
+    "api_eval_calibrate_corpus",
+    "api_knowledge_synthesis",
+    "api_knowledge_synthesis_extraction",
+    "api_expert_task_planner",
+    "composed_docs_analysis",
+    "multi_agent_team_research",
+    "hosted_expert_vector_upload",
+    # Planned ROADMAP names retained for design docs until call sites rename.
     "expert_make_nonlocal",
     "expert_make_learn",
-    "expert_plan_api_curriculum",
     "expert_refresh",
     "expert_refresh_synthesize",
     "expert_resume",
@@ -274,12 +293,7 @@ GATED_METERED_LIFECYCLE_SURFACES: tuple[str, ...] = (
     "fill_gaps",
     "fill_gaps_consensus",
     "fill_gaps_deep",
-    "expert_sync_api",
-    "expert_sync_all_api",
     "paid_portraits",
-    "consult_quality_judge_api",
-    "live_provider_benchmarks",
-    "eval_calibrate_corpus",
 )
 
 

--- a/src/deepr/experts/parent_budget_transaction.py
+++ b/src/deepr/experts/parent_budget_transaction.py
@@ -1,0 +1,299 @@
+"""Shared parent budget transaction for multi-call metered expert runs.
+
+ROADMAP requires every gated metered lifecycle surface to share one durable
+per-call and run-budget transaction. This module is the pure coordination
+layer:
+
+- One parent ceiling binds every nested child maximum.
+- Child admissions cannot oversubscribe remaining parent headroom.
+- Dispatch marks and settlements are one-use per child.
+- The module never contacts a provider and never flips execution flags.
+
+Adoption by individual surfaces remains fail-closed until each surface wires
+this transaction through reserve / mark / settle with hermetic tests.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+from uuid import uuid4
+
+from deepr.experts.maximum_charge_contract import ABSOLUTE_DEEPR_CEILING_USD
+
+
+class ParentBudgetError(ValueError):
+    """Raised when a parent or child budget transition is invalid."""
+
+
+class ParentBudgetState(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"
+    FROZEN = "frozen"
+
+
+class ChildCallState(StrEnum):
+    ADMITTED = "admitted"
+    DISPATCH_MARKED = "dispatch_marked"
+    SETTLED = "settled"
+    CONSUMED = "consumed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class ChildCallSlot:
+    """One nested call under a parent run ceiling."""
+
+    child_id: str
+    operation: str
+    max_usd: float
+    state: ChildCallState = ChildCallState.ADMITTED
+    settled_usd: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "child_id": self.child_id,
+            "operation": self.operation,
+            "max_usd": self.max_usd,
+            "state": self.state.value,
+            "settled_usd": self.settled_usd,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
+class ParentBudgetTransaction:
+    """In-process parent budget authority for a multi-call metered run."""
+
+    run_id: str
+    parent_ceiling_usd: float
+    surface: str
+    state: ParentBudgetState = ParentBudgetState.OPEN
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    children: dict[str, ChildCallSlot] = field(default_factory=dict)
+    freeze_reason: str = ""
+    _lock: threading.RLock = field(default_factory=threading.RLock, repr=False, compare=False)
+
+    def remaining_usd(self) -> float:
+        """Return parent headroom not yet admitted or settled conservatively."""
+        reserved = 0.0
+        for child in self.children.values():
+            if child.state in {ChildCallState.CANCELLED}:
+                continue
+            if child.state in {ChildCallState.SETTLED, ChildCallState.CONSUMED}:
+                reserved += float(child.settled_usd)
+            else:
+                reserved += float(child.max_usd)
+        return max(0.0, float(self.parent_ceiling_usd) - reserved)
+
+    def admitted_max_usd(self) -> float:
+        return sum(float(child.max_usd) for child in self.children.values() if child.state != ChildCallState.CANCELLED)
+
+    def settled_usd(self) -> float:
+        return sum(
+            float(child.settled_usd)
+            for child in self.children.values()
+            if child.state in {ChildCallState.SETTLED, ChildCallState.CONSUMED}
+        )
+
+    def admit_child(
+        self,
+        *,
+        operation: str,
+        max_usd: float,
+        child_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> ChildCallSlot:
+        """Admit one child under remaining parent headroom."""
+        with self._lock:
+            self._require_open()
+            ceiling = _positive_money(max_usd, field_name="max_usd")
+            if ceiling > self.remaining_usd() + 1e-12:
+                raise ParentBudgetError(
+                    f"child max_usd ${ceiling:.6f} exceeds remaining parent headroom ${self.remaining_usd():.6f}"
+                )
+            slot = ChildCallSlot(
+                child_id=child_id or f"child-{uuid4().hex}",
+                operation=str(operation or "").strip() or "unnamed",
+                max_usd=ceiling,
+                metadata=dict(metadata or {}),
+            )
+            if slot.child_id in self.children:
+                raise ParentBudgetError(f"child_id {slot.child_id!r} already admitted")
+            self.children[slot.child_id] = slot
+            return slot
+
+    def mark_dispatch(self, child_id: str) -> ChildCallSlot:
+        """Mark durable dispatch intent for one admitted child (still local)."""
+        with self._lock:
+            self._require_open()
+            child = self._child(child_id)
+            if child.state != ChildCallState.ADMITTED:
+                raise ParentBudgetError(f"child {child_id!r} cannot mark dispatch from state {child.state.value}")
+            child.state = ChildCallState.DISPATCH_MARKED
+            return child
+
+    def settle_child(self, child_id: str, actual_usd: float) -> ChildCallSlot:
+        """Settle exact usage that does not exceed the child maximum."""
+        with self._lock:
+            self._require_open()
+            child = self._child(child_id)
+            if child.state not in {ChildCallState.ADMITTED, ChildCallState.DISPATCH_MARKED}:
+                raise ParentBudgetError(f"child {child_id!r} cannot settle from state {child.state.value}")
+            actual = _non_negative_money(actual_usd, field_name="actual_usd")
+            if actual > child.max_usd + 1e-12:
+                self.state = ParentBudgetState.FROZEN
+                self.freeze_reason = f"child {child_id!r} actual ${actual:.6f} exceeded max ${child.max_usd:.6f}"
+                child.settled_usd = child.max_usd
+                child.state = ChildCallState.CONSUMED
+                raise ParentBudgetError(self.freeze_reason)
+            child.settled_usd = actual
+            child.state = ChildCallState.SETTLED
+            return child
+
+    def consume_child_ceiling(self, child_id: str, *, reason: str) -> ChildCallSlot:
+        """Conservatively consume the full child maximum (ambiguous usage)."""
+        with self._lock:
+            self._require_open()
+            child = self._child(child_id)
+            if child.state in {ChildCallState.SETTLED, ChildCallState.CONSUMED, ChildCallState.CANCELLED}:
+                raise ParentBudgetError(f"child {child_id!r} cannot consume from state {child.state.value}")
+            child.settled_usd = child.max_usd
+            child.state = ChildCallState.CONSUMED
+            child.metadata["consume_reason"] = str(reason or "conservative_consume")
+            return child
+
+    def cancel_child(self, child_id: str) -> ChildCallSlot:
+        """Cancel an admitted child that never dispatched."""
+        with self._lock:
+            self._require_open()
+            child = self._child(child_id)
+            if child.state != ChildCallState.ADMITTED:
+                raise ParentBudgetError(f"child {child_id!r} cannot cancel from state {child.state.value}")
+            child.state = ChildCallState.CANCELLED
+            child.settled_usd = 0.0
+            return child
+
+    def close(self) -> None:
+        """Close the parent after all children are terminal."""
+        with self._lock:
+            if self.state == ParentBudgetState.FROZEN:
+                raise ParentBudgetError("frozen parent cannot close cleanly; reconcile first")
+            open_children = [
+                child.child_id
+                for child in self.children.values()
+                if child.state in {ChildCallState.ADMITTED, ChildCallState.DISPATCH_MARKED}
+            ]
+            if open_children:
+                raise ParentBudgetError(f"cannot close parent while children remain open: {', '.join(open_children)}")
+            self.state = ParentBudgetState.CLOSED
+
+    def to_dict(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "run_id": self.run_id,
+                "surface": self.surface,
+                "state": self.state.value,
+                "parent_ceiling_usd": self.parent_ceiling_usd,
+                "remaining_usd": self.remaining_usd(),
+                "admitted_max_usd": self.admitted_max_usd(),
+                "settled_usd": self.settled_usd(),
+                "freeze_reason": self.freeze_reason,
+                "created_at": self.created_at.isoformat(),
+                "children": [child.to_dict() for child in self.children.values()],
+            }
+
+    def _child(self, child_id: str) -> ChildCallSlot:
+        try:
+            return self.children[child_id]
+        except KeyError as exc:
+            raise ParentBudgetError(f"unknown child_id {child_id!r}") from exc
+
+    def _require_open(self) -> None:
+        if self.state == ParentBudgetState.FROZEN:
+            raise ParentBudgetError(f"parent budget is frozen: {self.freeze_reason or 'unknown'}")
+        if self.state != ParentBudgetState.OPEN:
+            raise ParentBudgetError(f"parent budget is {self.state.value}")
+
+
+def open_parent_budget_transaction(
+    *,
+    surface: str,
+    parent_ceiling_usd: float,
+    run_id: str | None = None,
+) -> ParentBudgetTransaction:
+    """Open one parent transaction under the absolute Deepr ceiling."""
+    ceiling = _positive_money(parent_ceiling_usd, field_name="parent_ceiling_usd")
+    if ceiling > ABSOLUTE_DEEPR_CEILING_USD + 1e-12:
+        raise ParentBudgetError(
+            f"parent_ceiling_usd ${ceiling:.4f} exceeds absolute Deepr ceiling ${ABSOLUTE_DEEPR_CEILING_USD:.2f}"
+        )
+    name = str(surface or "").strip()
+    if not name:
+        raise ParentBudgetError("surface must be a non-empty string")
+    return ParentBudgetTransaction(
+        run_id=run_id or f"run-{uuid4().hex}",
+        parent_ceiling_usd=ceiling,
+        surface=name,
+    )
+
+
+def _positive_money(value: object, *, field_name: str) -> float:
+    amount = _non_negative_money(value, field_name=field_name)
+    if amount <= 0:
+        raise ParentBudgetError(f"{field_name} must be positive")
+    return amount
+
+
+def _non_negative_money(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ParentBudgetError(f"{field_name} must be a finite non-negative number")
+    amount = float(value)
+    if not math.isfinite(amount) or amount < 0:
+        raise ParentBudgetError(f"{field_name} must be a finite non-negative number")
+    return amount
+
+
+# Lifecycle surfaces that must adopt this parent transaction before metered
+# execution can be considered. Inventory only - not an enable list.
+GATED_METERED_LIFECYCLE_SURFACES: tuple[str, ...] = (
+    "expert_make_nonlocal",
+    "expert_make_learn",
+    "expert_plan_api_curriculum",
+    "expert_refresh",
+    "expert_refresh_synthesize",
+    "expert_resume",
+    "expert_reflect",
+    "mcp_deepr_reflect",
+    "fill_gaps",
+    "fill_gaps_consensus",
+    "fill_gaps_deep",
+    "expert_sync_api",
+    "expert_sync_all_api",
+    "paid_portraits",
+    "consult_quality_judge_api",
+    "live_provider_benchmarks",
+    "eval_calibrate_corpus",
+)
+
+
+def surface_requires_parent_budget(surface: str) -> bool:
+    return str(surface or "").strip() in GATED_METERED_LIFECYCLE_SURFACES
+
+
+__all__ = [
+    "GATED_METERED_LIFECYCLE_SURFACES",
+    "ChildCallSlot",
+    "ChildCallState",
+    "ParentBudgetError",
+    "ParentBudgetState",
+    "ParentBudgetTransaction",
+    "open_parent_budget_transaction",
+    "surface_requires_parent_budget",
+]

--- a/src/deepr/experts/parent_budget_transaction.py
+++ b/src/deepr/experts/parent_budget_transaction.py
@@ -183,6 +183,8 @@ class ParentBudgetTransaction:
     def close(self) -> None:
         """Close the parent after all children are terminal."""
         with self._lock:
+            if self.state == ParentBudgetState.CLOSED:
+                raise ParentBudgetError("parent budget is already closed")
             if self.state == ParentBudgetState.FROZEN:
                 raise ParentBudgetError("frozen parent cannot close cleanly; reconcile first")
             open_children = [

--- a/src/deepr/observability/spend_dispositions.py
+++ b/src/deepr/observability/spend_dispositions.py
@@ -1,0 +1,419 @@
+"""Append-only dispositions for settled spend without surviving report artifacts.
+
+The cost ledger is immutable. When paid events cannot be joined to a report
+directory, operators record a durable disposition so ``costs doctor`` can
+distinguish expected non-report work (and other closed cases) from still-
+unexplained orphans.
+
+Disposition kinds match ROADMAP P0:
+
+- ``failed_or_cancelled`` - work settled conservatively after failure/cancel
+- ``expected_non_report`` - intentional non-report surfaces (chat, portraits, ...)
+- ``lost_artifact`` - settlement with job identity but missing report artifact
+- ``unresolved_provider_evidence`` - needs external receipt before close-out
+
+Only the absence of a disposition keeps spend in the unexplained bucket.
+``unresolved_provider_evidence`` is a recorded disposition (not unexplained)
+so forensic inventory can be complete while still flagging weak evidence for
+review in reports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from deepr.utils.atomic_io import append_jsonl_durable
+
+DISPOSITION_SCHEMA_VERSION = "deepr-spend-disposition-v1"
+DISPOSITION_KIND = "deepr.costs.spend_disposition"
+
+DISPOSITION_FAILED_OR_CANCELLED = "failed_or_cancelled"
+DISPOSITION_EXPECTED_NON_REPORT = "expected_non_report"
+DISPOSITION_LOST_ARTIFACT = "lost_artifact"
+DISPOSITION_UNRESOLVED_PROVIDER = "unresolved_provider_evidence"
+
+DISPOSITION_KINDS = frozenset(
+    {
+        DISPOSITION_FAILED_OR_CANCELLED,
+        DISPOSITION_EXPECTED_NON_REPORT,
+        DISPOSITION_LOST_ARTIFACT,
+        DISPOSITION_UNRESOLVED_PROVIDER,
+    }
+)
+
+# Operations that never emit research report directories by design.
+_EXPECTED_NON_REPORT_OPERATIONS = frozenset(
+    {
+        "portrait_generation",
+        "expert_chat",
+        "standard_research_fallback",
+        "council_synthesis_backfill",
+    }
+)
+
+
+def spend_disposition_log_path(path: Path | None = None) -> Path:
+    """Return the append-only disposition log path (cost data dir by default)."""
+    if path is not None:
+        return path
+    from deepr.observability.cost_authority import default_cost_data_dir
+
+    return default_cost_data_dir() / "spend_dispositions.jsonl"
+
+
+def event_identity_key(
+    *,
+    timestamp: str,
+    operation: str,
+    provider: str,
+    model: str,
+    cost_usd: float,
+    task_id: str,
+    request_id: str = "",
+    source: str = "",
+    idempotency_key: str = "",
+) -> str:
+    """Stable identity for one ledger event without mutating the ledger.
+
+    Prefer a non-empty ledger ``idempotency_key``. Otherwise hash a canonical
+    field set so re-imports of the same event map to the same disposition.
+    """
+    key = str(idempotency_key or "").strip()
+    if key:
+        return f"idem:{key}"
+    payload = "|".join(
+        [
+            str(timestamp or ""),
+            str(operation or ""),
+            str(provider or ""),
+            str(model or ""),
+            f"{float(cost_usd):.6f}",
+            str(task_id or ""),
+            str(request_id or ""),
+            str(source or ""),
+        ]
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"hash:{digest}"
+
+
+def event_identity_key_from_ledger_event(event: Any) -> str:
+    """Build an identity key from a ``CostLedgerEvent`` or mapping-like object."""
+    if isinstance(event, Mapping):
+        timestamp = str(event.get("timestamp") or "")
+        cost = float(event.get("cost_usd") or 0.0)
+        return event_identity_key(
+            timestamp=timestamp[:32],
+            operation=str(event.get("operation") or ""),
+            provider=str(event.get("provider") or ""),
+            model=str(event.get("model") or ""),
+            cost_usd=cost,
+            task_id=str(event.get("task_id") or ""),
+            request_id=str(event.get("request_id") or ""),
+            source=str(event.get("source") or ""),
+            idempotency_key=str(event.get("idempotency_key") or ""),
+        )
+    stamp = getattr(event, "timestamp", "")
+    if hasattr(stamp, "isoformat"):
+        timestamp = stamp.isoformat()
+    else:
+        timestamp = str(stamp or "")
+    return event_identity_key(
+        timestamp=timestamp,
+        operation=str(getattr(event, "operation", "") or ""),
+        provider=str(getattr(event, "provider", "") or ""),
+        model=str(getattr(event, "model", "") or ""),
+        cost_usd=float(getattr(event, "cost_usd", 0.0) or 0.0),
+        task_id=str(getattr(event, "task_id", "") or ""),
+        request_id=str(getattr(event, "request_id", "") or ""),
+        source=str(getattr(event, "source", "") or ""),
+        idempotency_key=str(getattr(event, "idempotency_key", "") or ""),
+    )
+
+
+@dataclass(frozen=True)
+class SpendDispositionRecord:
+    """One durable disposition for a settled ledger event."""
+
+    event_key: str
+    disposition: str
+    cost_usd: float
+    task_id: str
+    operation: str
+    provider: str
+    model: str
+    event_timestamp: str
+    rationale: str
+    request_id: str = ""
+    job_id: str = ""
+    provider_receipt_id: str = ""
+    evidence: dict[str, Any] | None = None
+    recorded_at: datetime | None = None
+    recorded_by: str = "operator"
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.disposition not in DISPOSITION_KINDS:
+            raise ValueError(f"unknown disposition kind: {self.disposition!r}")
+        recorded = self.recorded_at or datetime.now(UTC)
+        return {
+            "schema_version": DISPOSITION_SCHEMA_VERSION,
+            "kind": DISPOSITION_KIND,
+            "event_key": self.event_key,
+            "disposition": self.disposition,
+            "cost_usd": round(float(self.cost_usd), 6),
+            "task_id": str(self.task_id or ""),
+            "operation": str(self.operation or ""),
+            "provider": str(self.provider or ""),
+            "model": str(self.model or ""),
+            "event_timestamp": str(self.event_timestamp or "")[:32],
+            "request_id": str(self.request_id or ""),
+            "job_id": str(self.job_id or ""),
+            "provider_receipt_id": str(self.provider_receipt_id or ""),
+            "rationale": str(self.rationale or ""),
+            "evidence": dict(self.evidence or {}),
+            "recorded_at": recorded.isoformat(),
+            "recorded_by": str(self.recorded_by or "operator"),
+        }
+
+
+def record_spend_disposition(
+    *,
+    event_key: str,
+    disposition: str,
+    cost_usd: float,
+    task_id: str,
+    operation: str,
+    provider: str,
+    model: str,
+    event_timestamp: str,
+    rationale: str,
+    request_id: str = "",
+    job_id: str = "",
+    provider_receipt_id: str = "",
+    evidence: dict[str, Any] | None = None,
+    recorded_by: str = "operator",
+    path: Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Append one disposition and return the stored record."""
+    if disposition not in DISPOSITION_KINDS:
+        raise ValueError(f"unknown disposition kind: {disposition!r}")
+    if not str(event_key or "").strip():
+        raise ValueError("event_key is required")
+    if not str(rationale or "").strip():
+        raise ValueError("rationale is required")
+    record = SpendDispositionRecord(
+        event_key=str(event_key).strip(),
+        disposition=disposition,
+        cost_usd=float(cost_usd),
+        task_id=task_id,
+        operation=operation,
+        provider=provider,
+        model=model,
+        event_timestamp=event_timestamp,
+        rationale=rationale.strip(),
+        request_id=request_id,
+        job_id=job_id,
+        provider_receipt_id=provider_receipt_id,
+        evidence=evidence,
+        recorded_at=now or datetime.now(UTC),
+        recorded_by=recorded_by,
+    ).to_dict()
+    append_jsonl_durable(spend_disposition_log_path(path), record, fsync=True)
+    return record
+
+
+def load_spend_dispositions(path: Path | None = None) -> list[dict[str, Any]]:
+    """Load all disposition records in append order."""
+    resolved = spend_disposition_log_path(path)
+    if not resolved.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    with resolved.open(encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                raise ValueError("spend disposition line must be a JSON object")
+            records.append(payload)
+    return records
+
+
+def latest_dispositions_by_event_key(path: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Return the latest disposition per event key (append-order last wins)."""
+    latest: dict[str, dict[str, Any]] = {}
+    for record in load_spend_dispositions(path):
+        key = str(record.get("event_key") or "").strip()
+        if not key:
+            continue
+        kind = str(record.get("disposition") or "")
+        if kind not in DISPOSITION_KINDS:
+            continue
+        latest[key] = record
+    return latest
+
+
+def classify_paid_events(
+    events: Iterable[Any],
+    dir_names: list[str],
+    cutoff: datetime,
+    dispositions_by_key: Mapping[str, Mapping[str, Any]] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split paid events into matched, disposed, and unexplained buckets.
+
+    Matched: report directory fragment join succeeds.
+    Disposed: no report match, but a durable disposition exists.
+    Unexplained: no report match and no disposition (doctor fails on this sum).
+    """
+    from datetime import datetime as dt
+
+    dispositions = dispositions_by_key or {}
+    matched: list[dict[str, Any]] = []
+    disposed: list[dict[str, Any]] = []
+    unexplained: list[dict[str, Any]] = []
+
+    for event in events:
+        cost = float(getattr(event, "cost_usd", 0.0) or 0.0)
+        if cost <= 0:
+            continue
+        stamp = getattr(event, "timestamp", None)
+        if isinstance(stamp, str):
+            try:
+                stamp = dt.fromisoformat(stamp)
+            except ValueError:
+                stamp = None
+        if stamp is not None and getattr(stamp, "tzinfo", None) is None:
+            stamp = stamp.replace(tzinfo=UTC)
+        if stamp is not None and stamp < cutoff:
+            continue
+
+        task = str(getattr(event, "task_id", "") or "")
+        fragment = task.split("research-", 1)[1][:8] if "research-" in task else ""
+        request_id = str(getattr(event, "request_id", "") or "")
+        operation = str(getattr(event, "operation", "") or "")
+        provider = str(getattr(event, "provider", "") or "")
+        model = str(getattr(event, "model", "") or "")
+        source = str(getattr(event, "source", "") or "")
+        event_key = event_identity_key_from_ledger_event(event)
+        entry: dict[str, Any] = {
+            "timestamp": str(getattr(event, "timestamp", ""))[:19],
+            "provider": provider,
+            "model": model,
+            "cost_usd": round(cost, 4),
+            "task_id": task,
+            "operation": operation,
+            "request_id": request_id,
+            "source": source,
+            "event_key": event_key,
+        }
+        if fragment and any(fragment in name for name in dir_names):
+            entry["status"] = "matched"
+            matched.append(entry)
+            continue
+
+        disposition = dispositions.get(event_key)
+        if disposition is not None:
+            entry["status"] = "disposed"
+            entry["disposition"] = str(disposition.get("disposition") or "")
+            entry["rationale"] = str(disposition.get("rationale") or "")
+            entry["job_id"] = str(disposition.get("job_id") or "")
+            entry["provider_receipt_id"] = str(disposition.get("provider_receipt_id") or "")
+            disposed.append(entry)
+            continue
+
+        entry["status"] = "unexplained"
+        unexplained.append(entry)
+
+    return matched, disposed, unexplained
+
+
+def suggest_disposition_for_orphan(entry: Mapping[str, Any]) -> tuple[str, str, dict[str, Any]]:
+    """Return a deterministic (kind, rationale, evidence) for a doctor orphan entry.
+
+    Used by forensic apply helpers and tests. Never contacts a provider.
+    """
+    operation = str(entry.get("operation") or "")
+    task_id = str(entry.get("task_id") or "")
+    source = str(entry.get("source") or "")
+    evidence: dict[str, Any] = {
+        "operation": operation,
+        "task_id": task_id,
+        "source": source,
+    }
+
+    if operation in _EXPECTED_NON_REPORT_OPERATIONS or task_id.startswith("portrait_"):
+        return (
+            DISPOSITION_EXPECTED_NON_REPORT,
+            (
+                f"Operation {operation or 'unknown'} is a non-report surface; "
+                "settled cost is not expected to map to a research report directory."
+            ),
+            evidence,
+        )
+
+    if task_id.startswith("chat_") or source in {"experts.chat", "web.browser_chat.failure"}:
+        return (
+            DISPOSITION_EXPECTED_NON_REPORT,
+            "Expert chat / chat-path settlement does not emit a research report directory.",
+            evidence,
+        )
+
+    if operation in {"research_job", "research_completion"}:
+        job_id = task_id
+        evidence["job_id"] = job_id
+        evidence["queue_row"] = "absent_or_unjoined"
+        return (
+            DISPOSITION_LOST_ARTIFACT,
+            (
+                "Research settlement has a job identity but no surviving report directory "
+                "and no joinable queue row; classified as lost artifact, not rewritten."
+            ),
+            evidence,
+        )
+
+    return (
+        DISPOSITION_UNRESOLVED_PROVIDER,
+        "No deterministic local rule matched; requires provider receipt or manual review.",
+        evidence,
+    )
+
+
+def apply_suggested_dispositions(
+    unexplained: Iterable[Mapping[str, Any]],
+    *,
+    path: Path | None = None,
+    recorded_by: str = "forensic-auto",
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Record suggested dispositions for each unexplained entry; return records."""
+    written: list[dict[str, Any]] = []
+    for entry in unexplained:
+        kind, rationale, evidence = suggest_disposition_for_orphan(entry)
+        job_id = str(evidence.get("job_id") or entry.get("task_id") or "")
+        record = record_spend_disposition(
+            event_key=str(entry.get("event_key") or ""),
+            disposition=kind,
+            cost_usd=float(entry.get("cost_usd") or 0.0),
+            task_id=str(entry.get("task_id") or ""),
+            operation=str(entry.get("operation") or ""),
+            provider=str(entry.get("provider") or ""),
+            model=str(entry.get("model") or ""),
+            event_timestamp=str(entry.get("timestamp") or ""),
+            rationale=rationale,
+            request_id=str(entry.get("request_id") or ""),
+            job_id=job_id if kind == DISPOSITION_LOST_ARTIFACT else "",
+            evidence=evidence,
+            recorded_by=recorded_by,
+            path=path,
+            now=now,
+        )
+        written.append(record)
+    return written

--- a/src/deepr/observability/spend_dispositions.py
+++ b/src/deepr/observability/spend_dispositions.py
@@ -109,7 +109,7 @@ def event_identity_key_from_ledger_event(event: Any) -> str:
         timestamp = str(event.get("timestamp") or "")
         cost = float(event.get("cost_usd") or 0.0)
         return event_identity_key(
-            timestamp=timestamp[:32],
+            timestamp=timestamp,
             operation=str(event.get("operation") or ""),
             provider=str(event.get("provider") or ""),
             model=str(event.get("model") or ""),
@@ -307,7 +307,7 @@ def classify_paid_events(
             "timestamp": str(getattr(event, "timestamp", ""))[:19],
             "provider": provider,
             "model": model,
-            "cost_usd": round(cost, 4),
+            "cost_usd": round(cost, 6),
             "task_id": task,
             "operation": operation,
             "request_id": request_id,

--- a/src/deepr/web/spend_truth.py
+++ b/src/deepr/web/spend_truth.py
@@ -173,23 +173,32 @@ def cost_exposure_snapshot(*, now: datetime | None = None) -> dict[str, Any]:
 
 
 def audit_spend_integrity(days: int, reports_root: Path) -> dict:
-    """Classify paid ledger events in the window as artifact-matched or orphaned.
+    """Classify paid ledger events as matched, disposed, or unexplained.
 
-    Same classifier as `deepr costs doctor`: settled spend either maps to a
-    report directory on disk (by job-id fragment) or is money with nothing to
-    show for it.
+    Same classifier as `deepr costs doctor`. ``orphaned_spend`` is the still-
+    unexplained residual (no report artifact and no durable disposition).
     """
     from deepr.cli.commands.costs import _doctor_classify
     from deepr.observability.cost_ledger import CostLedger
+    from deepr.observability.spend_dispositions import latest_dispositions_by_event_key
 
     cutoff = datetime.now(UTC) - timedelta(days=days)
     dir_names = [d.name for d in reports_root.iterdir() if d.is_dir()] if reports_root.exists() else []
     events = CostLedger().with_locked_accounting_events(list)
-    matched, orphaned = _doctor_classify(events, dir_names, cutoff)
+    matched, disposed, unexplained = _doctor_classify(
+        events,
+        dir_names,
+        cutoff,
+        dispositions_by_key=latest_dispositions_by_event_key(),
+    )
     return {
         "days": days,
         "matched_spend": round(sum(e["cost_usd"] for e in matched), 2),
-        "orphaned_spend": round(sum(e["cost_usd"] for e in orphaned), 2),
+        "disposed_spend": round(sum(e["cost_usd"] for e in disposed), 2),
+        "orphaned_spend": round(sum(e["cost_usd"] for e in unexplained), 2),
+        "unexplained_spend": round(sum(e["cost_usd"] for e in unexplained), 2),
         "matched_events": len(matched),
-        "orphaned_events": len(orphaned),
+        "disposed_events": len(disposed),
+        "orphaned_events": len(unexplained),
+        "unexplained_events": len(unexplained),
     }

--- a/tests/unit/test_cli/test_costs_doctor.py
+++ b/tests/unit/test_cli/test_costs_doctor.py
@@ -2,8 +2,8 @@
 
 The command exists because a 30-job research campaign once billed $37.79 with
 zero surviving report artifacts, and nothing surfaced the loss for 24 days.
-Every settled dollar must map to an artifact on disk or be flagged as orphaned,
-with a nonzero exit so schedulers can alarm.
+Every settled dollar must map to an artifact, a durable disposition, or remain
+unexplained with a nonzero exit so schedulers can alarm.
 """
 
 import json
@@ -16,16 +16,22 @@ from deepr.cli.commands.costs import costs
 from deepr.observability.cost_ledger import CostLedger
 
 
-def _seed(tmp_path: Path, events: list[tuple[str, float, str, str]]) -> Path:
+def _seed(
+    tmp_path: Path,
+    events: list[tuple[str, float, str, str]],
+    *,
+    operation: str = "research_completion",
+) -> Path:
     ledger_path = tmp_path / "cost_ledger.jsonl"
     ledger = CostLedger(ledger_path=ledger_path)
-    for task_id, cost, provider, model in events:
+    for index, (task_id, cost, provider, model) in enumerate(events):
         ledger.record_event(
-            operation="research_completion",
+            operation=operation,
             provider=provider,
             cost_usd=cost,
             model=model,
             task_id=task_id,
+            idempotency_key=f"seed-{index}-{task_id}",
         )
     return ledger_path
 
@@ -44,6 +50,8 @@ def test_doctor_matches_spend_with_artifacts(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert payload["matched_spend_usd"] == 0.03
     assert payload["orphaned_spend_usd"] == 0.0
+    assert payload["unexplained_spend_usd"] == 0.0
+    assert payload["disposed_spend_usd"] == 0.0
 
 
 def test_doctor_flags_orphaned_spend_and_exits_nonzero(tmp_path: Path) -> None:
@@ -64,10 +72,48 @@ def test_doctor_flags_orphaned_spend_and_exits_nonzero(tmp_path: Path) -> None:
 
     payload = json.loads(result.output)
     # A job id with no matching report dir AND an event with no linkage key at
-    # all are both orphaned: unlinkable spend is the disease being surfaced.
+    # all are both unexplained until a durable disposition is recorded.
     assert payload["orphaned_spend_usd"] == 3.95
+    assert payload["unexplained_spend_usd"] == 3.95
     assert payload["matched_spend_usd"] == 0.0
+    assert payload["disposed_spend_usd"] == 0.0
     assert result.exit_code == 1
+
+
+def test_doctor_treats_disposed_spend_as_explained(tmp_path: Path) -> None:
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    ledger_path = _seed(
+        tmp_path,
+        [("portrait_Demo Expert", 0.04, "auto", "")],
+        operation="portrait_generation",
+    )
+    dry = CliRunner().invoke(
+        costs,
+        [
+            "dispose-unexplained",
+            "--json",
+            "--apply",
+            "--reports-dir",
+            str(reports),
+            "--ledger-path",
+            str(ledger_path),
+        ],
+    )
+    assert dry.exit_code == 0
+    applied = json.loads(dry.output)
+    assert applied["written"] == 1
+
+    result = CliRunner().invoke(
+        costs,
+        ["doctor", "--json", "--reports-dir", str(reports), "--ledger-path", str(ledger_path)],
+    )
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["disposed_spend_usd"] == 0.04
+    assert payload["unexplained_spend_usd"] == 0.0
+    assert payload["orphaned_spend_usd"] == 0.0
+    assert payload["disposed"][0]["disposition"] == "expected_non_report"
 
 
 def test_doctor_ignores_zero_cost_events(tmp_path: Path) -> None:
@@ -81,7 +127,7 @@ def test_doctor_ignores_zero_cost_events(tmp_path: Path) -> None:
     )
 
     payload = json.loads(result.output)
-    assert payload["matched"] == [] and payload["orphaned"] == []
+    assert payload["matched"] == [] and payload["orphaned"] == [] and payload["disposed"] == []
     assert result.exit_code == 0
 
 

--- a/tests/unit/test_cli/test_costs_doctor.py
+++ b/tests/unit/test_cli/test_costs_doctor.py
@@ -148,6 +148,41 @@ def test_doctor_uses_configured_reports_root_by_default(
     assert payload["orphaned_spend_usd"] == 0.0
 
 
+def test_parent_budget_cli_lists_and_replays(tmp_path: Path) -> None:
+    from deepr.experts.parent_budget_store import DurableParentBudget
+
+    ledger_path = tmp_path / "cost_ledger.jsonl"
+    ledger_path.write_text("", encoding="utf-8")
+    journal = tmp_path / "parent_budget_transactions.jsonl"
+    durable = DurableParentBudget.open(
+        surface="fill_gaps",
+        parent_ceiling_usd=0.5,
+        run_id="run-cli-1",
+        path=journal,
+    )
+    child = durable.admit_child(operation="gap", max_usd=0.2, child_id="c1")
+    durable.settle_child(child.child_id, 0.1)
+    durable.close()
+
+    listed = CliRunner().invoke(
+        costs,
+        ["parent-budget", "--json", "--ledger-path", str(ledger_path)],
+    )
+    assert listed.exit_code == 0
+    listed_payload = json.loads(listed.output)
+    assert listed_payload["count"] >= 3
+
+    replayed = CliRunner().invoke(
+        costs,
+        ["parent-budget", "--json", "--run-id", "run-cli-1", "--ledger-path", str(ledger_path)],
+    )
+    assert replayed.exit_code == 0
+    replay_payload = json.loads(replayed.output)
+    assert replay_payload["found"] is True
+    assert replay_payload["transaction"]["state"] == "closed"
+    assert replay_payload["transaction"]["settled_usd"] == 0.1
+
+
 def test_doctor_fails_closed_on_malformed_canonical_ledger(tmp_path: Path) -> None:
     reports = tmp_path / "reports"
     reports.mkdir()

--- a/tests/unit/test_experts/test_chat_budget.py
+++ b/tests/unit/test_experts/test_chat_budget.py
@@ -621,13 +621,14 @@ async def test_concurrent_metered_turns_make_zero_provider_calls_and_zero_ledger
     assert session.cost_accumulated == 0.0
     assert session.cost_session.total_cost == 0.0
     record.assert_not_called()
-    assert session.get_chat_capacity() == {
-        "metered": True,
-        "execution_enabled": False,
-        "status": "blocked",
-        "block_code": "metered_expert_chat_accounting_unavailable",
-        "explicit_allow": False,
-    }
+    capacity = session.get_chat_capacity()
+    assert capacity["metered"] is True
+    assert capacity["execution_enabled"] is False
+    assert capacity["status"] == "blocked"
+    assert capacity["block_code"] == "metered_expert_chat_accounting_unavailable"
+    assert capacity["explicit_allow"] is False
+    assert capacity["maximum_charge_contract_runtime_proven"] is False
+    assert capacity["maximum_charge_contract"]["complete"] is False
 
 
 async def test_all_auxiliary_metered_chat_paths_fail_before_dispatch(monkeypatch):

--- a/tests/unit/test_experts/test_chat_capacity_confirmation.py
+++ b/tests/unit/test_experts/test_chat_capacity_confirmation.py
@@ -40,7 +40,12 @@ def test_owned_capacity_never_requires_metered_env(monkeypatch):
 
 def test_release_invariant_blocks_metered_chat_without_full_charge_envelope(monkeypatch):
     monkeypatch.setattr(chat_capacity, "METERED_EXPERT_CHAT_EXECUTION_ENABLED", True)
+    monkeypatch.setattr(chat_capacity, "MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN", False)
     monkeypatch.setattr(chat_capacity, "HOSTED_EXPERT_STORAGE_LIFECYCLE_ACCOUNTING_ENABLED", False)
 
+    with pytest.raises(RuntimeError, match="maximum-charge contract is runtime-proven"):
+        chat_capacity.validate_expert_chat_release_invariants()
+
+    monkeypatch.setattr(chat_capacity, "MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN", True)
     with pytest.raises(RuntimeError, match="provider-enforceable maximum-charge envelopes"):
         chat_capacity.validate_expert_chat_release_invariants()

--- a/tests/unit/test_experts/test_maximum_charge_contract.py
+++ b/tests/unit/test_experts/test_maximum_charge_contract.py
@@ -91,6 +91,12 @@ def test_rejects_missing_posture_flags() -> None:
     assert any("retries_disabled" in item for item in verdict.failures)
 
 
+def test_rejects_stringy_posture_flags() -> None:
+    verdict = evaluate_maximum_charge_contract(_complete_envelope(retries_disabled="false"))  # type: ignore[arg-type]
+    assert verdict.complete is False
+    assert any("boolean" in item for item in verdict.failures)
+
+
 def test_rejects_when_computed_max_exceeds_parent() -> None:
     # Tiny ceiling cannot cover 100k output tokens of gpt-5-mini.
     verdict = evaluate_maximum_charge_contract(_complete_envelope(parent_ceiling_usd=0.0001, output_tokens=100_000))

--- a/tests/unit/test_experts/test_maximum_charge_contract.py
+++ b/tests/unit/test_experts/test_maximum_charge_contract.py
@@ -1,0 +1,139 @@
+"""Tests for the offline maximum-charge contract (P1 metered re-enable substrate)."""
+
+from __future__ import annotations
+
+import pytest
+
+from deepr.experts.chat_capacity import (
+    MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN,
+    METERED_EXPERT_CHAT_EXECUTION_ENABLED,
+    MeteredExpertChatDisabledError,
+    expert_chat_capacity,
+)
+from deepr.experts.chat_metered import execute_metered_chat_provider_call
+from deepr.experts.maximum_charge_contract import (
+    ABSOLUTE_DEEPR_CEILING_USD,
+    MaximumChargeContractError,
+    evaluate_maximum_charge_contract,
+    incomplete_contract_summary,
+    require_complete_maximum_charge_contract,
+)
+
+
+def _complete_envelope(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "parent_ceiling_usd": 1.0,
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "endpoint": "https://api.openai.com/v1",
+        "account_scope": "org_test",
+        "credential_fingerprint": "cred-fingerprint-test",
+        "request_digest": "sha256:deadbeef",
+        "input_tokens": 1_000,
+        "output_tokens": 500,
+        "reasoning_tokens": 0,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "tool_usd": 0.0,
+        "hosted_storage_usd": 0.0,
+        "background_jobs_usd": 0.0,
+        "transport_surcharge_usd": 0.0,
+        "fallback_usd": 0.0,
+        "retries_disabled": True,
+        "redirects_disabled": True,
+        "deepr_owned_client": True,
+        "official_endpoint_pinned": True,
+        "injected_client_rejected": True,
+        "overage_disabled": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_release_flags_remain_fail_closed() -> None:
+    assert METERED_EXPERT_CHAT_EXECUTION_ENABLED is False
+    assert MAXIMUM_CHARGE_CONTRACT_RUNTIME_PROVEN is False
+
+
+def test_incomplete_summary_lists_required_dimensions() -> None:
+    summary = incomplete_contract_summary()
+    assert summary["complete"] is False
+    assert "input_tokens" in summary["required_token_dimensions"]
+    assert "tool_usd" in summary["required_usd_dimensions"]
+    assert summary["absolute_deepr_ceiling_usd"] == ABSOLUTE_DEEPR_CEILING_USD
+
+
+def test_complete_envelope_evaluates_offline() -> None:
+    verdict = evaluate_maximum_charge_contract(_complete_envelope())
+    assert verdict.complete is True
+    assert verdict.computed_max_usd is not None
+    assert verdict.computed_max_usd > 0
+    assert verdict.computed_max_usd <= 1.0
+    assert "input_tokens" in verdict.priced_components
+    require_complete_maximum_charge_contract(_complete_envelope())
+
+
+def test_rejects_average_or_expected_only_authority() -> None:
+    verdict = evaluate_maximum_charge_contract(_complete_envelope(expected_cost_usd=0.01, average_cost_usd=0.02))
+    assert verdict.complete is False
+    assert any("not spend authority" in item for item in verdict.failures)
+
+
+def test_rejects_ceiling_above_absolute_deepr_limit() -> None:
+    verdict = evaluate_maximum_charge_contract(_complete_envelope(parent_ceiling_usd=5.01))
+    assert verdict.complete is False
+    assert any("absolute Deepr ceiling" in item for item in verdict.failures)
+
+
+def test_rejects_missing_posture_flags() -> None:
+    verdict = evaluate_maximum_charge_contract(_complete_envelope(retries_disabled=False))
+    assert verdict.complete is False
+    assert any("retries_disabled" in item for item in verdict.failures)
+
+
+def test_rejects_when_computed_max_exceeds_parent() -> None:
+    # Tiny ceiling cannot cover 100k output tokens of gpt-5-mini.
+    verdict = evaluate_maximum_charge_contract(_complete_envelope(parent_ceiling_usd=0.0001, output_tokens=100_000))
+    assert verdict.complete is False
+    assert any("exceeds parent_ceiling_usd" in item for item in verdict.failures)
+
+
+def test_rejects_cache_tokens_without_usable_bound_when_unpriced() -> None:
+    # Use a model alias that has token pricing but force cache traffic; gpt-5-mini
+    # has cache pricing, so force an unknown model for the failure path.
+    verdict = evaluate_maximum_charge_contract(_complete_envelope(model="not-a-real-model-xyz", cache_read_tokens=100))
+    assert verdict.complete is False
+    assert verdict.failures
+
+
+def test_require_raises_on_incomplete() -> None:
+    with pytest.raises(MaximumChargeContractError):
+        require_complete_maximum_charge_contract(_complete_envelope(deepr_owned_client=False))
+
+
+@pytest.mark.asyncio
+async def test_metered_chat_call_still_blocked_with_contract_payload() -> None:
+    with pytest.raises(MeteredExpertChatDisabledError) as caught:
+        await execute_metered_chat_provider_call(
+            provider="openai",
+            model="gpt-5-mini",
+            source="test",
+            max_cost_per_job=0.5,
+            call=lambda: None,  # type: ignore[arg-type,return-value]
+            request_envelope={"messages": []},
+        )
+    payload = caught.value.to_dict()
+    assert payload["provider_work_dispatched"] is False
+    assert payload["metered_chat_execution_enabled"] is False
+    assert payload["maximum_charge_contract"]["complete"] is False
+    assert "messages" in payload["maximum_charge_contract"]["request_envelope_keys"]
+
+
+def test_expert_chat_capacity_exposes_contract_summary() -> None:
+    class _Metered:
+        metered = True
+
+    capacity = expert_chat_capacity(_Metered())
+    assert capacity["execution_enabled"] is False
+    assert capacity["maximum_charge_contract_runtime_proven"] is False
+    assert capacity["maximum_charge_contract"]["complete"] is False

--- a/tests/unit/test_experts/test_parent_budget_store.py
+++ b/tests/unit/test_experts/test_parent_budget_store.py
@@ -133,13 +133,13 @@ def test_open_gated_lifecycle_budget_rejects_unknown_surface(tmp_path: Path) -> 
             path=path,
         )
     durable = open_gated_lifecycle_budget(
-        surface="paid_portraits",
+        surface="api_expert_portrait",
         parent_ceiling_usd=1.0,
         maximum_charge_envelope=_complete_envelope(parent_ceiling_usd=1.0),
         run_id="run-portrait",
         path=path,
     )
-    assert durable.parent.surface == "paid_portraits"
+    assert durable.parent.surface == "api_expert_portrait"
 
 
 def test_durable_cancel_and_consume(tmp_path: Path) -> None:

--- a/tests/unit/test_experts/test_parent_budget_store.py
+++ b/tests/unit/test_experts/test_parent_budget_store.py
@@ -61,6 +61,59 @@ def test_durable_freeze_on_overrun_is_replayable(tmp_path: Path) -> None:
     assert rebuilt.children["r1"].settled_usd == pytest.approx(0.3)
 
 
+def _complete_envelope(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "parent_ceiling_usd": 1.0,
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "endpoint": "https://api.openai.com/v1",
+        "account_scope": "org_test",
+        "credential_fingerprint": "cred-fingerprint-test",
+        "request_digest": "sha256:deadbeef",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "reasoning_tokens": 0,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "tool_usd": 0.0,
+        "hosted_storage_usd": 0.0,
+        "background_jobs_usd": 0.0,
+        "transport_surcharge_usd": 0.0,
+        "fallback_usd": 0.0,
+        "retries_disabled": True,
+        "redirects_disabled": True,
+        "deepr_owned_client": True,
+        "official_endpoint_pinned": True,
+        "injected_client_rejected": True,
+        "overage_disabled": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_open_requires_complete_contract_when_requested(tmp_path: Path) -> None:
+    path = tmp_path / "parent_budget_transactions.jsonl"
+    with pytest.raises(ParentBudgetError):
+        DurableParentBudget.open(
+            surface="expert_refresh",
+            parent_ceiling_usd=1.0,
+            path=path,
+            require_complete_contract=True,
+            maximum_charge_envelope=_complete_envelope(retries_disabled=False),
+        )
+    durable = DurableParentBudget.open(
+        surface="expert_refresh",
+        parent_ceiling_usd=1.0,
+        run_id="run-contract",
+        path=path,
+        require_complete_contract=True,
+        maximum_charge_envelope=_complete_envelope(parent_ceiling_usd=1.0),
+    )
+    assert durable.parent.run_id == "run-contract"
+    events = load_parent_budget_events(path)
+    assert events[-1]["maximum_charge_contract"]["complete"] is True
+
+
 def test_durable_cancel_and_consume(tmp_path: Path) -> None:
     path = tmp_path / "parent_budget_transactions.jsonl"
     durable = DurableParentBudget.open(

--- a/tests/unit/test_experts/test_parent_budget_store.py
+++ b/tests/unit/test_experts/test_parent_budget_store.py
@@ -1,0 +1,83 @@
+"""Tests for durable parent budget journal and replay."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deepr.experts.parent_budget_store import (
+    DurableParentBudget,
+    load_parent_budget_events,
+    replay_parent_budget,
+)
+from deepr.experts.parent_budget_transaction import ChildCallState, ParentBudgetError, ParentBudgetState
+
+
+def test_durable_open_admit_settle_close_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "parent_budget_transactions.jsonl"
+    durable = DurableParentBudget.open(
+        surface="fill_gaps",
+        parent_ceiling_usd=1.0,
+        run_id="run-test-1",
+        path=path,
+    )
+    child = durable.admit_child(operation="gap", max_usd=0.4, child_id="c1")
+    durable.mark_dispatch(child.child_id)
+    durable.settle_child(child.child_id, 0.2)
+    durable.close()
+
+    events = load_parent_budget_events(path)
+    assert [event["event_type"] for event in events] == [
+        "opened",
+        "child_admitted",
+        "dispatch_marked",
+        "settled",
+        "closed",
+    ]
+    rebuilt = replay_parent_budget("run-test-1", path)
+    assert rebuilt is not None
+    assert rebuilt.state is ParentBudgetState.CLOSED
+    assert rebuilt.settled_usd() == pytest.approx(0.2)
+    assert rebuilt.children["c1"].state is ChildCallState.SETTLED
+
+
+def test_durable_freeze_on_overrun_is_replayable(tmp_path: Path) -> None:
+    path = tmp_path / "parent_budget_transactions.jsonl"
+    durable = DurableParentBudget.open(
+        surface="expert_reflect",
+        parent_ceiling_usd=0.5,
+        run_id="run-freeze",
+        path=path,
+    )
+    durable.admit_child(operation="reflect", max_usd=0.3, child_id="r1")
+    with pytest.raises(ParentBudgetError):
+        durable.settle_child("r1", 0.4)
+
+    rebuilt = replay_parent_budget("run-freeze", path)
+    assert rebuilt is not None
+    assert rebuilt.state is ParentBudgetState.FROZEN
+    assert rebuilt.children["r1"].state is ChildCallState.CONSUMED
+    assert rebuilt.children["r1"].settled_usd == pytest.approx(0.3)
+
+
+def test_durable_cancel_and_consume(tmp_path: Path) -> None:
+    path = tmp_path / "parent_budget_transactions.jsonl"
+    durable = DurableParentBudget.open(
+        surface="paid_portraits",
+        parent_ceiling_usd=1.0,
+        run_id="run-cancel",
+        path=path,
+    )
+    durable.admit_child(operation="a", max_usd=0.2, child_id="a1")
+    durable.cancel_child("a1")
+    durable.admit_child(operation="b", max_usd=0.5, child_id="b1")
+    durable.mark_dispatch("b1")
+    durable.consume_child_ceiling("b1", reason="lost_response")
+    durable.close()
+
+    rebuilt = replay_parent_budget("run-cancel", path)
+    assert rebuilt is not None
+    assert rebuilt.children["a1"].state is ChildCallState.CANCELLED
+    assert rebuilt.children["b1"].state is ChildCallState.CONSUMED
+    assert rebuilt.settled_usd() == pytest.approx(0.5)

--- a/tests/unit/test_experts/test_parent_budget_store.py
+++ b/tests/unit/test_experts/test_parent_budget_store.py
@@ -101,6 +101,14 @@ def test_open_requires_complete_contract_when_requested(tmp_path: Path) -> None:
             require_complete_contract=True,
             maximum_charge_envelope=_complete_envelope(retries_disabled=False),
         )
+    with pytest.raises(ParentBudgetError, match="must match parent_ceiling_usd"):
+        DurableParentBudget.open(
+            surface="expert_refresh",
+            parent_ceiling_usd=1.0,
+            path=path,
+            require_complete_contract=True,
+            maximum_charge_envelope=_complete_envelope(parent_ceiling_usd=0.5),
+        )
     durable = DurableParentBudget.open(
         surface="expert_refresh",
         parent_ceiling_usd=1.0,

--- a/tests/unit/test_experts/test_parent_budget_store.py
+++ b/tests/unit/test_experts/test_parent_budget_store.py
@@ -9,6 +9,7 @@ import pytest
 from deepr.experts.parent_budget_store import (
     DurableParentBudget,
     load_parent_budget_events,
+    open_gated_lifecycle_budget,
     replay_parent_budget,
 )
 from deepr.experts.parent_budget_transaction import ChildCallState, ParentBudgetError, ParentBudgetState
@@ -120,6 +121,25 @@ def test_open_requires_complete_contract_when_requested(tmp_path: Path) -> None:
     assert durable.parent.run_id == "run-contract"
     events = load_parent_budget_events(path)
     assert events[-1]["maximum_charge_contract"]["complete"] is True
+
+
+def test_open_gated_lifecycle_budget_rejects_unknown_surface(tmp_path: Path) -> None:
+    path = tmp_path / "parent_budget_transactions.jsonl"
+    with pytest.raises(ParentBudgetError, match="not in the gated"):
+        open_gated_lifecycle_budget(
+            surface="not_a_real_surface",
+            parent_ceiling_usd=1.0,
+            maximum_charge_envelope=_complete_envelope(),
+            path=path,
+        )
+    durable = open_gated_lifecycle_budget(
+        surface="paid_portraits",
+        parent_ceiling_usd=1.0,
+        maximum_charge_envelope=_complete_envelope(parent_ceiling_usd=1.0),
+        run_id="run-portrait",
+        path=path,
+    )
+    assert durable.parent.surface == "paid_portraits"
 
 
 def test_durable_cancel_and_consume(tmp_path: Path) -> None:

--- a/tests/unit/test_experts/test_parent_budget_transaction.py
+++ b/tests/unit/test_experts/test_parent_budget_transaction.py
@@ -99,3 +99,34 @@ def test_cannot_close_with_open_children() -> None:
     parent.admit_child(operation="resume_step", max_usd=0.2)
     with pytest.raises(ParentBudgetError):
         parent.close()
+
+
+def test_concurrent_admits_never_oversubscribe() -> None:
+    import threading
+
+    parent = open_parent_budget_transaction(surface="fill_gaps_deep", parent_ceiling_usd=1.0)
+    errors: list[BaseException] = []
+    admitted = 0
+    admitted_lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        nonlocal admitted
+        try:
+            parent.admit_child(operation=f"c{index}", max_usd=0.3, child_id=f"c{index}")
+            with admitted_lock:
+                admitted += 1
+        except ParentBudgetError as exc:
+            errors.append(exc)
+        except Exception as exc:  # pragma: no cover - unexpected
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert admitted <= 3
+    assert parent.admitted_max_usd() <= 1.0 + 1e-9
+    assert all(isinstance(err, ParentBudgetError) for err in errors)
+    assert admitted + len(errors) == 10

--- a/tests/unit/test_experts/test_parent_budget_transaction.py
+++ b/tests/unit/test_experts/test_parent_budget_transaction.py
@@ -1,0 +1,101 @@
+"""Tests for shared parent budget transaction substrate."""
+
+from __future__ import annotations
+
+import pytest
+
+from deepr.experts.maximum_charge_contract import ABSOLUTE_DEEPR_CEILING_USD
+from deepr.experts.metered_mutation_gate import (
+    METERED_EXPERT_MUTATIONS_ENABLED,
+    MeteredExpertMutationDisabledError,
+    require_metered_expert_mutation,
+)
+from deepr.experts.parent_budget_transaction import (
+    ChildCallState,
+    GATED_METERED_LIFECYCLE_SURFACES,
+    ParentBudgetError,
+    ParentBudgetState,
+    open_parent_budget_transaction,
+    surface_requires_parent_budget,
+)
+
+
+def test_mutations_remain_fail_closed() -> None:
+    assert METERED_EXPERT_MUTATIONS_ENABLED is False
+    with pytest.raises(MeteredExpertMutationDisabledError) as caught:
+        require_metered_expert_mutation("expert_refresh", safe_alternative="use --local")
+    payload = caught.value.to_dict()
+    assert payload["provider_work_started"] is False
+    assert payload["parent_budget_transaction_required"] is True
+    assert "expert_refresh" in payload["gated_lifecycle_surfaces"]
+
+
+def test_gated_surface_inventory_is_non_empty() -> None:
+    assert "fill_gaps" in GATED_METERED_LIFECYCLE_SURFACES
+    assert surface_requires_parent_budget("fill_gaps") is True
+    assert surface_requires_parent_budget("unknown") is False
+
+
+def test_parent_admits_children_within_ceiling() -> None:
+    parent = open_parent_budget_transaction(surface="expert_refresh", parent_ceiling_usd=1.0)
+    first = parent.admit_child(operation="call_a", max_usd=0.4)
+    second = parent.admit_child(operation="call_b", max_usd=0.5)
+    assert first.state is ChildCallState.ADMITTED
+    assert second.state is ChildCallState.ADMITTED
+    assert parent.remaining_usd() == pytest.approx(0.1)
+    with pytest.raises(ParentBudgetError):
+        parent.admit_child(operation="call_c", max_usd=0.2)
+
+
+def test_dispatch_settle_and_close() -> None:
+    parent = open_parent_budget_transaction(surface="fill_gaps", parent_ceiling_usd=0.5)
+    child = parent.admit_child(operation="gap_fill", max_usd=0.4)
+    parent.mark_dispatch(child.child_id)
+    parent.settle_child(child.child_id, 0.25)
+    assert parent.children[child.child_id].state is ChildCallState.SETTLED
+    assert parent.settled_usd() == pytest.approx(0.25)
+    assert parent.remaining_usd() == pytest.approx(0.25)
+    parent.close()
+    assert parent.state is ParentBudgetState.CLOSED
+
+
+def test_over_actual_freezes_and_consumes_ceiling() -> None:
+    parent = open_parent_budget_transaction(surface="expert_reflect", parent_ceiling_usd=0.3)
+    child = parent.admit_child(operation="reflect", max_usd=0.2)
+    with pytest.raises(ParentBudgetError):
+        parent.settle_child(child.child_id, 0.25)
+    assert parent.state is ParentBudgetState.FROZEN
+    assert parent.children[child.child_id].state is ChildCallState.CONSUMED
+    assert parent.children[child.child_id].settled_usd == pytest.approx(0.2)
+
+
+def test_cancel_releases_headroom() -> None:
+    parent = open_parent_budget_transaction(surface="paid_portraits", parent_ceiling_usd=1.0)
+    child = parent.admit_child(operation="portrait", max_usd=0.7)
+    parent.cancel_child(child.child_id)
+    assert parent.remaining_usd() == pytest.approx(1.0)
+    parent.close()
+
+
+def test_consume_child_ceiling_is_conservative() -> None:
+    parent = open_parent_budget_transaction(surface="eval_calibrate_corpus", parent_ceiling_usd=1.0)
+    child = parent.admit_child(operation="judge", max_usd=0.5)
+    parent.mark_dispatch(child.child_id)
+    parent.consume_child_ceiling(child.child_id, reason="ambiguous_usage")
+    assert parent.children[child.child_id].settled_usd == pytest.approx(0.5)
+    assert parent.remaining_usd() == pytest.approx(0.5)
+
+
+def test_rejects_parent_above_absolute_ceiling() -> None:
+    with pytest.raises(ParentBudgetError):
+        open_parent_budget_transaction(
+            surface="expert_sync_api",
+            parent_ceiling_usd=ABSOLUTE_DEEPR_CEILING_USD + 0.01,
+        )
+
+
+def test_cannot_close_with_open_children() -> None:
+    parent = open_parent_budget_transaction(surface="expert_resume", parent_ceiling_usd=1.0)
+    parent.admit_child(operation="resume_step", max_usd=0.2)
+    with pytest.raises(ParentBudgetError):
+        parent.close()

--- a/tests/unit/test_experts/test_parent_budget_transaction.py
+++ b/tests/unit/test_experts/test_parent_budget_transaction.py
@@ -32,7 +32,10 @@ def test_mutations_remain_fail_closed() -> None:
 
 def test_gated_surface_inventory_is_non_empty() -> None:
     assert "fill_gaps" in GATED_METERED_LIFECYCLE_SURFACES
+    assert "api_expert_portrait" in GATED_METERED_LIFECYCLE_SURFACES
+    assert "api_expert_sync" in GATED_METERED_LIFECYCLE_SURFACES
     assert surface_requires_parent_budget("fill_gaps") is True
+    assert surface_requires_parent_budget("api_expert_portrait") is True
     assert surface_requires_parent_budget("unknown") is False
 
 

--- a/tests/unit/test_experts/test_parent_budget_transaction.py
+++ b/tests/unit/test_experts/test_parent_budget_transaction.py
@@ -105,6 +105,13 @@ def test_cannot_close_with_open_children() -> None:
         parent.close()
 
 
+def test_cannot_double_close() -> None:
+    parent = open_parent_budget_transaction(surface="expert_resume", parent_ceiling_usd=1.0)
+    parent.close()
+    with pytest.raises(ParentBudgetError, match="already closed"):
+        parent.close()
+
+
 def test_concurrent_admits_never_oversubscribe() -> None:
     import threading
 

--- a/tests/unit/test_experts/test_parent_budget_transaction.py
+++ b/tests/unit/test_experts/test_parent_budget_transaction.py
@@ -23,11 +23,12 @@ from deepr.experts.parent_budget_transaction import (
 def test_mutations_remain_fail_closed() -> None:
     assert METERED_EXPERT_MUTATIONS_ENABLED is False
     with pytest.raises(MeteredExpertMutationDisabledError) as caught:
-        require_metered_expert_mutation("expert_refresh", safe_alternative="use --local")
+        require_metered_expert_mutation("api_expert_sync", safe_alternative="use --local")
     payload = caught.value.to_dict()
     assert payload["provider_work_started"] is False
     assert payload["parent_budget_transaction_required"] is True
-    assert "expert_refresh" in payload["gated_lifecycle_surfaces"]
+    assert payload["parent_budget_surface_known"] is True
+    assert "api_expert_sync" in payload["gated_lifecycle_surfaces"]
 
 
 def test_gated_surface_inventory_is_non_empty() -> None:

--- a/tests/unit/test_observability/test_spend_dispositions.py
+++ b/tests/unit/test_observability/test_spend_dispositions.py
@@ -1,0 +1,173 @@
+"""Unit tests for durable spend dispositions (ROADMAP P0 orphan reconciliation)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from deepr.observability.cost_ledger import CostLedger, CostLedgerEvent
+from deepr.observability.spend_dispositions import (
+    DISPOSITION_EXPECTED_NON_REPORT,
+    DISPOSITION_LOST_ARTIFACT,
+    apply_suggested_dispositions,
+    classify_paid_events,
+    event_identity_key,
+    event_identity_key_from_ledger_event,
+    latest_dispositions_by_event_key,
+    record_spend_disposition,
+    suggest_disposition_for_orphan,
+)
+
+
+def test_event_identity_prefers_idempotency_key() -> None:
+    key = event_identity_key(
+        timestamp="2026-07-01T00:00:00+00:00",
+        operation="research_job",
+        provider="openai",
+        model="o3",
+        cost_usd=1.0,
+        task_id="abc",
+        idempotency_key="queue:update_results:abc:1.000000",
+    )
+    assert key == "idem:queue:update_results:abc:1.000000"
+
+
+def test_event_identity_hashes_when_no_idempotency_key() -> None:
+    a = event_identity_key(
+        timestamp="2026-07-01T00:00:00+00:00",
+        operation="portrait_generation",
+        provider="auto",
+        model="",
+        cost_usd=0.04,
+        task_id="portrait_X",
+    )
+    b = event_identity_key(
+        timestamp="2026-07-01T00:00:00+00:00",
+        operation="portrait_generation",
+        provider="auto",
+        model="",
+        cost_usd=0.04,
+        task_id="portrait_X",
+    )
+    c = event_identity_key(
+        timestamp="2026-07-01T00:00:00+00:00",
+        operation="portrait_generation",
+        provider="auto",
+        model="",
+        cost_usd=0.04,
+        task_id="portrait_Y",
+    )
+    assert a.startswith("hash:")
+    assert a == b
+    assert a != c
+
+
+def test_classify_separates_matched_disposed_unexplained(tmp_path: Path) -> None:
+    reports = tmp_path / "reports"
+    (reports / "2026-07-25_topic_a7ae5c65").mkdir(parents=True)
+    ledger_path = tmp_path / "cost_ledger.jsonl"
+    ledger = CostLedger(ledger_path=ledger_path)
+    ledger.record_event(
+        operation="research_completion",
+        provider="xai",
+        cost_usd=0.03,
+        model="grok-4-5",
+        task_id="research_research-a7ae5c653d8c",
+        idempotency_key="matched-1",
+    )
+    ledger.record_event(
+        operation="portrait_generation",
+        provider="auto",
+        cost_usd=0.04,
+        task_id="portrait_Demo",
+        idempotency_key="portrait-1",
+    )
+    ledger.record_event(
+        operation="research_job",
+        provider="openai",
+        cost_usd=1.85,
+        model="o3-deep-research",
+        task_id="deadbeef-uuid",
+        idempotency_key="orphan-1",
+    )
+    events = ledger.with_locked_accounting_events(list)
+    portrait_key = event_identity_key_from_ledger_event(next(e for e in events if e.task_id == "portrait_Demo"))
+    record_spend_disposition(
+        event_key=portrait_key,
+        disposition=DISPOSITION_EXPECTED_NON_REPORT,
+        cost_usd=0.04,
+        task_id="portrait_Demo",
+        operation="portrait_generation",
+        provider="auto",
+        model="",
+        event_timestamp="2026-07-25T00:00:00",
+        rationale="portraits do not create report dirs",
+        path=tmp_path / "spend_dispositions.jsonl",
+    )
+    cutoff = datetime.now(UTC) - timedelta(days=45)
+    matched, disposed, unexplained = classify_paid_events(
+        events,
+        [d.name for d in reports.iterdir()],
+        cutoff,
+        dispositions_by_key=latest_dispositions_by_event_key(tmp_path / "spend_dispositions.jsonl"),
+    )
+    assert len(matched) == 1
+    assert matched[0]["cost_usd"] == 0.03
+    assert len(disposed) == 1
+    assert disposed[0]["disposition"] == DISPOSITION_EXPECTED_NON_REPORT
+    assert len(unexplained) == 1
+    assert unexplained[0]["cost_usd"] == 1.85
+
+
+def test_suggest_and_apply_closes_unexplained(tmp_path: Path) -> None:
+    entry = {
+        "event_key": "idem:portrait-x",
+        "cost_usd": 0.04,
+        "task_id": "portrait_Coffee",
+        "operation": "portrait_generation",
+        "provider": "auto",
+        "model": "",
+        "timestamp": "2026-07-01T00:00:00",
+        "request_id": "",
+        "source": "experts.portraits",
+    }
+    kind, rationale, evidence = suggest_disposition_for_orphan(entry)
+    assert kind == DISPOSITION_EXPECTED_NON_REPORT
+    assert "non-report" in rationale
+    assert evidence["operation"] == "portrait_generation"
+
+    research = {
+        "event_key": "idem:rj-1",
+        "cost_usd": 0.52,
+        "task_id": "682b02bf-15ed-4b70-8175-5ec9fd9ea5f0",
+        "operation": "research_job",
+        "provider": "openai",
+        "model": "o3-deep-research",
+        "timestamp": "2026-07-01T00:22:22",
+        "request_id": "",
+        "source": "queue.update_results",
+    }
+    kind2, _rationale2, evidence2 = suggest_disposition_for_orphan(research)
+    assert kind2 == DISPOSITION_LOST_ARTIFACT
+    assert evidence2["job_id"] == research["task_id"]
+
+    path = tmp_path / "spend_dispositions.jsonl"
+    written = apply_suggested_dispositions([entry, research], path=path)
+    assert len(written) == 2
+    latest = latest_dispositions_by_event_key(path)
+    assert latest["idem:portrait-x"]["disposition"] == DISPOSITION_EXPECTED_NON_REPORT
+    assert latest["idem:rj-1"]["disposition"] == DISPOSITION_LOST_ARTIFACT
+    assert latest["idem:rj-1"]["job_id"] == research["task_id"]
+
+
+def test_ledger_event_identity_roundtrip() -> None:
+    event = CostLedgerEvent(
+        operation="expert_chat",
+        provider="openai",
+        cost_usd=0.01,
+        model="gpt-5.2",
+        task_id="chat_Demo_abc",
+        idempotency_key="chat-key-1",
+        timestamp=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+    assert event_identity_key_from_ledger_event(event) == "idem:chat-key-1"


### PR DESCRIPTION
## Summary

- Close ROADMAP P0 orphaned spend with durable dispositions and doctor matched/disposed/unexplained buckets.
- Land fail-closed maximum-charge contract evaluation for metered chat re-enable substrate.
- Land parent budget transaction substrate with durable journal, crash replay, gated lifecycle open helper, and costs parent-budget CLI.
- Bump package/README/changelog/roadmap status to v2.42.0. Paid dispatch remains frozen.

## Test plan

- [x] Focused unit tests for dispositions, doctor, max-charge, parent budget, concurrency
- [x] ruff, file-size ratchet, paid API boundary check
- [ ] CI green on this PR
- [ ] Merge to main
- [ ] Tag and GitHub Release v2.42.0 with wheel/sdist/SHA256SUMS
- [ ] Also publish missing v2.41.0 release from MCP commit if still absent