### PR TITLE
feat: offline MCP host-interop conformance rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ and the [MCP Agent Guide](docs/MCP_AGENT_TEST_GUIDE.md) for workflows across the
 current 36 MCP tools. The MCP server implements the final `2026-07-28`
 protocol revision (stateless per-request negotiation, `server/discover`,
 `subscriptions/listen`, Streamable HTTP header and Origin validation) while
-still serving legacy `initialize`-era clients on both transports.
+still serving legacy `initialize`-era clients on both transports. Operators can
+prove the offline host-interop posture with `deepr mcp conformance` (`$0`, no
+network, no model).
 
 ## Documentation
 

--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -229,12 +229,20 @@ deepr expert consult "What changed in plan capacity?" --plan claude --json
 deepr expert judge-consult-quality "Platform Team Expert" consult_abc123 --plan claude --json
 ```
 
-Run Claude plan commands from a dedicated shell without `ANTHROPIC_API_KEY`.
-For PowerShell, remove it only from that shell with
-`Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue`. The stored
-Claude subscription login remains intact. Deepr intentionally refuses when the
-API credential is present rather than guessing which authentication path the
-vendor will charge.
+Run Claude plan commands from a dedicated shell without a truthy
+`ANTHROPIC_API_KEY`. Prefer setting an empty value for that process so
+checkout-local `.env` loading cannot reintroduce a real key
+(`load_dotenv` does not override an already-set process variable):
+
+```powershell
+$env:ANTHROPIC_API_KEY = ""
+deepr expert consult "question" --plan claude -y
+```
+
+`Remove-Item Env:ANTHROPIC_API_KEY` alone is not enough when `.env` still
+defines the key. The stored Claude subscription login remains intact. Deepr
+intentionally refuses when the API credential is present rather than guessing
+which authentication path the vendor will charge.
 
 The API judge form is visible but gated in v2.36.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Approach contract](APPROACH.md): normative open-source method claims,
   refusals, capacity classes, epistemic state, and composition model. Linked
   from the README, docs index, and roadmap.
+- Offline MCP host-interop conformance rollup: `deepr mcp conformance`
+  (`deepr-mcp-conformance-v1`). Aggregates dual-era protocol constants, offline
+  consult form checks, remote smoke and managed-conversation fail-closed
+  postures, registration-manifest offline shape, and the capabilities map.
+  No network, no model, `$0`. Documented in
+  [MCP_AGENT_TEST_GUIDE.md](MCP_AGENT_TEST_GUIDE.md) and
+  [SUPPORTED_SURFACE.md](SUPPORTED_SURFACE.md).
+
+### Changed
+
+- Supported Surface status advanced to v2.42.0 / 2026-08-01 with dual-era MCP,
+  offline conformance, spend dispositions, and parent-budget substrate
+  language. Plan-quota operator guidance clarifies empty
+  `ANTHROPIC_API_KEY` process masking so `.env` cannot reintroduce a metered
+  credential.
 
 ## [2.42.0] - 2026-07-31
 

--- a/docs/MCP_AGENT_TEST_GUIDE.md
+++ b/docs/MCP_AGENT_TEST_GUIDE.md
@@ -66,15 +66,16 @@ explicit plan-capacity path.
   expert fallback and return a `capacity.live_metered_fallback=false` marker.
 - API consult synthesis exposes explicit `provider`, `model`, and budget
   inputs for preview and contract testing. Production metered dispatch remains
-  blocked in v2.40 until authenticated provider account controls and current
-  credential identity are proven. Use local or plan modes for execution.
+  blocked (freeze since v2.40; still current on v2.42) until authenticated
+  provider account controls and current credential identity are proven. Use
+  local or plan modes for execution.
 - `deepr_query_expert` stays off metered APIs when the caller sets
   `backend` to `local` or `plan`. Those modes route one named expert through
   a read-only compiled-context chat turn, attach `readonly_chat_artifact`, set
   `research_triggered=0`, and reject `agentic=true`. Omitted or
-  `backend="api"` is blocked before provider work in v2.40 with
+  `backend="api"` is blocked before provider work with
   `metered_expert_chat_accounting_unavailable`.
-- `deepr_agentic_research` is always execution-blocked in v2.40.
+- `deepr_agentic_research` is always execution-blocked under the same freeze.
   `deepr_research` exposes a bounded metered request contract, but production
   dispatch is blocked by the same provider-account authority gate. Mutating
   tools are not safe for automatic no-cost testing unless their schema exposes
@@ -86,14 +87,33 @@ explicit plan-capacity path.
 
 ## Operator Self-Validation
 
-Before handing the endpoint to another machine, validate the consult contract
-from the operator shell:
+Before handing the endpoint to another machine, run the offline conformance
+rollup (preferred first gate):
+
+```powershell
+deepr mcp conformance --json
+```
+
+This costs `$0`, opens no network, calls no model, and emits
+`schema_version="deepr-mcp-conformance-v1"`. It must report `ok=true` with all
+of:
+
+| Check | Expected posture |
+| --- | --- |
+| `dual_era_protocol` | Modern `2026-07-28` plus legacy versions and tool aliases |
+| `offline_consult_validation` | 15 form checks on `deepr-consult-v1` |
+| `remote_smoke_fail_closed` | Smoke blocked; no network open |
+| `managed_conversation_fail_closed` | Managed loopback blocked without cost authority |
+| `registration_manifest_offline` | Manifest built; remote smoke pending cost authority |
+| `capabilities_map` | `deepr-capabilities-v1` with local + Claude zero-cost paths |
+
+Then validate the consult contract alone if you need a smaller fixture:
 
 ```powershell
 deepr mcp validate-consult --json
 ```
 
-This offline fixture costs `$0` and proves the `deepr-consult-v1` artifact,
+That offline fixture costs `$0` and proves the `deepr-consult-v1` artifact,
 `deepr-expert-collaboration-v1` metadata, trace linkage, no-metered capacity
 posture, cost fields, dissent handling, host action boundary, and secret
 redaction checks without requiring Ollama or a plan CLI.
@@ -110,9 +130,19 @@ deepr mcp validate-consult-fleet --plan claude --expert "AI Agent Harnesses" --j
 Claude is the current safety-eligible adapter for this live check. Each call
 first requires live provider metadata proving paid extra usage is disabled,
 then runs in safe mode with empty tool and MCP surfaces, no persistence, the
-included `sonnet` alias, and no API credential. Codex,
-OpenCode, Kiro, Grok, Antigravity, and Copilot are fleet-visible but fail before
-vendor dispatch; inspect their exact reasons with `deepr capacity fleet`.
+included `sonnet` alias, and no API credential. **Plan mode refuses when
+`ANTHROPIC_API_KEY` is set and non-empty** (including values loaded from
+`.env`). Use a dedicated shell and clear only that process variable so dotenv
+cannot reintroduce a truthy key:
+
+```powershell
+$env:ANTHROPIC_API_KEY = ""
+deepr mcp validate-consult --live --synthesis-backend plan --plan claude --json
+```
+
+Codex, OpenCode, Kiro, Grok, Antigravity, and Copilot are fleet-visible but
+fail before vendor dispatch; inspect their exact reasons with
+`deepr capacity fleet`.
 
 `capacity validate-fleet` is the preferred operator check when validating a
 plan fleet. It first proves CLI transport and auth, records quota observations,

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,8 +1,9 @@
 # Supported Surface
 
-Status: v2.40.0 current main, 2026-07-29. This document defines what users and host
+Status: v2.42.0 current main, 2026-08-01. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
-data remains portable if development stops.
+data remains portable if development stops. Production metered dispatch remains
+frozen since v2.40 until provider account-control adapters land.
 
 ## Support Levels
 
@@ -80,16 +81,36 @@ must not be described as usable capacity.
 - Expert skill inventory, metadata, installation, and scaffolding. Python and
   MCP tool execution is quarantined before module import, process creation, or
   network dispatch; legacy `run-skill` validates and exits blocked.
-- MCP stdio server and MCP HTTP serve mode.
+- MCP stdio server and MCP HTTP serve mode. Dual-era protocol support for the
+  MCP `2026-07-28` revision (modern per-request `_meta` negotiation,
+  `server/discover`, `subscriptions/listen`, Streamable HTTP header/Origin
+  rules) while continuing to serve legacy `initialize`-era clients
+  (`2025-06-18`, `2025-03-26`, `2024-11-05`) on both transports.
+- Offline machine-checkable MCP host-interop rollup via
+  `deepr mcp conformance` (`deepr-mcp-conformance-v1`): dual-era constants,
+  offline consult form checks, remote smoke fail-closed posture, managed
+  conversation fail-closed posture, registration-manifest offline shape, and
+  the capabilities map. No network, no model, `$0`. Does not score semantic
+  answer quality.
+- Offline and live no-metered consult validation (`deepr mcp validate-consult`,
+  `validate-consult-fleet`) and fail-closed remote smoke / conversation
+  validation commands. Remote HTTP tool calls remain blocked until an
+  independently enforced cost authority exists.
 - MCP durable local expert conversations through
   `deepr_start_expert_conversation`, `deepr_continue_expert_conversation`,
   `deepr_get_expert_conversation`, and `deepr_close_expert_conversation`.
   Opaque application handles, scoped ownership, optimistic concurrency,
   idempotency, frozen expert snapshots, retention, and no metered fallback are
-  enforced by the shared conversation core. A separate validation command
-  exercises the full remote sequence.
+  enforced by the shared conversation core. Managed and remote conversation
+  validation currently fail closed before dispatch without cost authority.
 - Scoped MCP keys, per-key budgets, per-key rate limits, HTTP concurrency caps,
   HTTP smoke checks, registration manifests, and remote-call audit review.
+- Durable spend dispositions for settled cost events without report artifacts
+  (`deepr costs dispose`, `dispose-unexplained`, `dispositions`) and
+  `deepr costs doctor` matched / disposed / unexplained buckets. The
+  append-only cost ledger is never rewritten. Parent-budget transaction
+  substrate and offline maximum-charge contract evaluators are present for
+  future metered lifecycle re-enable; production paid dispatch stays blocked.
 - `deepr_expert_handoff`, `deepr_expert_loop_status`, and adjacent versioned
   handoff contracts. The MCP loop-status tool, the CLI JSON loop-status command,
   and `/api/experts/{name}/loop-status` share the `deepr-loop-status-v1` rollup

--- a/docs/schemas/mcp-conformance-v1.json
+++ b/docs/schemas/mcp-conformance-v1.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/blisspixel/deepr/docs/schemas/mcp-conformance-v1.json",
+  "title": "Deepr MCP Offline Conformance v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "kind",
+    "generated_at",
+    "server_version",
+    "mode",
+    "ok",
+    "cost_usd",
+    "contract",
+    "protocol",
+    "summary",
+    "checks"
+  ],
+  "properties": {
+    "schema_version": {"const": "deepr-mcp-conformance-v1"},
+    "kind": {"const": "deepr.mcp.conformance"},
+    "generated_at": {"type": "string"},
+    "server_version": {"type": "string", "minLength": 1},
+    "mode": {"const": "offline"},
+    "ok": {"type": "boolean"},
+    "cost_usd": {"const": 0.0},
+    "contract": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "cost_usd",
+        "network_opened",
+        "calls_metered_api",
+        "writes_state",
+        "semantic_verdict",
+        "checks_form_and_side_effects_only",
+        "live_model_required"
+      ],
+      "properties": {
+        "cost_usd": {"const": 0.0},
+        "network_opened": {"const": false},
+        "calls_metered_api": {"const": false},
+        "writes_state": {"const": false},
+        "semantic_verdict": {"const": false},
+        "checks_form_and_side_effects_only": {"const": true},
+        "live_model_required": {"const": false}
+      }
+    },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["modern", "legacy", "supported"],
+      "properties": {
+        "modern": {"const": "2026-07-28"},
+        "legacy": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "supported": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 2
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["ok", "check_count", "failed_checks"],
+      "properties": {
+        "ok": {"type": "boolean"},
+        "check_count": {"type": "integer", "minimum": 0},
+        "failed_checks": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["name", "status", "detail", "expected"],
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "status": {"type": "string", "enum": ["passed", "failed"]},
+          "detail": {"type": "string"},
+          "expected": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/registry.json
+++ b/docs/schemas/registry.json
@@ -367,6 +367,14 @@
       "compatibility": "additive-within-v1"
     },
     {
+      "name": "mcp-conformance",
+      "schema_version": "deepr-mcp-conformance-v1",
+      "kind": "deepr.mcp.conformance",
+      "path": "mcp-conformance-v1.json",
+      "status": "experimental",
+      "compatibility": "additive-within-v1"
+    },
+    {
       "name": "mcp-consult-validation",
       "schema_version": "deepr-mcp-consult-validation-v1",
       "kind": "deepr.mcp.consult_validation",

--- a/src/deepr/cli/commands/mcp.py
+++ b/src/deepr/cli/commands/mcp.py
@@ -5,6 +5,7 @@ import sys
 import click
 
 from deepr.cli.async_runner import run_async_command
+from deepr.cli.commands.mcp_conformance import conformance
 from deepr.cli.commands.mcp_consult_validation import validate_consult_fleet
 from deepr.cli.commands.mcp_conversation_validation import validate_conversation
 
@@ -17,6 +18,7 @@ def mcp():
     pass
 
 
+mcp.add_command(conformance)
 mcp.add_command(validate_consult_fleet)
 mcp.add_command(validate_conversation)
 

--- a/src/deepr/cli/commands/mcp_conformance.py
+++ b/src/deepr/cli/commands/mcp_conformance.py
@@ -1,0 +1,55 @@
+"""CLI: offline machine-checkable MCP conformance report."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+
+@click.command("conformance")
+@click.option("--json", "as_json", is_flag=True, help="Emit the versioned conformance payload as JSON.")
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, path_type=str),
+    help="Write the full JSON report to a file.",
+)
+def conformance(as_json: bool, output: str | None) -> None:
+    """Run offline MCP host-interop conformance checks ($0, no network, no model).
+
+    Proves dual-era protocol constants, offline consult form contracts, remote
+    smoke fail-closed posture, managed conversation fail-closed posture,
+    registration-manifest offline shape, and the capabilities map. Does not
+    score semantic answer quality and does not open remote connections.
+    """
+    from pathlib import Path
+
+    from deepr.mcp.conformance import run_offline_mcp_conformance
+
+    try:
+        report = run_offline_mcp_conformance()
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    payload = report.to_dict()
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    if output:
+        Path(output).write_text(text, encoding="utf-8")
+        if not as_json:
+            click.echo(f"Wrote MCP conformance report: {output}")
+
+    if as_json:
+        click.echo(text, nl=False)
+    elif not output:
+        click.echo(f"MCP offline conformance (server {report.server_version})")
+        click.echo(f"Protocol: modern {payload['protocol']['modern']}; legacy {payload['protocol']['legacy']}")
+        for check in report.checks:
+            state = "ok" if check.status == "passed" else "fail"
+            click.echo(f"[{state}] {check.name}: {check.detail}")
+        click.echo("Result: passed" if report.ok else "Result: failed")
+        click.echo("Cost: $0.0000 (offline; no network; no model)")
+
+    if not report.ok:
+        sys.exit(1)

--- a/src/deepr/mcp/conformance.py
+++ b/src/deepr/mcp/conformance.py
@@ -232,9 +232,10 @@ def _check_managed_conversation_fail_closed() -> ConformanceCheck:
             f"remote_tool_call_attempted={payload.get('remote_tool_call_attempted')!r}",
             expected=expected,
         )
-    error = payload.get("error") if isinstance(payload.get("error"), dict) else {}
-    code = error.get("error_code", "")
-    if "BLOCKED" not in str(code):
+    error_raw = payload.get("error")
+    error: dict[str, Any] = error_raw if isinstance(error_raw, dict) else {}
+    code = str(error.get("error_code", "") or "")
+    if "BLOCKED" not in code:
         return _failed(
             "managed_conversation_fail_closed",
             f"error_code={code!r} is not a blocked posture",

--- a/src/deepr/mcp/conformance.py
+++ b/src/deepr/mcp/conformance.py
@@ -1,0 +1,352 @@
+"""Offline, machine-checkable MCP host-interop conformance report.
+
+Aggregates form and side-effect checks that prove Deepr's dual-era MCP posture
+without opening remote connections, calling models, or spending money. Semantic
+answer quality is intentionally out of scope (AGENTIC_BALANCE).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from deepr.mcp.consult_validation import run_offline_consult_validation
+from deepr.mcp.protocol_compat import LEGACY_METHOD_MAP
+from deepr.mcp.protocol_modern import (
+    LEGACY_PROTOCOL_VERSIONS,
+    MODERN_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+)
+from deepr.mcp.smoke import build_http_registration_manifest, run_http_smoke
+
+CONFORMANCE_SCHEMA_VERSION = "deepr-mcp-conformance-v1"
+CONFORMANCE_KIND = "deepr.mcp.conformance"
+
+CheckStatus = Literal["passed", "failed"]
+
+_PROBE_URL = "http://127.0.0.1:9/mcp"
+
+
+@dataclass(frozen=True)
+class ConformanceCheck:
+    """One deterministic form or side-effect assertion."""
+
+    name: str
+    status: CheckStatus
+    detail: str
+    expected: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+            "expected": self.expected,
+        }
+
+
+@dataclass(frozen=True)
+class MCPConformanceReport:
+    """Secret-free offline conformance rollup."""
+
+    checks: tuple[ConformanceCheck, ...]
+    generated_at: datetime
+    server_version: str
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.checks) and all(check.status == "passed" for check in self.checks)
+
+    def to_dict(self) -> dict[str, Any]:
+        failed = [check.name for check in self.checks if check.status != "passed"]
+        return {
+            "schema_version": CONFORMANCE_SCHEMA_VERSION,
+            "kind": CONFORMANCE_KIND,
+            "generated_at": self.generated_at.isoformat(),
+            "server_version": self.server_version,
+            "mode": "offline",
+            "ok": self.ok,
+            "cost_usd": 0.0,
+            "contract": {
+                "cost_usd": 0.0,
+                "network_opened": False,
+                "calls_metered_api": False,
+                "writes_state": False,
+                "semantic_verdict": False,
+                "checks_form_and_side_effects_only": True,
+                "live_model_required": False,
+            },
+            "protocol": {
+                "modern": MODERN_PROTOCOL_VERSION,
+                "legacy": list(LEGACY_PROTOCOL_VERSIONS),
+                "supported": list(SUPPORTED_PROTOCOL_VERSIONS),
+            },
+            "summary": {
+                "ok": self.ok,
+                "check_count": len(self.checks),
+                "failed_checks": failed,
+            },
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+def _passed(name: str, detail: str, *, expected: str) -> ConformanceCheck:
+    return ConformanceCheck(name=name, status="passed", detail=detail, expected=expected)
+
+
+def _failed(name: str, detail: str, *, expected: str) -> ConformanceCheck:
+    return ConformanceCheck(name=name, status="failed", detail=detail, expected=expected)
+
+
+def _check_dual_era_protocol() -> ConformanceCheck:
+    expected = f"modern={MODERN_PROTOCOL_VERSION}; legacy includes {', '.join(LEGACY_PROTOCOL_VERSIONS)}"
+    if MODERN_PROTOCOL_VERSION != "2026-07-28":
+        return _failed(
+            "dual_era_protocol",
+            f"modern version is {MODERN_PROTOCOL_VERSION!r}",
+            expected=expected,
+        )
+    if MODERN_PROTOCOL_VERSION not in SUPPORTED_PROTOCOL_VERSIONS:
+        return _failed(
+            "dual_era_protocol",
+            "modern version missing from SUPPORTED_PROTOCOL_VERSIONS",
+            expected=expected,
+        )
+    missing_legacy = [v for v in LEGACY_PROTOCOL_VERSIONS if v not in SUPPORTED_PROTOCOL_VERSIONS]
+    if missing_legacy:
+        return _failed(
+            "dual_era_protocol",
+            f"legacy versions missing from supported list: {missing_legacy}",
+            expected=expected,
+        )
+    if not LEGACY_METHOD_MAP:
+        return _failed(
+            "dual_era_protocol",
+            "legacy method alias map is empty",
+            expected=expected,
+        )
+    bad_aliases = {
+        legacy: canonical for legacy, canonical in LEGACY_METHOD_MAP.items() if not str(canonical).startswith("deepr_")
+    }
+    if bad_aliases:
+        return _failed(
+            "dual_era_protocol",
+            f"legacy aliases must map to deepr_ tools: {bad_aliases}",
+            expected=expected,
+        )
+    return _passed(
+        "dual_era_protocol",
+        (f"supported {list(SUPPORTED_PROTOCOL_VERSIONS)}; {len(LEGACY_METHOD_MAP)} legacy tool aliases"),
+        expected=expected,
+    )
+
+
+def _check_offline_consult() -> ConformanceCheck:
+    expected = "offline consult validation summary.ok=true with cost_usd=0"
+    try:
+        report = run_offline_consult_validation()
+        payload = report.to_dict()
+    except Exception as exc:
+        return _failed("offline_consult_validation", f"{type(exc).__name__}: {exc}", expected=expected)
+    summary = payload.get("summary") if isinstance(payload, dict) else None
+    ok = isinstance(summary, dict) and summary.get("ok") is True
+    contract = payload.get("contract") if isinstance(payload, dict) else {}
+    cost = contract.get("cost_usd") if isinstance(contract, dict) else None
+    if not ok:
+        failed = summary.get("failed_checks") if isinstance(summary, dict) else []
+        return _failed(
+            "offline_consult_validation",
+            f"summary.ok is not true; failed_checks={failed!r}",
+            expected=expected,
+        )
+    if cost != 0.0:
+        return _failed(
+            "offline_consult_validation",
+            f"contract.cost_usd={cost!r}",
+            expected=expected,
+        )
+    check_count = summary.get("check_count") if isinstance(summary, dict) else 0
+    return _passed(
+        "offline_consult_validation",
+        f"{check_count} form checks passed; cost_usd=0.0",
+        expected=expected,
+    )
+
+
+def _check_remote_smoke_fail_closed() -> ConformanceCheck:
+    expected = "smoke blocked before network; remote_tool_call_attempted=false"
+    try:
+        report = asyncio.run(run_http_smoke(_PROBE_URL))
+        payload = report.to_dict()
+    except Exception as exc:
+        return _failed("remote_smoke_fail_closed", f"{type(exc).__name__}: {exc}", expected=expected)
+    contract = payload.get("contract") if isinstance(payload, dict) else {}
+    network_opened = contract.get("network_opened") if isinstance(contract, dict) else None
+    remote_attempted = contract.get("remote_tool_call_attempted") if isinstance(contract, dict) else None
+    # Pass means the gate blocked: report.ok is False and no network/tool attempt.
+    if payload.get("ok") is True:
+        return _failed(
+            "remote_smoke_fail_closed",
+            "smoke reported ok=true without cost authority proof",
+            expected=expected,
+        )
+    if network_opened is not False or remote_attempted is not False:
+        return _failed(
+            "remote_smoke_fail_closed",
+            f"network_opened={network_opened!r} remote_tool_call_attempted={remote_attempted!r}",
+            expected=expected,
+        )
+    return _passed(
+        "remote_smoke_fail_closed",
+        "remote smoke blocked with no network open",
+        expected=expected,
+    )
+
+
+def _check_managed_conversation_fail_closed() -> ConformanceCheck:
+    expected = "managed loopback conversation validation blocked without cost authority"
+    try:
+        from deepr.mcp.conversation_validation_managed import (
+            run_managed_loopback_conversation_validation,
+        )
+
+        report = asyncio.run(run_managed_loopback_conversation_validation())
+        payload = report.to_dict()
+    except Exception as exc:
+        return _failed(
+            "managed_conversation_fail_closed",
+            f"{type(exc).__name__}: {exc}",
+            expected=expected,
+        )
+    if payload.get("ok") is True:
+        return _failed(
+            "managed_conversation_fail_closed",
+            "managed conversation validation unexpectedly passed",
+            expected=expected,
+        )
+    if payload.get("remote_tool_call_attempted") is not False:
+        return _failed(
+            "managed_conversation_fail_closed",
+            f"remote_tool_call_attempted={payload.get('remote_tool_call_attempted')!r}",
+            expected=expected,
+        )
+    error = payload.get("error") if isinstance(payload.get("error"), dict) else {}
+    code = error.get("error_code", "")
+    if "BLOCKED" not in str(code):
+        return _failed(
+            "managed_conversation_fail_closed",
+            f"error_code={code!r} is not a blocked posture",
+            expected=expected,
+        )
+    return _passed(
+        "managed_conversation_fail_closed",
+        f"blocked with error_code={code}",
+        expected=expected,
+    )
+
+
+def _check_registration_manifest() -> ConformanceCheck:
+    expected = "network-free registration manifest with remote smoke blocked"
+    try:
+        payload = build_http_registration_manifest(_PROBE_URL)
+    except Exception as exc:
+        return _failed("registration_manifest_offline", f"{type(exc).__name__}: {exc}", expected=expected)
+    registration = payload.get("registration") if isinstance(payload, dict) else {}
+    status = registration.get("remote_smoke_status") if isinstance(registration, dict) else None
+    if status != "blocked_pending_cost_authority":
+        return _failed(
+            "registration_manifest_offline",
+            f"remote_smoke_status={status!r}",
+            expected=expected,
+        )
+    operational = payload.get("operational_contract") if isinstance(payload, dict) else {}
+    if (
+        not isinstance(operational, dict)
+        or operational.get("remote_tool_calls_blocked_without_cost_authority") is not True
+    ):
+        return _failed(
+            "registration_manifest_offline",
+            "operational_contract.remote_tool_calls_blocked_without_cost_authority is not true",
+            expected=expected,
+        )
+    return _passed(
+        "registration_manifest_offline",
+        "manifest built without network; remote smoke blocked pending cost authority",
+        expected=expected,
+    )
+
+
+def _check_capabilities_map(*, version: str) -> ConformanceCheck:
+    expected = "deepr-capabilities-v1 map builds with zero-cost synthesis paths"
+    try:
+        from deepr.mcp.capabilities import CAPABILITIES_SCHEMA_VERSION, build_capabilities
+        from deepr.mcp.server import DeeprMCPServer
+
+        server = DeeprMCPServer()
+        payload = build_capabilities(server.store, server.registry, version=version)
+    except Exception as exc:
+        return _failed("capabilities_map", f"{type(exc).__name__}: {exc}", expected=expected)
+    if payload.get("schema_version") != CAPABILITIES_SCHEMA_VERSION:
+        return _failed(
+            "capabilities_map",
+            f"schema_version={payload.get('schema_version')!r}",
+            expected=expected,
+        )
+    zero_cost = payload.get("zero_cost_synthesis") if isinstance(payload, dict) else None
+    if not isinstance(zero_cost, dict) or zero_cost.get("owned") != "local":
+        return _failed(
+            "capabilities_map",
+            f"zero_cost_synthesis={zero_cost!r}",
+            expected=expected,
+        )
+    plans = zero_cost.get("prepaid_plans")
+    if not isinstance(plans, list) or "claude" not in plans:
+        return _failed(
+            "capabilities_map",
+            f"prepaid_plans={plans!r} must include claude",
+            expected=expected,
+        )
+    tools = payload.get("tools") if isinstance(payload, dict) else []
+    tool_count = len(tools) if isinstance(tools, list) else 0
+    return _passed(
+        "capabilities_map",
+        f"{CAPABILITIES_SCHEMA_VERSION} with {tool_count} key tool(s); local+claude zero-cost paths",
+        expected=expected,
+    )
+
+
+def run_offline_mcp_conformance(*, server_version: str | None = None) -> MCPConformanceReport:
+    """Run the offline MCP conformance suite. No network, no model, $0."""
+    version = server_version
+    if not version:
+        try:
+            from deepr import __version__ as package_version
+
+            version = str(package_version)
+        except Exception:
+            version = "unknown"
+
+    checks = (
+        _check_dual_era_protocol(),
+        _check_offline_consult(),
+        _check_remote_smoke_fail_closed(),
+        _check_managed_conversation_fail_closed(),
+        _check_registration_manifest(),
+        _check_capabilities_map(version=version),
+    )
+    return MCPConformanceReport(
+        checks=checks,
+        generated_at=datetime.now(UTC),
+        server_version=version,
+    )
+
+
+__all__ = [
+    "CONFORMANCE_KIND",
+    "CONFORMANCE_SCHEMA_VERSION",
+    "ConformanceCheck",
+    "MCPConformanceReport",
+    "run_offline_mcp_conformance",
+]

--- a/src/deepr/mcp/conformance.py
+++ b/src/deepr/mcp/conformance.py
@@ -1,7 +1,8 @@
 """Offline, machine-checkable MCP host-interop conformance report.
 
 Aggregates form and side-effect checks that prove Deepr's dual-era MCP posture
-without opening remote connections, calling models, or spending money. Semantic
+without opening remote connections, calling models, spending money, or starting
+the full MCP server (no expert-store session, no durable job state). Semantic
 answer quality is intentionally out of scope (AGENTIC_BALANCE).
 """
 
@@ -283,10 +284,18 @@ def _check_capabilities_map(*, version: str) -> ConformanceCheck:
     expected = "deepr-capabilities-v1 map builds with zero-cost synthesis paths"
     try:
         from deepr.mcp.capabilities import CAPABILITIES_SCHEMA_VERSION, build_capabilities
-        from deepr.mcp.server import DeeprMCPServer
+        from deepr.mcp.search.registry import create_default_registry
+        from deepr.mcp.server import _register_new_tools
 
-        server = DeeprMCPServer()
-        payload = build_capabilities(server.store, server.registry, version=version)
+        class _EmptyExpertStore:
+            """Read-only empty roster; no filesystem or network side effects."""
+
+            def list_all(self) -> list[Any]:
+                return []
+
+        registry = create_default_registry()
+        _register_new_tools(registry)
+        payload = build_capabilities(_EmptyExpertStore(), registry, version=version)
     except Exception as exc:
         return _failed("capabilities_map", f"{type(exc).__name__}: {exc}", expected=expected)
     if payload.get("schema_version") != CAPABILITIES_SCHEMA_VERSION:

--- a/tests/unit/test_mcp/test_conformance.py
+++ b/tests/unit/test_mcp/test_conformance.py
@@ -1,0 +1,78 @@
+"""Offline MCP conformance suite tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from deepr.cli.commands.mcp import mcp
+from deepr.mcp.conformance import (
+    CONFORMANCE_KIND,
+    CONFORMANCE_SCHEMA_VERSION,
+    run_offline_mcp_conformance,
+)
+from deepr.mcp.protocol_modern import MODERN_PROTOCOL_VERSION
+
+
+def test_offline_mcp_conformance_passes_without_network_or_model() -> None:
+    report = run_offline_mcp_conformance(server_version="test")
+    payload = report.to_dict()
+
+    assert report.ok is True
+    assert payload["schema_version"] == CONFORMANCE_SCHEMA_VERSION
+    assert payload["kind"] == CONFORMANCE_KIND
+    assert payload["mode"] == "offline"
+    assert payload["cost_usd"] == 0.0
+    assert payload["contract"]["network_opened"] is False
+    assert payload["contract"]["calls_metered_api"] is False
+    assert payload["contract"]["live_model_required"] is False
+    assert payload["protocol"]["modern"] == MODERN_PROTOCOL_VERSION
+    assert payload["summary"]["ok"] is True
+    assert payload["summary"]["failed_checks"] == []
+    names = {check["name"] for check in payload["checks"]}
+    assert names == {
+        "dual_era_protocol",
+        "offline_consult_validation",
+        "remote_smoke_fail_closed",
+        "managed_conversation_fail_closed",
+        "registration_manifest_offline",
+        "capabilities_map",
+    }
+    assert all(check["status"] == "passed" for check in payload["checks"])
+
+
+def test_mcp_conformance_cli_json_exit_zero() -> None:
+    result = CliRunner().invoke(mcp, ["conformance", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["schema_version"] == CONFORMANCE_SCHEMA_VERSION
+    assert payload["summary"]["failed_checks"] == []
+
+
+def test_mcp_conformance_cli_writes_output_file(tmp_path: Path) -> None:
+    out = tmp_path / "conformance.json"
+    result = CliRunner().invoke(mcp, ["conformance", "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "Wrote MCP conformance report" in result.output
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["kind"] == CONFORMANCE_KIND
+
+
+def test_published_mcp_conformance_schema_matches_payload() -> None:
+    schema_path = (
+        Path(__file__).resolve().parents[3] / "docs" / "schemas" / "mcp-conformance-v1.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    payload = run_offline_mcp_conformance(server_version="2.42.0").to_dict()
+    assert schema["properties"]["schema_version"]["const"] == payload["schema_version"]
+    assert schema["properties"]["kind"]["const"] == payload["kind"]
+    assert schema["properties"]["mode"]["const"] == payload["mode"]
+    assert schema["properties"]["protocol"]["properties"]["modern"]["const"] == payload["protocol"][
+        "modern"
+    ]
+    for key in schema["required"]:
+        assert key in payload


### PR DESCRIPTION
## Summary
- Add `deepr mcp conformance` offline rollup (`deepr-mcp-conformance-v1`) proving dual-era MCP 2026-07-28 posture, consult form contracts, remote smoke and managed conversation fail-closed gates, registration-manifest offline shape, and capabilities map at $0 with no network or model.
- Publish schema + registry entry; unit and CLI tests.
- Bring operator docs to August 2026 readiness: Supported Surface v2.42.0, MCP agent guide conformance matrix, plan-quota empty ANTHROPIC_API_KEY mask for dotenv, README entry point.

## Test plan
- [x] pytest tests/unit/test_mcp/test_conformance.py
- [x] ruff check/format on new modules
- [x] scripts/check_docs_consistency.py
- [x] scripts/check_file_sizes.py
- [x] deepr mcp conformance 6/6 ok
- [ ] CI green on PR