### PR TITLE
release: v2.43.1 doctor MCP host-interop preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/blisspixel/deepr/actions/workflows/ci.yml/badge.svg)](https://github.com/blisspixel/deepr/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.43.0-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.43.0)
+[![Version](https://img.shields.io/badge/version-2.43.1-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.43.1)
 
 **Persistent domain experts built from bounded, auditable research.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -368,7 +368,7 @@ reliable product, not a four-language architecture diagram.
 
 **v2.43.1 additions:** `deepr doctor` surfaces offline MCP host-interop
 conformance under the MCP category; interop checklist, MCP README, and
-agent-guide preflight treat `deepr mcp conformance` as the dual-era proof
+agent-guide preflight treats `deepr mcp conformance` as the dual-era proof
 gate. Paid dispatch remains frozen.
 
 **v2.43.0 additions:** offline machine-checkable MCP host-interop conformance

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -364,7 +364,12 @@ reliable product, not a four-language architecture diagram.
 
 ---
 
-## Current Status (v2.43.0)
+## Current Status (v2.43.1)
+
+**v2.43.1 additions:** `deepr doctor` surfaces offline MCP host-interop
+conformance under the MCP category; interop checklist, MCP README, and
+agent-guide preflight treat `deepr mcp conformance` as the dual-era proof
+gate. Paid dispatch remains frozen.
 
 **v2.43.0 additions:** offline machine-checkable MCP host-interop conformance
 (`deepr mcp conformance`, `deepr-mcp-conformance-v1`) proving dual-era

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.43.1] - 2026-08-02
+
 ### Changed
 
 - `deepr doctor` includes offline MCP host-interop conformance under the MCP
   category (`deepr mcp conformance` form and side-effect rollup, $0).
 - MCP interop checklist, MCP README, and agent-guide operator preflight point
   hosts at `deepr mcp conformance` as the dual-era proof gate (v2.43.0 baseline).
+- Supported Surface status advanced to v2.43.1 with doctor MCP preflight as a
+  first-class host-interop check.
 
 ## [2.43.0] - 2026-08-02
 

--- a/docs/MCP_A2A_INTEROP_CHECKLIST.md
+++ b/docs/MCP_A2A_INTEROP_CHECKLIST.md
@@ -1,6 +1,6 @@
 # MCP and A2A Interop Checklist
 
-Status: current with Deepr v2.43.0. Last reviewed: 2026-08-02.
+Status: current with Deepr v2.43.1. Last reviewed: 2026-08-02.
 
 Use this checklist when connecting Deepr experts to another agent host through
 MCP or A2A. It is a compact integration review, not the command guide. For

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,6 +1,6 @@
 # Supported Surface
 
-Status: v2.43.0 current main, 2026-08-02. This document defines what users and host
+Status: v2.43.1 current main, 2026-08-02. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
 data remains portable if development stops. Production metered dispatch remains
 frozen since v2.40 until provider account-control adapters land.
@@ -91,7 +91,8 @@ must not be described as usable capacity.
   offline consult form checks, remote smoke fail-closed posture, managed
   conversation fail-closed posture, registration-manifest offline shape, and
   the capabilities map. No network, no model, `$0`. Does not score semantic
-  answer quality.
+  answer quality. `deepr doctor` surfaces the same offline rollup under the MCP
+  category so host preflight is one command.
 - Offline and live no-metered consult validation (`deepr mcp validate-consult`,
   `validate-consult-fleet`) and fail-closed remote smoke / conversation
   validation commands. Remote HTTP tool calls remain blocked until an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepr-research"
-version = "2.43.0"
+version = "2.43.1"
 description = "Research automation platform that replicates human research team workflows using AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/deepr/__init__.py
+++ b/src/deepr/__init__.py
@@ -5,7 +5,7 @@ Keep package import lightweight by lazily importing heavy modules.
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "2.43.0"
+__version__ = "2.43.1"
 __author__ = "Nick Seal"
 
 if TYPE_CHECKING:

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "deepr-research"
-version = "2.40.0"
+version = "2.43.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump package and docs to **v2.43.1** after #117 landed on main
- Document that `deepr doctor` surfaces offline MCP host-interop conformance under the MCP category
- Keep releases current with the doctor/host preflight surface (dual-era MCP proof gate from v2.43.0)

## Test plan

- [x] Local `deepr mcp conformance --json` ok (6 checks, $0)
- [x] Local `deepr doctor` shows MCP offline conformance OK
- [ ] CI green on this PR
- [ ] Tag `v2.43.1` and GitHub release with wheel/sdist after merge

No paid path is enabled. Metered dispatch remains frozen.