### PR TITLE
release: v2.43.0 MCP conformance and approach contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/blisspixel/deepr/actions/workflows/ci.yml/badge.svg)](https://github.com/blisspixel/deepr/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.42.0-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.42.0)
+[![Version](https://img.shields.io/badge/version-2.43.0-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.43.0)
 
 **Persistent domain experts built from bounded, auditable research.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -364,7 +364,17 @@ reliable product, not a four-language architecture diagram.
 
 ---
 
-## Current Status (v2.42.0)
+## Current Status (v2.43.0)
+
+**v2.43.0 additions:** offline machine-checkable MCP host-interop conformance
+(`deepr mcp conformance`, `deepr-mcp-conformance-v1`) proving dual-era
+`2026-07-28` protocol constants, offline consult form contracts, remote smoke
+and managed-conversation fail-closed postures, registration-manifest offline
+shape, and the capabilities map at `$0` with no network or model. Approach
+contract (`docs/APPROACH.md`) freezes open-source method claims and refusals.
+Plan-quota operator guidance documents empty `ANTHROPIC_API_KEY` process
+masking so `.env` cannot reintroduce a metered credential. Paid dispatch
+remains frozen.
 
 **v2.42.0 additions:** durable spend dispositions close historical orphaned
 settled spend without ledger rewrite (`costs doctor` matched/disposed/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.43.0] - 2026-08-02
+
 ### Added
 
 - [Approach contract](APPROACH.md): normative open-source method claims,
@@ -18,15 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   postures, registration-manifest offline shape, and the capabilities map.
   No network, no model, `$0`. Documented in
   [MCP_AGENT_TEST_GUIDE.md](MCP_AGENT_TEST_GUIDE.md) and
-  [SUPPORTED_SURFACE.md](SUPPORTED_SURFACE.md).
+  [SUPPORTED_SURFACE.md](SUPPORTED_SURFACE.md). Dual-era MCP `2026-07-28`
+  support remains the protocol baseline from v2.41.0; this release makes the
+  offline proof operator-facing and machine-checkable.
 
 ### Changed
 
-- Supported Surface status advanced to v2.42.0 / 2026-08-01 with dual-era MCP,
+- Supported Surface status advanced to v2.43.0 / 2026-08-02 with dual-era MCP,
   offline conformance, spend dispositions, and parent-budget substrate
   language. Plan-quota operator guidance clarifies empty
   `ANTHROPIC_API_KEY` process masking so `.env` cannot reintroduce a metered
   credential.
+- Demo CLI screenshot and render script for README (fictional session data).
 
 ## [2.42.0] - 2026-07-31
 

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,6 +1,6 @@
 # Supported Surface
 
-Status: v2.42.0 current main, 2026-08-01. This document defines what users and host
+Status: v2.43.0 current main, 2026-08-02. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
 data remains portable if development stops. Production metered dispatch remains
 frozen since v2.40 until provider account-control adapters land.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepr-research"
-version = "2.42.0"
+version = "2.43.0"
 description = "Research automation platform that replicates human research team workflows using AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/deepr/__init__.py
+++ b/src/deepr/__init__.py
@@ -5,7 +5,7 @@ Keep package import lightweight by lazily importing heavy modules.
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "2.42.0"
+__version__ = "2.43.0"
 __author__ = "Nick Seal"
 
 if TYPE_CHECKING:

--- a/tests/unit/test_mcp/test_conformance.py
+++ b/tests/unit/test_mcp/test_conformance.py
@@ -67,12 +67,13 @@ def test_published_mcp_conformance_schema_matches_payload() -> None:
         Path(__file__).resolve().parents[3] / "docs" / "schemas" / "mcp-conformance-v1.json"
     )
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    payload = run_offline_mcp_conformance(server_version="2.43.0").to_dict()
+    payload = run_offline_mcp_conformance().to_dict()
     assert schema["properties"]["schema_version"]["const"] == payload["schema_version"]
     assert schema["properties"]["kind"]["const"] == payload["kind"]
     assert schema["properties"]["mode"]["const"] == payload["mode"]
     assert schema["properties"]["protocol"]["properties"]["modern"]["const"] == payload["protocol"][
         "modern"
     ]
+    assert payload["server_version"]  # package metadata default, not a pinned release string
     for key in schema["required"]:
         assert key in payload

--- a/tests/unit/test_mcp/test_conformance.py
+++ b/tests/unit/test_mcp/test_conformance.py
@@ -67,7 +67,7 @@ def test_published_mcp_conformance_schema_matches_payload() -> None:
         Path(__file__).resolve().parents[3] / "docs" / "schemas" / "mcp-conformance-v1.json"
     )
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    payload = run_offline_mcp_conformance(server_version="2.42.0").to_dict()
+    payload = run_offline_mcp_conformance(server_version="2.43.0").to_dict()
     assert schema["properties"]["schema_version"]["const"] == payload["schema_version"]
     assert schema["properties"]["kind"]["const"] == payload["kind"]
     assert schema["properties"]["mode"]["const"] == payload["mode"]


### PR DESCRIPTION
## Summary
- Bump package to **2.43.0** and cut release notes for work already on main after v2.42.0.
- Highlights: offline `deepr mcp conformance` (dual-era MCP `2026-07-28` host-interop proof), approach contract, plan-quota dotenv key masking docs, README demo screenshot.
- Paid dispatch remains frozen.

## Test plan
- [x] pytest conformance + version metadata tests
- [x] check_docs_consistency
- [ ] CI green
- [ ] After merge: tag `v2.43.0`, build wheel/sdist, publish GH release assets
