### PR TITLE
feat: surface offline MCP conformance in doctor and host guides

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `deepr doctor` includes offline MCP host-interop conformance under the MCP
+  category (`deepr mcp conformance` form and side-effect rollup, $0).
+- MCP interop checklist, MCP README, and agent-guide operator preflight point
+  hosts at `deepr mcp conformance` as the dual-era proof gate (v2.43.0 baseline).
+
 ## [2.43.0] - 2026-08-02
 
 ### Added

--- a/docs/MCP_A2A_INTEROP_CHECKLIST.md
+++ b/docs/MCP_A2A_INTEROP_CHECKLIST.md
@@ -1,10 +1,27 @@
 # MCP and A2A Interop Checklist
 
-Status: current with Deepr v2.41.0. Last reviewed: 2026-07-31.
+Status: current with Deepr v2.43.0. Last reviewed: 2026-08-02.
 
 Use this checklist when connecting Deepr experts to another agent host through
 MCP or A2A. It is a compact integration review, not the command guide. For
 copy-ready validation commands, use [MCP_AGENT_TEST_GUIDE.md](MCP_AGENT_TEST_GUIDE.md).
+
+## Operator preflight (offline, $0)
+
+Before handing Deepr to a host agent, prove the dual-era form and side-effect
+posture on the operator machine:
+
+```powershell
+deepr mcp conformance --json
+deepr doctor --skip-connectivity
+```
+
+`deepr mcp conformance` must report `ok=true` with
+`schema_version="deepr-mcp-conformance-v1"`. It checks modern `2026-07-28`
+protocol constants, offline consult form contracts, remote smoke fail-closed,
+managed conversation fail-closed, registration-manifest offline shape, and the
+capabilities map. No network, no model, no semantic scoring. `deepr doctor`
+includes the same offline MCP conformance check under the MCP category.
 
 ## Current Sources
 
@@ -25,8 +42,9 @@ copy-ready validation commands, use [MCP_AGENT_TEST_GUIDE.md](MCP_AGENT_TEST_GUI
   `deepr_tool_search` or `deepr_capabilities` instead of assuming a fixed full
   tool list. Modern clients can call `server/discover` first for supported
   versions, capabilities, and identity in one request.
-- Deepr's MCP server is dual-era as of v2.41.0. Modern `2026-07-28` requests
-  carry `io.modelcontextprotocol/protocolVersion` and
+- Deepr's MCP server is dual-era (protocol baseline v2.41.0; offline proof
+  surface v2.43.0). Modern `2026-07-28` requests carry
+  `io.modelcontextprotocol/protocolVersion` and
   `io.modelcontextprotocol/clientCapabilities` in `params._meta` on every
   request and get the stateless envelope (`resultType`, result `serverInfo`
   `_meta`, `ttlMs`/`cacheScope` on cacheable methods). Legacy clients keep the

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ understand why it works the way it does.
 - **[design/local-structured-consult-graph.md](design/local-structured-consult-graph.md)** - Eval-only bounded local expert-position graph and promotion gates
 - **[MODELS.md](MODELS.md)** - Model selection and provider guide
 - **[../mcp/README.md](../mcp/README.md)** - MCP server setup and tools
+- **[MCP_AGENT_TEST_GUIDE.md](MCP_AGENT_TEST_GUIDE.md)** - No-surprise-cost agent test path and `deepr mcp conformance`
 - **[MCP_A2A_INTEROP_CHECKLIST.md](MCP_A2A_INTEROP_CHECKLIST.md)** - Current MCP and A2A host interop review checklist
 
 ## Technical

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,6 +4,16 @@
 
 Deepr exposes research and expert capabilities via Model Context Protocol (MCP) for AI agents including OpenClaw, Claude Desktop, Cursor, VS Code, and Zed. For a no-surprise-cost agent test path, see [docs/MCP_AGENT_TEST_GUIDE.md](../docs/MCP_AGENT_TEST_GUIDE.md).
 
+**Operator preflight (offline, $0):**
+
+```powershell
+deepr mcp conformance --json
+```
+
+This proves dual-era MCP `2026-07-28` host-interop form and side-effect posture
+(no network, no model). Also covered by `deepr doctor --skip-connectivity`.
+Interop review checklist: [docs/MCP_A2A_INTEROP_CHECKLIST.md](../docs/MCP_A2A_INTEROP_CHECKLIST.md).
+
 ---
 
 ## For the consuming agent (start here)

--- a/src/deepr/cli/commands/doctor.py
+++ b/src/deepr/cli/commands/doctor.py
@@ -519,13 +519,13 @@ def check_mcp_conformance() -> list[DiagnosticCheck]:
         report = run_offline_mcp_conformance()
         payload = report.to_dict()
         summary = payload.get("summary") if isinstance(payload, dict) else {}
+        protocol = payload.get("protocol") if isinstance(payload, dict) else {}
         failed = summary.get("failed_checks") if isinstance(summary, dict) else []
+        modern = protocol.get("modern", "?") if isinstance(protocol, dict) else "?"
+        check_count = summary.get("check_count", len(report.checks)) if isinstance(summary, dict) else len(report.checks)
         if report.ok:
             check.passed = True
-            check.message = (
-                f"ok ({summary.get('check_count', len(report.checks))} checks; "
-                f"modern {payload.get('protocol', {}).get('modern', '?')})"
-            )
+            check.message = f"ok ({check_count} checks; modern {modern})"
             check.details.append("Run: deepr mcp conformance --json")
             check.details.append("No network, no model, $0; form and side-effect posture only")
         else:

--- a/src/deepr/cli/commands/doctor.py
+++ b/src/deepr/cli/commands/doctor.py
@@ -401,7 +401,7 @@ def doctor(skip_connectivity: bool):
             raise click.ClickException("Could not load configuration. Review local settings and retry.") from exc
 
         # Run all checks
-        with click.progressbar(length=7, label="Running checks") as bar:
+        with click.progressbar(length=9, label="Running checks") as bar:
             all_checks.extend(await check_api_keys(config))
             bar.update(1)
 
@@ -425,6 +425,9 @@ def doctor(skip_connectivity: bool):
             bar.update(1)
 
             all_checks.extend(check_spend_integrity())
+            bar.update(1)
+
+            all_checks.extend(check_mcp_conformance())
             bar.update(1)
 
         # Print results
@@ -505,6 +508,37 @@ def check_native_instruments() -> list[DiagnosticCheck]:
     checks.append(check)
 
     return checks
+
+
+def check_mcp_conformance() -> list[DiagnosticCheck]:
+    """Offline dual-era MCP host-interop posture ($0, no network, no model)."""
+    check = DiagnosticCheck("MCP offline conformance", "MCP")
+    try:
+        from deepr.mcp.conformance import run_offline_mcp_conformance
+
+        report = run_offline_mcp_conformance()
+        payload = report.to_dict()
+        summary = payload.get("summary") if isinstance(payload, dict) else {}
+        failed = summary.get("failed_checks") if isinstance(summary, dict) else []
+        if report.ok:
+            check.passed = True
+            check.message = (
+                f"ok ({summary.get('check_count', len(report.checks))} checks; "
+                f"modern {payload.get('protocol', {}).get('modern', '?')})"
+            )
+            check.details.append("Run: deepr mcp conformance --json")
+            check.details.append("No network, no model, $0; form and side-effect posture only")
+        else:
+            check.message = f"failed: {', '.join(failed) if failed else 'unknown'}"
+            check.details.append("Run: deepr mcp conformance --json")
+            for item in report.checks:
+                if item.status != "passed":
+                    check.details.append(f"{item.name}: {item.detail}")
+    except Exception as exc:
+        check.message = f"probe error: {type(exc).__name__}"
+        check.details.append(str(exc)[:120])
+        check.details.append("Run: deepr mcp conformance --json")
+    return [check]
 
 
 def check_storage_locations() -> list[DiagnosticCheck]:

--- a/src/deepr/cli/commands/doctor.py
+++ b/src/deepr/cli/commands/doctor.py
@@ -522,7 +522,9 @@ def check_mcp_conformance() -> list[DiagnosticCheck]:
         protocol = payload.get("protocol") if isinstance(payload, dict) else {}
         failed = summary.get("failed_checks") if isinstance(summary, dict) else []
         modern = protocol.get("modern", "?") if isinstance(protocol, dict) else "?"
-        check_count = summary.get("check_count", len(report.checks)) if isinstance(summary, dict) else len(report.checks)
+        check_count = (
+            summary.get("check_count", len(report.checks)) if isinstance(summary, dict) else len(report.checks)
+        )
         if report.ok:
             check.passed = True
             check.message = f"ok ({check_count} checks; modern {modern})"

--- a/src/deepr/cli/commands/mcp.py
+++ b/src/deepr/cli/commands/mcp.py
@@ -206,15 +206,19 @@ Run this on the machine that owns the Deepr experts:
 
 ```powershell
 cd C:\\GitHub\\deepr
+# Offline dual-era host-interop proof ($0, no network, no model)
+.\\.venv\\Scripts\\deepr.exe mcp conformance --json
 $env:DEEPR_MCP_KEYS_PATH = "{keys_path}"
 .\\.venv\\Scripts\\deepr.exe mcp serve --http --host {bind_host} --port {port} --path {normalized_path} --keys-path $env:DEEPR_MCP_KEYS_PATH
 ```
 
-Smoke test:
+Remote smoke is intentionally fail-closed until cost authority is proven:
 
 ```powershell
 .\\.venv\\Scripts\\deepr.exe mcp smoke-http {endpoint} --auth-token "{token}"
 ```
+
+Expected: blocked report with network_opened=false (not a green remote probe).
 
 Scoped key:
 

--- a/src/deepr/cli/commands/mcp.py
+++ b/src/deepr/cli/commands/mcp.py
@@ -168,101 +168,23 @@ def _build_agent_guide_text(
     synthesis_backend: str,
     plan: str | None,
 ) -> str:
-    import json
+    from deepr.cli.commands.mcp_agent_guide_text import build_agent_guide_text
 
-    arguments: dict[str, object] = {
-        "_approved": True,
-        "question": "What should the current project do next?",
-        "max_experts": 3,
-        "synthesis_backend": synthesis_backend,
-        "budget": 0,
-    }
-    if experts:
-        arguments["experts"] = list(experts)
-    if synthesis_backend == "plan" and plan:
-        arguments["plan"] = plan
-    consult_call = {"name": "deepr_consult_experts", "arguments": arguments}
-
-    list_step = (
-        f"2. Use only these experts: {', '.join(experts)}."
-        if experts
-        else "2. Call deepr_list_experts and select one to three relevant experts."
+    return build_agent_guide_text(
+        endpoint=endpoint,
+        token=token,
+        key_id=key_id,
+        bind_host=bind_host,
+        port=port,
+        http_path=http_path,
+        keys_path=keys_path,
+        mode=mode,
+        budget=budget,
+        rate_limit=rate_limit,
+        experts=experts,
+        synthesis_backend=synthesis_backend,
+        plan=plan,
     )
-    info_step = (
-        "3. Call deepr_get_expert_info for one allowed expert with _approved=true."
-        if experts
-        else "3. Call deepr_get_expert_info for at least one selected expert with _approved=true."
-    )
-    key_line = f"Key id: {key_id}" if key_id else "Key id: shared token"
-    budget_line = "none" if budget is None else f"${budget:.2f}"
-    rate_line = "none" if rate_limit is None else f"{rate_limit}/minute"
-    normalized_path = _normalize_mcp_path(http_path)
-
-    return f"""# Deepr MCP Agent Trial
-
-## Operator
-
-Run this on the machine that owns the Deepr experts:
-
-```powershell
-cd C:\\GitHub\\deepr
-# Offline dual-era host-interop proof ($0, no network, no model)
-.\\.venv\\Scripts\\deepr.exe mcp conformance --json
-$env:DEEPR_MCP_KEYS_PATH = "{keys_path}"
-.\\.venv\\Scripts\\deepr.exe mcp serve --http --host {bind_host} --port {port} --path {normalized_path} --keys-path $env:DEEPR_MCP_KEYS_PATH
-```
-
-Remote smoke is intentionally fail-closed until cost authority is proven:
-
-```powershell
-.\\.venv\\Scripts\\deepr.exe mcp smoke-http {endpoint} --auth-token "{token}"
-```
-
-Expected: blocked report with network_opened=false (not a green remote probe).
-
-Scoped key:
-
-```text
-{key_line}
-Mode: {mode}
-Budget: {budget_line}
-Rate limit: {rate_line}
-Token: {token}
-```
-
-## Agent Instructions
-
-Connect to:
-
-```text
-{endpoint}
-```
-
-Use this HTTP header:
-
-```text
-Authorization: Bearer {token}
-```
-
-Rules:
-
-1. First call deepr_tool_search with query "expert list handoff consult".
-{list_step}
-{info_step}
-4. Prefer deepr_expert_handoff for context. Include _approved=true.
-5. Prefer deepr_consult_experts for questions. Use one expert for focused advice or multiple experts for council guidance. Include _approved=true.
-6. Do not call deepr_query_expert, deepr_research, deepr_agentic_research, deepr_expert_absorb, deepr_reflect, deepr_install_skill, or mutating tools.
-7. For consults, force no-metered execution with synthesis_backend="{synthesis_backend}" and budget=0.
-8. Verify capacity.live_metered_fallback=false and cost_usd=0.
-9. If local or plan synthesis is unavailable, return the structured error. Do not retry with API or metered fallback.
-10. Preserve expert disagreement and uncertainty in your consolidated guidance. Deepr experts are perspectives, not a fact list.
-
-Example consult call:
-
-```json
-{json.dumps(consult_call, indent=2)}
-```
-"""
 
 
 def _filter_audit_records(records, *, key_id: str | None, tool_name: str | None, outcome: str | None):

--- a/src/deepr/cli/commands/mcp_agent_guide_text.py
+++ b/src/deepr/cli/commands/mcp_agent_guide_text.py
@@ -1,0 +1,122 @@
+"""Render the operator/agent trial guide for ``deepr mcp agent-guide``."""
+
+from __future__ import annotations
+
+import json
+
+
+def normalize_mcp_path(path: str) -> str:
+    resolved = path.strip() or "/mcp"
+    return resolved if resolved.startswith("/") else f"/{resolved}"
+
+
+def build_agent_guide_text(
+    *,
+    endpoint: str,
+    token: str,
+    key_id: str | None,
+    bind_host: str,
+    port: int,
+    http_path: str,
+    keys_path: str,
+    mode: str,
+    budget: float | None,
+    rate_limit: int | None,
+    experts: tuple[str, ...],
+    synthesis_backend: str,
+    plan: str | None,
+) -> str:
+    """Return the redacted or live agent trial guide body."""
+    arguments: dict[str, object] = {
+        "_approved": True,
+        "question": "What should the current project do next?",
+        "max_experts": 3,
+        "synthesis_backend": synthesis_backend,
+        "budget": 0,
+    }
+    if experts:
+        arguments["experts"] = list(experts)
+    if synthesis_backend == "plan" and plan:
+        arguments["plan"] = plan
+    consult_call = {"name": "deepr_consult_experts", "arguments": arguments}
+
+    list_step = (
+        f"2. Use only these experts: {', '.join(experts)}."
+        if experts
+        else "2. Call deepr_list_experts and select one to three relevant experts."
+    )
+    info_step = (
+        "3. Call deepr_get_expert_info for one allowed expert with _approved=true."
+        if experts
+        else "3. Call deepr_get_expert_info for at least one selected expert with _approved=true."
+    )
+    key_line = f"Key id: {key_id}" if key_id else "Key id: shared token"
+    budget_line = "none" if budget is None else f"${budget:.2f}"
+    rate_line = "none" if rate_limit is None else f"{rate_limit}/minute"
+    normalized_path = normalize_mcp_path(http_path)
+
+    return f"""# Deepr MCP Agent Trial
+
+## Operator
+
+Run this on the machine that owns the Deepr experts:
+
+```powershell
+cd C:\\GitHub\\deepr
+# Offline dual-era host-interop proof ($0, no network, no model)
+.\\.venv\\Scripts\\deepr.exe mcp conformance --json
+$env:DEEPR_MCP_KEYS_PATH = "{keys_path}"
+.\\.venv\\Scripts\\deepr.exe mcp serve --http --host {bind_host} --port {port} --path {normalized_path} --keys-path $env:DEEPR_MCP_KEYS_PATH
+```
+
+Remote smoke is intentionally fail-closed until cost authority is proven:
+
+```powershell
+.\\.venv\\Scripts\\deepr.exe mcp smoke-http {endpoint} --auth-token "{token}"
+```
+
+Expected: blocked report with network_opened=false (not a green remote probe).
+
+Scoped key:
+
+```text
+{key_line}
+Mode: {mode}
+Budget: {budget_line}
+Rate limit: {rate_line}
+Token: {token}
+```
+
+## Agent Instructions
+
+Connect to:
+
+```text
+{endpoint}
+```
+
+Use this HTTP header:
+
+```text
+Authorization: Bearer {token}
+```
+
+Rules:
+
+1. First call deepr_tool_search with query "expert list handoff consult".
+{list_step}
+{info_step}
+4. Prefer deepr_expert_handoff for context. Include _approved=true.
+5. Prefer deepr_consult_experts for questions. Use one expert for focused advice or multiple experts for council guidance. Include _approved=true.
+6. Do not call deepr_query_expert, deepr_research, deepr_agentic_research, deepr_expert_absorb, deepr_reflect, deepr_install_skill, or mutating tools.
+7. For consults, force no-metered execution with synthesis_backend="{synthesis_backend}" and budget=0.
+8. Verify capacity.live_metered_fallback=false and cost_usd=0.
+9. If local or plan synthesis is unavailable, return the structured error. Do not retry with API or metered fallback.
+10. Preserve expert disagreement and uncertainty in your consolidated guidance. Deepr experts are perspectives, not a fact list.
+
+Example consult call:
+
+```json
+{json.dumps(consult_call, indent=2)}
+```
+"""

--- a/src/deepr/mcp/conformance.py
+++ b/src/deepr/mcp/conformance.py
@@ -9,9 +9,11 @@ answer quality is intentionally out of scope (AGENTIC_BALANCE).
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 from deepr.mcp.consult_validation import run_offline_consult_validation
 from deepr.mcp.protocol_compat import LEGACY_METHOD_MAP
@@ -28,6 +30,23 @@ CONFORMANCE_KIND = "deepr.mcp.conformance"
 CheckStatus = Literal["passed", "failed"]
 
 _PROBE_URL = "http://127.0.0.1:9/mcp"
+
+_T = TypeVar("_T")
+
+
+def _run_async(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run a coroutine from sync code, including under an already-running loop.
+
+    Doctor and other callers may invoke the suite from inside asyncio. Using
+    ``asyncio.run`` there raises; a worker thread keeps the check pure and $0.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
 
 
 @dataclass(frozen=True)
@@ -179,7 +198,7 @@ def _check_offline_consult() -> ConformanceCheck:
 def _check_remote_smoke_fail_closed() -> ConformanceCheck:
     expected = "smoke blocked before network; remote_tool_call_attempted=false"
     try:
-        report = asyncio.run(run_http_smoke(_PROBE_URL))
+        report = _run_async(run_http_smoke(_PROBE_URL))
         payload = report.to_dict()
     except Exception as exc:
         return _failed("remote_smoke_fail_closed", f"{type(exc).__name__}: {exc}", expected=expected)
@@ -213,7 +232,7 @@ def _check_managed_conversation_fail_closed() -> ConformanceCheck:
             run_managed_loopback_conversation_validation,
         )
 
-        report = asyncio.run(run_managed_loopback_conversation_validation())
+        report = _run_async(run_managed_loopback_conversation_validation())
         payload = report.to_dict()
     except Exception as exc:
         return _failed(
@@ -283,9 +302,30 @@ def _check_registration_manifest() -> ConformanceCheck:
 def _check_capabilities_map(*, version: str) -> ConformanceCheck:
     expected = "deepr-capabilities-v1 map builds with zero-cost synthesis paths"
     try:
-        from deepr.mcp.capabilities import CAPABILITIES_SCHEMA_VERSION, build_capabilities
-        from deepr.mcp.search.registry import create_default_registry
-        from deepr.mcp.server import _register_new_tools
+        from deepr.mcp.capabilities import (
+            _KEY_TOOLS,
+            CAPABILITIES_SCHEMA_VERSION,
+            build_capabilities,
+        )
+        from deepr.mcp.search.registry import ToolRegistry, ToolSchema
+    except Exception as exc:
+        return _failed("capabilities_map", f"{type(exc).__name__}: {exc}", expected=expected)
+
+    try:
+        # Build a minimal registry with only key tools so optional skill/docx
+        # deps are never imported (CI core-install has no optional extras).
+        registry = ToolRegistry()
+        for name, use_when in _KEY_TOOLS:
+            del use_when
+            registry.register(
+                ToolSchema(
+                    name=name,
+                    description=name,
+                    input_schema={"type": "object", "properties": {}},
+                    category="system",
+                    cost_tier="free",
+                )
+            )
 
         class _EmptyExpertStore:
             """Read-only empty roster; no filesystem or network side effects."""
@@ -293,8 +333,6 @@ def _check_capabilities_map(*, version: str) -> ConformanceCheck:
             def list_all(self) -> list[Any]:
                 return []
 
-        registry = create_default_registry()
-        _register_new_tools(registry)
         payload = build_capabilities(_EmptyExpertStore(), registry, version=version)
     except Exception as exc:
         return _failed("capabilities_map", f"{type(exc).__name__}: {exc}", expected=expected)

--- a/tests/unit/test_cli/test_doctor_command.py
+++ b/tests/unit/test_cli/test_doctor_command.py
@@ -97,6 +97,18 @@ class TestDoctorChecks:
         assert any("one writer at a time" in detail.lower() for detail in expert_check.details)
         assert any("wait for sync" in detail.lower() for detail in expert_check.details)
 
+    def test_mcp_conformance_check_passes_offline(self):
+        from deepr.cli.commands.doctor import check_mcp_conformance
+
+        checks = check_mcp_conformance()
+        assert len(checks) == 1
+        check = checks[0]
+        assert check.name == "MCP offline conformance"
+        assert check.category == "MCP"
+        assert check.passed is True
+        assert "2026-07-28" in check.message or "ok" in check.message.lower()
+        assert any("mcp conformance" in detail.lower() for detail in check.details)
+
     async def test_database_check_surfaces_stale_queue_candidates_read_only(self, tmp_path):
         from deepr.cli.commands.doctor import check_database
         from deepr.queue import ResearchJob, SQLiteQueue

--- a/tests/unit/test_cli/test_mcp_agent_guide.py
+++ b/tests/unit/test_cli/test_mcp_agent_guide.py
@@ -40,6 +40,8 @@ def test_mcp_agent_guide_creates_scoped_zero_budget_key(tmp_path):
     assert "deepr_consult_experts" in guide
     assert "capacity.live_metered_fallback=false" in guide
     assert "cost_usd=0" in guide
+    assert "mcp conformance" in guide
+    assert "network_opened=false" in guide
     assert "one expert for focused advice or multiple experts for council guidance" in guide
     assert "Preserve expert disagreement and uncertainty" in guide
     assert "deepr_mcp_" not in keys_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- `deepr doctor` runs offline MCP host-interop conformance (, no network, no model).
- Agent-guide operator preflight, MCP README, and A2A interop checklist point at `deepr mcp conformance` as the dual-era proof gate.
- Docs index links the MCP agent test guide.

## Test plan
- [x] unit doctor MCP check
- [x] agent-guide tests
- [ ] CI green
