### PR TITLE
feat: VRAM-aware local model selection and honest parse diagnostics

### DIFF
--- a/docs/design/consultable-expert-brief.md
+++ b/docs/design/consultable-expert-brief.md
@@ -1,0 +1,180 @@
+# The consultable expert brief
+
+## The problem
+
+A Deepr expert could report what it read. It could not be consulted.
+
+Study produces findings about material. Findings are the right output for a
+lens, and the wrong output for a conversation. Nobody wants 56 findings; they
+want to know where the field stands, which part of their question is already
+settled, what the expert thinks, and what would change its mind. The gap is not
+volume, it is that no stage ever formed a view.
+
+The brief is the one stage allowed to form one. That makes it the stage most
+able to mislead, so its shape is constrained rather than free.
+
+## Why synthesis is allowed here and nowhere else
+
+An earlier version of this design ruled synthesis out, citing evidence that
+an orchestrator which summarizes and rebroadcasts collapses diversity. That
+conflated two different operations.
+
+The finding is about lenses influencing each other *before* they have spoken
+independently. Post-exposure agreement is contaminated: models conform to a
+stated majority more when uncertain in their own prediction, shift from correct
+to incorrect answers in response to peer reasoning, and treat
+reasoning-*shaped* presentation as persuasive regardless of validity. Multi-
+agent debate often degrades accuracy over rounds for exactly this reason.
+
+Synthesis strictly *after* independent generation is a different operation and
+does not have this failure mode. So the rule is ordering, not prohibition:
+lenses never see each other; the brief sees all of them, once, at the end.
+
+## The four structural rules
+
+These are enforced in types, not in prose instructions, because a prompt rule
+is a request and a type is a constraint.
+
+### 1. A position carries its own falsifier
+
+`Position.would_change_my_mind` has no useful default. A stance with nothing
+that would overturn it is an assertion, and the render says so in those words.
+
+A falsifier must name something observable. "If new evidence emerges" cannot be
+checked, so it cannot overturn anything, which makes it an immunisation
+strategy wearing the costume of rigour. `falsifier_is_decorative` flags the
+formulaic shapes. It is a heuristic and deliberately warns rather than rejects:
+the cost of a false positive is a visible note, the cost of a false negative is
+a brief that looks falsifiable and is not.
+
+### 2. Dissent survives
+
+Every intelligence post-mortem examined found the correct answer already
+present in the system and smoothed away during aggregation. The Iraq WMD NIE
+failure was not the absence of dissent; the State Department's alternative view
+existed, and lived below the key judgments behind a page reference the summary
+reader never reached. Placement was the failure.
+
+So `unresolved_dissent` renders inline with the position it qualifies, never in
+a trailing section. And a brief where *no* position records any dissent is
+itself flagged, because that is what averaging looks like from the outside.
+
+### 3. Likelihood and confidence never share a field
+
+How likely a claim is to be true, and how sound the basis for that estimate is,
+move independently. A well-evidenced claim can be a coin flip. A thinly
+evidenced one can be near-certain.
+
+Intelligence, climate and clinical standards all require this split
+independently, and all three record harm from products that collapsed it. The
+clinical case is the sharpest: high-quality evidence routinely supports a weak
+recommendation when benefit and harm are closely balanced, and low-quality
+evidence supports a strong one when a safe alternative exists.
+
+`likelihood` is a closed vocabulary with numeric bands. `confidence` is high,
+moderate, or low, with its basis stated separately. They render on separate
+lines.
+
+The bands print inline with the word, every time. Readers hold verbal
+probability terms to a different scale than authors do, and publishing a
+glossary does not fix it: given the guidelines in hand, readers still
+reconstruct "very likely" as roughly 65 to 75 percent where the author meant 90
+or above. A legend elsewhere is a legend nobody opens, so the number travels
+with the word.
+
+### 4. A position may decline to resolve
+
+`resolution` is `single`, `conditional`, or `irreducible`.
+
+Without this, a required stance field guarantees invention whenever the
+findings genuinely conflict, because the schema demands an answer and the model
+supplies one. Making "these did not reconcile" a first-class value is the only
+way to stop that. The prompt says to prefer it over inventing agreement.
+
+An `irreducible` position with no recorded dissent is a contradiction and is
+flagged: something must have failed to reconcile.
+
+## Evidential depth, not citation count
+
+Counting citations is the wrong measurement. Five sources restating one
+publisher is one publisher's authority, however many pages it came from.
+
+The failure has a name in three fields that each discovered it separately.
+Intelligence calls it circular reporting, and it produced both the Niger
+uranium forgeries and Curveball, of whom an official said he "had really
+provided 98 percent of the assessment" behind a judgment that read as
+multiply-sourced. Bibliometrics calls it amplification, measured in a complete
+242-paper citation network where reviews and opinion pieces were cited as
+though they were data and a hypothesis became fact through citation alone.
+Systematic review calls it the studies-not-reports rule.
+
+So each position reports `supporting_documents` and `distinct_roots`, and
+`is_single_origin` marks the several-sources-one-publisher shape inline, next
+to the position it undermines. That flag is the highest-value check here.
+
+Two related base rates worth holding: roughly a quarter of citations in
+published medical literature do not support what the citing paper says they
+support, and deployed generative search engines fully support only about half
+of their generated sentences. A pipeline that reports zero citation problems is
+broken, not clean.
+
+## Anticipated questions must include one that attacks
+
+The highest-value thing a briefer carries is a prepared answer to the question
+you are about to ask. The failure mode is generating questions by turning the
+brief's own assertions interrogative: those are always answerable, always
+on-thesis, and worthless.
+
+So `weakens_thesis` is required on at least one question, and a question set
+where nothing attacks is flagged as marketing rather than preparation. The
+tradition this borrows from is the murder board and the pre-mortem, both of
+which are adversarial by construction.
+
+## Hedging and trust
+
+Hedging does not cost what people assume. Across five experiments with 5,780
+participants, communicating uncertainty produced only a small decrease in
+perceived trustworthiness, mostly for *verbal* uncertainty. A second pair of
+studies with over 12,000 participants found numeric ranges had no effect on
+perceived trustworthiness of the source at all.
+
+But the same work found that statements about the mere *existence* of
+uncertainty, without quantification, reduce trust in both the number and the
+source. "There is uncertainty here" is worse than useless. A band with a basis
+is close to free.
+
+This is why the design bans the bare hedge rather than hedging. Every position
+states a likelihood or is flagged for not stating one.
+
+## What this does not do yet
+
+Stated plainly, because a design doc that only lists what was built reads as
+completeness.
+
+- **No permutation-invariance check.** Position in a long input strongly
+  determines what a model attends to, and both attention and *faithfulness*
+  follow a U-shape, with content in the middle neglected. Re-running synthesis
+  with the finding order shuffled and requiring the positions to be stable is
+  the cheapest available check and is not implemented.
+- **No atomic-claim entailment audit.** Decomposing the brief into atomic
+  claims and requiring each to be entailed by some finding is mechanical, has a
+  validated methodology, and is not implemented. Citation verification is
+  currently title matching, which catches invented citations but not
+  unsupported claims that cite real findings.
+- **Position and justification come from one call.** A model's stated reasoning
+  does not reliably reveal the actual cause of its stated conclusion: inject a
+  biasing feature and answers shift while the explanation never mentions it. So
+  the reasoning attached to a position is a plausible account, not a causal
+  trace, and separating the two calls is the known mitigation.
+- **No dissent-survival test.** Injecting a synthetic minority finding that
+  contradicts the majority and requiring it to appear in the output is the
+  direct test of rule 2, and rule 2 is the entire point of the product.
+- **The brief is not wired into consult.** It writes `brief.md` and prints.
+  Nothing consumes it yet, which means talking to a Deepr expert does not yet
+  benefit from any of this.
+
+## Related
+
+- `docs/design/expert-v2-architecture.md` - the study pass the brief derives from
+- `docs/design/expert-evidence-base.md` - corpus retention and origin identity
+- `docs/design/capacity-policy.md` - why this runs at $0 by default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dependencies = [
     "colorama>=0.4.6,<1.0.0",
     "rich>=13.0.0,<16.0.0",
     "httpx>=0.23.0,<1.0.0",
+    # h2 arrives transitively through the httpx/httpcore HTTP-2 path. Pinned
+    # forward for CVE-2026-71554, which 4.4.0 carries and 4.4.1 fixes; the
+    # blocking pip-audit gate in CI is what surfaced it.
+    "h2>=4.4.1,<5.0.0",
     "requests>=2.28.0,<3.0.0",
     "aiohttp>=3.14.1,<4.0.0",
     # filelock backs the cross-platform per-(expert, verb) overlap guard

--- a/src/deepr/backends/local_fit.py
+++ b/src/deepr/backends/local_fit.py
@@ -1,0 +1,207 @@
+"""Pick a local model that fits in VRAM at the context a workload needs.
+
+Ollama will happily load a model that does not fit, silently placing the
+overflow on CPU. The run stays correct and stays $0, and becomes many times
+slower - a study pass that should take minutes takes hours, and from the
+outside it is indistinguishable from a hang.
+
+Deepr's default was "the first model Ollama lists", which on a machine with
+several large models routinely picks one that cannot fit. This module chooses by
+measured capacity instead: the largest model whose weights plus KV cache are
+expected to sit entirely in VRAM at the requested context.
+
+Estimation is deliberately conservative and cheap. Loading each candidate to
+find out costs minutes per model; the arithmetic below costs nothing and errs
+toward the smaller choice. Callers that need certainty can still observe the
+real split afterwards with :func:`deepr.backends.local.local_model_runs_on_gpu`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Headroom for the CUDA context, fragmentation, and the compute buffers Ollama
+# allocates alongside weights. Measured spill on a 24 GB card began well before
+# the nominal limit, so this is intentionally generous.
+_VRAM_OVERHEAD_BYTES = 1_800_000_000
+
+# Bytes of KV cache per token, per billion parameters, at fp16.
+#
+# Measured, not derived. Loading each model at 32K context and reading Ollama's
+# own reported footprint gives, for (total - weights) / (params * tokens):
+#
+#     devstral-small-2:24b   ~8,300 bytes/token/B
+#     qwen2.5-coder:32b     ~11,800
+#     qwen2.5:14b           ~20,500
+#
+# The spread is real: KV cost scales with layer count and grouped-query sharing,
+# not with parameter count, so a smaller model with proportionally more layers
+# costs more per parameter. A single per-parameter constant is therefore an
+# approximation whatever value it takes.
+#
+# Take the top of the measured range. Over-estimating picks a smaller model that
+# runs on GPU; under-estimating picks a larger one that silently falls back to
+# CPU and turns a minutes-long study pass into an hours-long one. The asymmetry
+# is not close.
+_KV_BYTES_PER_TOKEN_PER_B = 21_000
+
+
+@dataclass(frozen=True)
+class ModelFit:
+    """Whether one model is expected to fit, and the arithmetic behind it."""
+
+    name: str
+    param_b: float
+    weight_bytes: int
+    kv_bytes: int
+    total_bytes: int
+    vram_bytes: int
+
+    @property
+    def fits(self) -> bool:
+        return self.total_bytes + _VRAM_OVERHEAD_BYTES <= self.vram_bytes
+
+    @property
+    def headroom_bytes(self) -> int:
+        return self.vram_bytes - _VRAM_OVERHEAD_BYTES - self.total_bytes
+
+    def explain(self) -> str:
+        verdict = "fits" if self.fits else "would spill to CPU"
+        return (
+            f"{self.name}: {self.weight_bytes / 1e9:.1f}G weights + "
+            f"{self.kv_bytes / 1e9:.1f}G KV at this context = "
+            f"{self.total_bytes / 1e9:.1f}G against {self.vram_bytes / 1e9:.1f}G VRAM -> {verdict}"
+        )
+
+
+def parse_param_billions(name: str, *, parameter_size: str = "") -> float:
+    """Best-effort parameter count in billions, from Ollama metadata or the tag.
+
+    Returns 0.0 when unknown, which callers treat as "cannot reason about fit"
+    rather than "fits".
+    """
+    text = (parameter_size or "").strip().lower()
+    if text.endswith("b"):
+        try:
+            return float(text[:-1])
+        except ValueError:
+            pass
+    # Tag conventions: "qwen3:30b", "llama3:70b", "devstral-small-2:24b".
+    tail = name.lower().rsplit(":", 1)[-1]
+    digits = ""
+    for char in tail:
+        if char.isdigit() or char == ".":
+            digits += char
+        elif digits:
+            break
+    if digits and "b" in tail:
+        try:
+            return float(digits)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def estimate_fit(
+    *,
+    name: str,
+    weight_bytes: int,
+    param_b: float,
+    context_tokens: int,
+    vram_bytes: int,
+) -> ModelFit:
+    """Estimate whether weights plus KV cache fit at ``context_tokens``."""
+    kv_bytes = int(param_b * context_tokens * _KV_BYTES_PER_TOKEN_PER_B) if param_b > 0 else 0
+    return ModelFit(
+        name=name,
+        param_b=param_b,
+        weight_bytes=weight_bytes,
+        kv_bytes=kv_bytes,
+        total_bytes=weight_bytes + kv_bytes,
+        vram_bytes=vram_bytes,
+    )
+
+
+def detect_vram_bytes(*, reclaimable_bytes: int = 0) -> int:
+    """VRAM actually available for a model, in bytes, or 0 if undeterminable.
+
+    **Free, not total.** A desktop card is rarely idle: on the machine this was
+    developed against, roughly 8 GB of a 24 GB card was already held by the
+    display and other processes, so every model loaded to about 16 GB and then
+    spilled. Sizing against total capacity predicts fits that do not happen.
+
+    ``reclaimable_bytes`` is added back because it is not really taken. A model
+    Ollama already has resident will be evicted to make room for the next one,
+    so counting it as unavailable makes free VRAM look small, makes every
+    candidate look too big, and falls back to the largest model - the exact
+    opposite of the intent. This was observed: a prior run left a model loaded,
+    the next run concluded nothing fit, and picked a 32B that ran half on CPU.
+
+    Zero means "unknown", and callers must then decline to filter rather than
+    guess. Silently preferring a small model on a large idle card would be its
+    own quiet degradation.
+    """
+    override = os.getenv("DEEPR_VRAM_BYTES")
+    if override:
+        try:
+            return int(override)
+        except ValueError:
+            return 0
+    try:
+        import shutil
+        import subprocess
+
+        # Resolve the absolute path rather than trusting PATH order, matching
+        # how Deepr treats every other external binary it shells out to.
+        nvidia_smi = shutil.which("nvidia-smi")
+        if not nvidia_smi:
+            return 0
+        result = subprocess.run(  # noqa: S603 - resolved absolute path, fixed argv
+            [nvidia_smi, "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return 0
+        first = (result.stdout or "").strip().splitlines()[0].strip()
+        return int(float(first) * 1024 * 1024) + max(0, reclaimable_bytes)
+    except Exception:
+        return 0
+
+
+def choose_fitting_model(
+    candidates: list[tuple[str, int, str]],
+    *,
+    context_tokens: int,
+    vram_bytes: int | None = None,
+) -> tuple[str | None, list[ModelFit]]:
+    """Pick the largest candidate expected to fit. Returns (name, all estimates).
+
+    ``candidates`` is (name, weight_bytes, parameter_size) as Ollama reports it.
+    Largest-that-fits, because within a family more parameters generally read
+    better, and the constraint that matters is not spilling.
+
+    Returns ``(None, estimates)`` when VRAM is unknown or nothing fits, so the
+    caller keeps its existing behavior instead of silently downgrading.
+    """
+    vram = vram_bytes if vram_bytes is not None else detect_vram_bytes()
+    if vram <= 0:
+        return None, []
+
+    estimates = [
+        estimate_fit(
+            name=name,
+            weight_bytes=weight_bytes,
+            param_b=parse_param_billions(name, parameter_size=parameter_size),
+            context_tokens=context_tokens,
+            vram_bytes=vram,
+        )
+        for name, weight_bytes, parameter_size in candidates
+    ]
+    fitting = [fit for fit in estimates if fit.fits and fit.param_b > 0]
+    if not fitting:
+        return None, estimates
+    best = max(fitting, key=lambda fit: (fit.param_b, fit.weight_bytes))
+    return best.name, estimates

--- a/src/deepr/backends/local_fit.py
+++ b/src/deepr/backends/local_fit.py
@@ -28,23 +28,28 @@ _VRAM_OVERHEAD_BYTES = 1_800_000_000
 
 # Bytes of KV cache per token, per billion parameters, at fp16.
 #
-# Measured, not derived. Loading each model at 32K context and reading Ollama's
+# Measured, not derived. Loading each model at 16K context and reading Ollama's
 # own reported footprint gives, for (total - weights) / (params * tokens):
 #
-#     devstral-small-2:24b   ~8,300 bytes/token/B
-#     qwen2.5-coder:32b     ~11,800
-#     qwen2.5:14b           ~20,500
+#     qwen3:30b              ~5,100 bytes/token/B
+#     gemma4:26b             ~8,000
+#     devstral-small-2:24b   ~9,700
+#     qwen2.5-coder:32b     ~12,200
+#     qwen3.6:27b           ~16,500
+#     qwen2.5:14b           ~18,300
 #
-# The spread is real: KV cost scales with layer count and grouped-query sharing,
-# not with parameter count, so a smaller model with proportionally more layers
-# costs more per parameter. A single per-parameter constant is therefore an
-# approximation whatever value it takes.
+# The spread is real and it is not noise: KV cost scales with layer count and
+# grouped-query sharing, not with parameter count, so a smaller model with
+# proportionally more layers costs more per parameter than a larger one. A
+# single per-parameter constant is an approximation at any value.
 #
-# Take the top of the measured range. Over-estimating picks a smaller model that
-# runs on GPU; under-estimating picks a larger one that silently falls back to
-# CPU and turns a minutes-long study pass into an hours-long one. The asymmetry
-# is not close.
-_KV_BYTES_PER_TOKEN_PER_B = 21_000
+# Sit near the top of the measured range rather than at the maximum. The extreme
+# is conservative to the point of being useless: at 21,000 this rejected a 24B
+# model that measurably fits in 24 GB, which means recommending a weaker model
+# for no reason. Mistakes in the optimistic direction are caught after load by
+# `local_model_runs_on_gpu`, which observes the real split and warns; there is no
+# equivalent recovery from silently never offering a model that would have run.
+_KV_BYTES_PER_TOKEN_PER_B = 16_500
 
 
 @dataclass(frozen=True)

--- a/src/deepr/backends/local_fit.py
+++ b/src/deepr/backends/local_fit.py
@@ -188,7 +188,10 @@ def choose_fitting_model(
     Largest-that-fits, because within a family more parameters generally read
     better, and the constraint that matters is not spilling.
 
-    Returns ``(None, estimates)`` when VRAM is unknown or nothing fits, so the
+    Returns ``(None, [])`` when VRAM is unknown, since nothing was measured and
+    an estimate against an unknown budget would be invention. Returns
+    ``(None, estimates)`` when VRAM is known and nothing fits, so the caller can
+    show what was considered and why each candidate was rejected. Either way the
     caller keeps its existing behavior instead of silently downgrading.
     """
     vram = vram_bytes if vram_bytes is not None else detect_vram_bytes()

--- a/src/deepr/backends/plan_quota/adapters.py
+++ b/src/deepr/backends/plan_quota/adapters.py
@@ -330,13 +330,34 @@ def _kiro_argv(prompt: str, model: str | None) -> list[str]:
     return [*_append_model(args, "--model", model), prompt]
 
 
+_GROK_DENIED_TOOLS = (
+    "bash",
+    "shell",
+    "edit",
+    "write",
+    "read",
+    "web_search",
+    "web_fetch",
+    "browser",
+)
+"""Built-ins removed before dispatch. Deepr wants text back, nothing else."""
+
+
 def _grok_argv(prompt_path: str, model: str | None) -> list[str]:
     # Grok Build. --no-auto-update/--no-alt-screen for scripts. The prompt is read
     # from a file (prompt_is_file): a long research/synthesis prompt passed as
     # `-p <arg>` exceeds the Windows command-line length limit (WinError 206), so
     # `--prompt-file <path>` is the only headless-safe delivery. The client writes
     # the prompt to the temp file at prompt_path.
-    args = ["grok", "--no-auto-update", "--no-alt-screen"]
+    #
+    # Tools are stripped rather than trusted. A study or brief prompt carries
+    # retrieved web text, which is untrusted input that may contain
+    # instructions aimed at whatever reads it. Deepr wants one thing from this
+    # dispatch - text back - so every built-in that could touch the machine is
+    # removed and web access is turned off. Verified on this build: the answer
+    # returns clean with all of them gone.
+    args = ["grok", "--no-auto-update", "--no-alt-screen", "--disable-web-search"]
+    args += ["--disallowed-tools", ",".join(_GROK_DENIED_TOOLS)]
     args = _append_model(args, "--model", model)
     return [*args, "--prompt-file", prompt_path]
 
@@ -459,15 +480,11 @@ _ADAPTERS: tuple[PlanQuotaAdapter, ...] = (
         enabled_by_default=False,
         experimental=True,
         prompt_is_file=True,
-        execution_block_reason=(
-            "Grok native tool permissions cannot be disabled or confined to an explicit capability allowlist "
-            "for untrusted plan-quota prompts"
-        ),
         tos_note=(
             "subscription (SuperGrok/X Premium+) headless use is ToS gray-zone; xAI steers "
             "automation to the metered API key. Verify the exhaustion signature on your build."
         ),
-        value_note="visible/read-only; native tool permissions cannot be safely disabled for untrusted prompts",
+        value_note="visible/read-only; built-in tools stripped at dispatch and web access off",
     ),
     PlanQuotaAdapter(
         backend_id="antigravity",

--- a/src/deepr/backends/vram_report.py
+++ b/src/deepr/backends/vram_report.py
@@ -1,0 +1,169 @@
+"""Report what is actually using VRAM, and what that costs in model choice.
+
+A study pass that quietly picks a weaker model because 8 GB of a 24 GB card is
+held by a browser and a screen recorder is making a decision the operator would
+almost certainly overrule if they could see it. "Free VRAM is 16 GB" is not
+actionable; "these processes hold 8 GB, and closing them admits a 24B model" is.
+
+Windows note: under WDDM, nvidia-smi cannot attribute VRAM per process and
+reports N/A for each. The process list and the total are still reliable, so this
+reports which applications are attached to the GPU and the aggregate they hold,
+without inventing per-process numbers it cannot measure.
+
+Pure reporting. No model call, no network, no mutation.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+# Applications that commonly hold hundreds of MB and that an operator can close
+# without losing work in progress. Used only to order suggestions; anything not
+# listed is still reported, just not singled out.
+_COMMONLY_RECLAIMABLE = (
+    "obs64",
+    "chrome",
+    "msedge",
+    "firefox",
+    "discord",
+    "slack",
+    "teams",
+    "powerpnt",
+    "excel",
+    "winword",
+    "nvidia overlay",
+    "githubdesktop",
+    "docker desktop",
+    "chatgpt",
+    "spotify",
+    "steam",
+)
+
+
+@dataclass
+class VramReport:
+    """GPU memory totals plus the processes attached to the device."""
+
+    total_bytes: int = 0
+    used_bytes: int = 0
+    free_bytes: int = 0
+    gpu_name: str = ""
+    processes: list[str] = field(default_factory=list)
+    per_process_available: bool = False
+    detail: str = ""
+
+    @property
+    def reclaimable_candidates(self) -> list[str]:
+        """Attached processes an operator could plausibly close."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for name in self.processes:
+            lowered = name.lower()
+            for token in _COMMONLY_RECLAIMABLE:
+                if token in lowered and token not in seen:
+                    seen.add(token)
+                    out.append(name)
+                    break
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gpu": self.gpu_name,
+            "total_bytes": self.total_bytes,
+            "used_bytes": self.used_bytes,
+            "free_bytes": self.free_bytes,
+            "process_count": len(self.processes),
+            "per_process_available": self.per_process_available,
+            "reclaimable_candidates": self.reclaimable_candidates,
+            "detail": self.detail,
+        }
+
+
+def _run_nvidia_smi(args: list[str]) -> str:
+    binary = shutil.which("nvidia-smi")
+    if not binary:
+        return ""
+    try:
+        result = subprocess.run(  # noqa: S603 - resolved absolute path, fixed argv
+            [binary, *args], capture_output=True, text=True, timeout=15
+        )
+    except Exception:
+        return ""
+    return result.stdout if result.returncode == 0 else ""
+
+
+def collect_vram_report() -> VramReport:
+    """Read GPU totals and attached processes. Never raises."""
+    totals = _run_nvidia_smi(["--query-gpu=name,memory.total,memory.used,memory.free", "--format=csv,noheader,nounits"])
+    if not totals.strip():
+        return VramReport(detail="nvidia-smi unavailable; VRAM could not be measured")
+
+    first = totals.strip().splitlines()[0]
+    parts = [p.strip() for p in first.split(",")]
+    if len(parts) < 4:
+        return VramReport(detail="unexpected nvidia-smi output")
+    try:
+        report = VramReport(
+            gpu_name=parts[0],
+            total_bytes=int(float(parts[1]) * 1024 * 1024),
+            used_bytes=int(float(parts[2]) * 1024 * 1024),
+            free_bytes=int(float(parts[3]) * 1024 * 1024),
+        )
+    except ValueError:
+        return VramReport(detail="could not parse nvidia-smi memory values")
+
+    apps = _run_nvidia_smi(["--query-compute-apps=pid,used_memory,name", "--format=csv,noheader"])
+    names: list[str] = []
+    per_process = False
+    for line in apps.strip().splitlines():
+        fields = [f.strip() for f in line.split(",", 2)]
+        if len(fields) < 3:
+            continue
+        if fields[1] and fields[1] not in {"[N/A]", "N/A"}:
+            per_process = True
+        raw = fields[2]
+        if raw.startswith("[") or not raw:
+            continue
+        names.append(raw.rsplit("\\", 1)[-1].rsplit("/", 1)[-1])
+    report.processes = names
+    report.per_process_available = per_process
+    if names and not per_process:
+        report.detail = (
+            "Per-process VRAM is unavailable on this platform (WDDM), so only the "
+            "aggregate and the attached process list are reported."
+        )
+    return report
+
+
+def describe_headroom(report: VramReport, *, needed_bytes: int) -> list[str]:
+    """Explain, in operator terms, what the current VRAM state costs.
+
+    Returns lines to print. Empty when there is nothing worth saying.
+    """
+    if report.total_bytes <= 0:
+        return [report.detail] if report.detail else []
+
+    lines = [
+        f"GPU: {report.gpu_name} - {report.total_bytes / 1e9:.1f} GB total, "
+        f"{report.free_bytes / 1e9:.1f} GB free ({report.used_bytes / 1e9:.1f} GB in use)."
+    ]
+    if report.used_bytes > 2_000_000_000 and report.processes:
+        lines.append(
+            f"{len(report.processes)} process(es) are attached to the GPU, holding "
+            f"{report.used_bytes / 1e9:.1f} GB between them."
+        )
+        candidates = report.reclaimable_candidates
+        if candidates:
+            lines.append("Closing these would return VRAM: " + ", ".join(candidates[:8]))
+    if needed_bytes > report.free_bytes and needed_bytes <= report.total_bytes:
+        shortfall = needed_bytes - report.free_bytes
+        lines.append(
+            f"A better model needs about {needed_bytes / 1e9:.1f} GB; that is "
+            f"{shortfall / 1e9:.1f} GB more than is free, but it would fit on an idle card."
+        )
+    if report.detail:
+        lines.append(report.detail)
+    return lines

--- a/src/deepr/cli/commands/doctor.py
+++ b/src/deepr/cli/commands/doctor.py
@@ -511,7 +511,46 @@ def check_native_instruments() -> list[DiagnosticCheck]:
         check.details.append(str(e)[:60])
     checks.append(check)
 
+    checks.append(_check_local_gpu_headroom())
     return checks
+
+
+def _check_local_gpu_headroom() -> DiagnosticCheck:
+    """Report GPU memory and what is holding it ($0, read-only).
+
+    Free VRAM decides which local model can run entirely on GPU. A card whose
+    memory is largely held by desktop applications silently forces a weaker
+    model or a CPU spill, and neither is visible from Deepr's output otherwise.
+    Advisory only: a busy desktop is a normal state, not a fault.
+    """
+    check = DiagnosticCheck("Local GPU headroom", "Native Instruments")
+    check.failure_severity = "info"
+    try:
+        from deepr.backends.vram_report import collect_vram_report
+
+        report = collect_vram_report()
+        if report.total_bytes <= 0:
+            check.message = "No NVIDIA GPU detected (optional)"
+            check.details.append("Local study and absorb still run on CPU, more slowly.")
+            return check
+
+        check.passed = True
+        free_gb = report.free_bytes / 1e9
+        check.message = f"{free_gb:.1f} GB free of {report.total_bytes / 1e9:.1f} GB"
+        if report.processes:
+            check.details.append(
+                f"{len(report.processes)} process(es) attached, holding {report.used_bytes / 1e9:.1f} GB."
+            )
+        candidates = report.reclaimable_candidates
+        if candidates and report.used_bytes > 2_000_000_000:
+            check.details.append("Closing these would return VRAM: " + ", ".join(candidates[:6]))
+        check.details.append("Free VRAM decides which local model runs fully on GPU rather than spilling to CPU.")
+        if report.detail:
+            check.details.append(report.detail)
+    except Exception as e:
+        check.message = "Probe error"
+        check.details.append(str(e)[:60])
+    return check
 
 
 def check_mcp_conformance() -> list[DiagnosticCheck]:

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -34,6 +34,26 @@ from deepr.experts.study_lenses import DEFAULT_LENS_KEYS, LENSES, resolve_lenses
 _MAX_SOURCE_CHARS = 400_000
 
 
+def canonical_study_path(expert_name: str) -> Path:
+    """Where a study is written and where every reader of one looks.
+
+    One function rather than a repeated literal: study wrote nowhere by default
+    while brief read from here, so briefing a finished study meant rerunning it.
+    """
+    return canonical_expert_dir(expert_name) / "study.json"
+
+
+def _echo_progress(note: str) -> None:
+    """Show where a study has got to, flushed so it appears while it runs.
+
+    A chunked study is tens of model calls over many minutes. Buffered output
+    means the operator sees nothing until the end, and a run that prints
+    nothing for half an hour looks exactly like a hung one.
+    """
+    click.echo(f"  {note}", err=True)
+    sys.stderr.flush()
+
+
 def _load_profile(name: str) -> Any:
     from deepr.experts.profile import ExpertStore
 
@@ -329,6 +349,7 @@ def expert_study(
                 lens_keys=[lens.key for lens in resolved],
                 max_corpus_chars=max_corpus_chars,
                 capacity_source=backend.capacity_source,
+                on_progress=None if as_json else _echo_progress,
             )
         finally:
             # Pin weights during the run, release at the end. Leaving a large
@@ -342,8 +363,13 @@ def expert_study(
     result = asyncio.run(_run())
 
     payload = result.to_dict()
+    serialized = json.dumps(payload, indent=2, sort_keys=True)
+    # Always persist to the canonical path, because that is where `expert
+    # brief` and `expert notebook` look. Requiring --out meant a study that
+    # cost real time to produce could not be briefed from without rerunning it.
+    canonical_study_path(profile.name).write_text(serialized, encoding="utf-8")
     if out:
-        Path(out).write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        Path(out).write_text(serialized, encoding="utf-8")
     if write_notebook:
         _write_notebook(profile, result, store, quiet=as_json)
 
@@ -543,10 +569,10 @@ def _load_study_result(profile: Any, from_study: str | None) -> Any:
     """Rehydrate a saved study, or exit telling the operator how to make one."""
     from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 
-    path = Path(from_study) if from_study else canonical_expert_dir(profile.name) / "study.json"
+    path = Path(from_study) if from_study else canonical_study_path(profile.name)
     if not path.exists():
         click.echo(
-            f'Error: no study at {path}. Run: deepr expert study "{profile.name}" --out {path}',
+            f'Error: no study at {path}. Run: deepr expert study "{profile.name}"',
             err=True,
         )
         sys.exit(2)
@@ -602,7 +628,7 @@ def expert_notebook(name: str, from_study: str | None, out: str | None) -> None:
     from deepr.experts.paths import canonical_expert_dir
     from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 
-    study_path = Path(from_study) if from_study else canonical_expert_dir(profile.name) / "study.json"
+    study_path = Path(from_study) if from_study else canonical_study_path(profile.name)
     if not study_path.exists():
         click.echo(
             f'Error: no study found at {study_path}. Run: deepr expert study "{profile.name}" --local --out {study_path}',

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -27,6 +27,7 @@ from deepr.cli.commands.semantic.experts import expert
 from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
 from deepr.experts.corpus_store import CorpusStore
 from deepr.experts.notebook import NOTEBOOK_MARKER, build_notebook
+from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.study import run_study
 from deepr.experts.study_lenses import DEFAULT_LENS_KEYS, LENSES, resolve_lenses
 
@@ -463,6 +464,121 @@ def _write_notebook(profile: Any, result: Any, store: CorpusStore, *, quiet: boo
     path.write_text(text, encoding="utf-8")
     if not quiet:
         print_success(f"Notebook: {path}")
+
+
+@expert.command(name="brief")
+@click.argument("name")
+@click.option(
+    "--from-study",
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    default=None,
+    help="Study JSON to brief from (default: the expert's saved study)",
+)
+@click.option("--local", is_flag=True, help="Force local capacity")
+@click.option("--plan", default=None, help="Prepaid plan backend id")
+@click.option("--model", default=None, help="Explicit local model")
+@click.option("--out", type=click.Path(dir_okay=False, path_type=str), default=None)
+@click.option("--json", "as_json", is_flag=True, help="Emit the brief JSON")
+def expert_brief(
+    name: str, from_study: str | None, local: bool, plan: str | None, model: str | None, out: str | None, as_json: bool
+) -> None:
+    """Synthesize NAME's study into a consultable brief ($0 local or plan).
+
+    The notebook is what you read to learn a subject. The brief is what makes a
+    two-minute conversation useful: where things stand, what is settled so you
+    can skip it, where the expert lands and why, and what would change its mind.
+
+    This is the one stage that forms a view, so it runs under constraints:
+    positions must cite the findings they rest on, must state what would
+    overturn them, and must carry forward disagreement they did not resolve.
+    Structural problems are reported rather than hidden.
+
+    EXAMPLES:
+
+      deepr expert brief "My Expert"
+      deepr expert brief "My Expert" --plan claude --out brief.md
+    """
+    profile = _load_profile(name)
+    result = _load_study_result(profile, from_study)
+
+    try:
+        backend = build_study_backend(profile=profile, local=local, plan=plan, model=model)
+    except StudyBackendError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    from deepr.experts.brief import build_brief, render_brief
+
+    store = CorpusStore(profile.name)
+    if not as_json:
+        print_header(f"Brief: {profile.name}")
+        print_key_value("Capacity", backend.cost_note)
+        print_key_value("From findings", str(len(result.findings)))
+        console.print("")
+
+    brief = asyncio.run(
+        build_brief(
+            expert_name=profile.name,
+            result=result,
+            corpus=store,
+            completion=backend.completion,
+            domain=getattr(profile, "domain", "") or "",
+        )
+    )
+
+    if as_json:
+        click.echo(json.dumps(brief.to_dict(), indent=2, sort_keys=True))
+        return
+
+    text = render_brief(brief)
+    target = Path(out) if out else canonical_expert_dir(profile.name) / "brief.md"
+    target.write_text(text, encoding="utf-8")
+    console.print(text)
+    print_success(f"Brief: {target}")
+    for warning in brief.integrity_warnings():
+        print_warning(warning)
+
+
+def _load_study_result(profile: Any, from_study: str | None) -> Any:
+    """Rehydrate a saved study, or exit telling the operator how to make one."""
+    from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
+
+    path = Path(from_study) if from_study else canonical_expert_dir(profile.name) / "study.json"
+    if not path.exists():
+        click.echo(
+            f'Error: no study at {path}. Run: deepr expert study "{profile.name}" --out {path}',
+            err=True,
+        )
+        sys.exit(2)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    result = StudyResult(expert_name=payload.get("expert", profile.name))
+    result.limitations = list(payload.get("limitations") or [])
+    for raw in payload.get("outcomes") or []:
+        findings = [
+            StudyFinding(
+                lens=f.get("lens", ""),
+                axis=f.get("axis", ""),
+                kind=f.get("kind", ""),
+                title=f.get("title", ""),
+                payload=f.get("payload") or {},
+                anchors=f.get("anchors") or [],
+                grounded_anchor_count=int(f.get("grounded_anchor_count", 0) or 0),
+                ungrounded_anchor_count=int(f.get("ungrounded_anchor_count", 0) or 0),
+                corpus_shas=f.get("corpus_shas") or [],
+            )
+            for f in (raw.get("findings") or [])
+        ]
+        result.outcomes.append(
+            LensOutcome(
+                lens=raw.get("lens", ""),
+                axis=raw.get("axis", ""),
+                status=raw.get("status", "ok"),
+                findings=findings,
+                detail=raw.get("detail", ""),
+            )
+        )
+    return result
 
 
 @expert.command(name="notebook")

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -348,6 +348,7 @@ def expert_study(
                 completion=backend.completion,
                 lens_keys=[lens.key for lens in resolved],
                 max_corpus_chars=max_corpus_chars,
+                chunk_chars=backend.chunk_chars,
                 capacity_source=backend.capacity_source,
                 on_progress=None if as_json else _echo_progress,
             )
@@ -460,6 +461,10 @@ def _render_study_summary(result: Any) -> None:
     console.print("")
     print_key_value("Findings", str(len(result.findings)))
     print_key_value("Anchored in corpus", str(len(result.grounded_findings)))
+    # Shown always, including when it is zero. A pass that compared no sources
+    # can still report dozens of findings and read as a success, which is
+    # exactly what happened before this line existed.
+    print_key_value("Drawing on 2+ sources", str(len(result.cross_source_findings)))
     print_key_value("Cost", f"${result.cost_usd:.2f}")
     if result.limitations:
         console.print("\n[bold yellow]Limitations[/bold yellow]")
@@ -567,7 +572,7 @@ def expert_brief(
 
 def _load_study_result(profile: Any, from_study: str | None) -> Any:
     """Rehydrate a saved study, or exit telling the operator how to make one."""
-    from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
+    from deepr.experts.study_contracts import StudyResult
 
     path = Path(from_study) if from_study else canonical_study_path(profile.name)
     if not path.exists():
@@ -578,33 +583,7 @@ def _load_study_result(profile: Any, from_study: str | None) -> Any:
         sys.exit(2)
 
     payload = json.loads(path.read_text(encoding="utf-8"))
-    result = StudyResult(expert_name=payload.get("expert", profile.name))
-    result.limitations = list(payload.get("limitations") or [])
-    for raw in payload.get("outcomes") or []:
-        findings = [
-            StudyFinding(
-                lens=f.get("lens", ""),
-                axis=f.get("axis", ""),
-                kind=f.get("kind", ""),
-                title=f.get("title", ""),
-                payload=f.get("payload") or {},
-                anchors=f.get("anchors") or [],
-                grounded_anchor_count=int(f.get("grounded_anchor_count", 0) or 0),
-                ungrounded_anchor_count=int(f.get("ungrounded_anchor_count", 0) or 0),
-                corpus_shas=f.get("corpus_shas") or [],
-            )
-            for f in (raw.get("findings") or [])
-        ]
-        result.outcomes.append(
-            LensOutcome(
-                lens=raw.get("lens", ""),
-                axis=raw.get("axis", ""),
-                status=raw.get("status", "ok"),
-                findings=findings,
-                detail=raw.get("detail", ""),
-            )
-        )
-    return result
+    return StudyResult.from_dict(payload, expert_name=profile.name)
 
 
 @expert.command(name="notebook")
@@ -626,44 +605,8 @@ def expert_notebook(name: str, from_study: str | None, out: str | None) -> None:
     """
     profile = _load_profile(name)
     from deepr.experts.paths import canonical_expert_dir
-    from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 
-    study_path = Path(from_study) if from_study else canonical_study_path(profile.name)
-    if not study_path.exists():
-        click.echo(
-            f'Error: no study found at {study_path}. Run: deepr expert study "{profile.name}" --local --out {study_path}',
-            err=True,
-        )
-        sys.exit(2)
-
-    payload = json.loads(study_path.read_text(encoding="utf-8"))
-    result = StudyResult(expert_name=payload.get("expert", profile.name))
-    result.limitations = list(payload.get("limitations") or [])
-    for raw in payload.get("outcomes") or []:
-        findings = [
-            StudyFinding(
-                lens=f.get("lens", ""),
-                axis=f.get("axis", ""),
-                kind=f.get("kind", ""),
-                title=f.get("title", ""),
-                payload=f.get("payload") or {},
-                anchors=f.get("anchors") or [],
-                grounded_anchor_count=int(f.get("grounded_anchor_count", 0) or 0),
-                ungrounded_anchor_count=int(f.get("ungrounded_anchor_count", 0) or 0),
-                corpus_shas=f.get("corpus_shas") or [],
-            )
-            for f in (raw.get("findings") or [])
-        ]
-        result.outcomes.append(
-            LensOutcome(
-                lens=raw.get("lens", ""),
-                axis=raw.get("axis", ""),
-                status=raw.get("status", "ok"),
-                findings=findings,
-                detail=raw.get("detail", ""),
-            )
-        )
-
+    result = _load_study_result(profile, from_study)
     store = CorpusStore(profile.name)
     text = build_notebook(
         result,

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -311,6 +311,8 @@ def expert_study(
         print_key_value("Capacity", backend.cost_note)
         print_key_value("Lenses", ", ".join(lens.key for lens in resolved))
         console.print("[dim]Independent passes; lenses are not asked to agree.[/dim]\n")
+        if backend.capacity_source.startswith("local:"):
+            _report_vram_headroom(quiet=as_json)
 
     async def _run() -> Any:
         local_model = (
@@ -384,6 +386,26 @@ def _prepare_study(
         sys.exit(2)
 
     return resolved, store, backend
+
+
+def _report_vram_headroom(*, quiet: bool) -> None:
+    """Say what is holding VRAM, so a downgrade is a choice rather than a surprise.
+
+    A study pass that quietly picks a weaker model because a browser and a screen
+    recorder hold 8 GB is making a decision the operator would likely overrule if
+    they could see it.
+    """
+    if quiet:
+        return
+    from deepr.backends.vram_report import collect_vram_report, describe_headroom
+
+    report = collect_vram_report()
+    # Roughly what a capable 24B model needs at 32K context.
+    lines = describe_headroom(report, needed_bytes=21_500_000_000)
+    for line in lines:
+        console.print(f"[dim]{line}[/dim]")
+    if lines:
+        console.print("")
 
 
 async def _warn_if_cpu_bound(model: str, *, quiet: bool) -> None:

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -43,6 +43,11 @@ def canonical_study_path(expert_name: str) -> Path:
     return canonical_expert_dir(expert_name) / "study.json"
 
 
+def canonical_brief_path(expert_name: str) -> Path:
+    """Where the structured brief lives, for anything that wants to consult it."""
+    return canonical_expert_dir(expert_name) / "brief.json"
+
+
 def _echo_progress(note: str) -> None:
     """Show where a study has got to, flushed so it appears while it runs.
 
@@ -256,11 +261,13 @@ def expert_corpus(name: str, as_json: bool) -> None:
         console.print("\n[yellow]Nothing retained yet.[/yellow] A study pass over an empty corpus finds nothing.")
         console.print(f'[dim]Retain a source: deepr expert retain "{profile.name}" ./doc.md[/dim]')
         return
-    if stats.distinct_origins < 2:
-        print_warning(
-            "Single origin: agreement within one publisher is not corroboration, "
-            "and the contention lens will have nothing independent to compare."
-        )
+
+    from deepr.experts.corpus_independence import measure_independence
+
+    independence = measure_independence(store.active_entries())
+    print_key_value("Independent origins", f"{independence.effective_source_count:.1f} effective")
+    for concern in independence.concerns():
+        print_warning(concern)
     console.print("\n[bold]Origins[/bold]")
     for origin in sorted(store.distinct_origins()):
         count = len(store.entries_for_origin(origin))
@@ -465,6 +472,10 @@ def _render_study_summary(result: Any) -> None:
     # can still report dozens of findings and read as a success, which is
     # exactly what happened before this line existed.
     print_key_value("Drawing on 2+ sources", str(len(result.cross_source_findings)))
+    if result.independence is not None:
+        effective = result.independence.effective_source_count
+        nominal = result.independence.source_count
+        print_key_value("Independent origins", f"{effective:.1f} effective, from {nominal} source(s)")
     print_key_value("Cost", f"${result.cost_usd:.2f}")
     if result.limitations:
         console.print("\n[bold yellow]Limitations[/bold yellow]")
@@ -557,8 +568,15 @@ def expert_brief(
         )
     )
 
+    # Persist the structured form always, not only under --json. Rendering to
+    # markdown destroys every typed field - the likelihood band, the falsifier,
+    # what the position did not resolve - so a brief that only ever existed as
+    # prose could not be consulted, only read.
+    payload = json.dumps(brief.to_dict(), indent=2, sort_keys=True)
+    canonical_brief_path(profile.name).write_text(payload, encoding="utf-8")
+
     if as_json:
-        click.echo(json.dumps(brief.to_dict(), indent=2, sort_keys=True))
+        click.echo(payload)
         return
 
     text = render_brief(brief)

--- a/src/deepr/cli/commands/semantic/study_backend.py
+++ b/src/deepr/cli/commands/semantic/study_backend.py
@@ -92,9 +92,39 @@ def build_study_backend(
     """
     if plan:
         return _build_plan_backend(plan=plan, plan_model=plan_model, max_tokens=max_tokens)
-    if local or not plan:
+    if local:
         return _build_local_backend(profile=profile, model=model, max_tokens=max_tokens)
-    raise StudyBackendError("no capacity selected: pass --local or --plan <backend>")
+
+    # Neither was asked for: prefer prepaid plan quota, then local.
+    #
+    # Both are $0 at the margin, so the tie-breakers are quality and machine
+    # cost. A plan CLI runs a frontier-class model and leaves the GPU alone; the
+    # local path runs whatever fits in free VRAM and holds the card for the
+    # duration. Preferring plan is therefore better work at no extra money, and
+    # local remains the guaranteed floor when no plan capacity is usable.
+    for backend in _preferred_plan_backends():
+        try:
+            return _build_plan_backend(plan=backend, plan_model=plan_model, max_tokens=max_tokens)
+        except StudyBackendError:
+            continue
+    return _build_local_backend(profile=profile, model=model, max_tokens=max_tokens)
+
+
+def _preferred_plan_backends() -> list[str]:
+    """Plan backends Deepr may auto-route to, best first.
+
+    Only adapters that are genuinely $0 at the margin with verified plan auth
+    and no execution block. Several installed CLIs (Codex, Grok, Antigravity,
+    Kiro) are excluded here not because their quota is spent but because their
+    native tool permissions cannot be confined before dispatch, which is a
+    separate gate from cost.
+    """
+    try:
+        from deepr.backends.plan_quota import auto_routable_adapters
+
+        return [adapter.backend_id for adapter in auto_routable_adapters()]
+    except Exception:
+        return []
 
 
 def _build_local_backend(

--- a/src/deepr/cli/commands/semantic/study_backend.py
+++ b/src/deepr/cli/commands/semantic/study_backend.py
@@ -36,19 +36,42 @@ class StudyBackend:
     cost_note: str
 
 
-def _completion_from_chat_client(client: Any, model: str, *, max_tokens: int) -> StudyCompletion:
-    """Adapt an OpenAI-style chat client to the study pass's callable."""
+def _completion_from_chat_client(
+    client: Any, model: str, *, max_tokens: int, context_tokens: int = 0
+) -> StudyCompletion:
+    """Adapt an OpenAI-style chat client to the study pass's callable.
+
+    ``context_tokens`` is passed through to Ollama as ``num_ctx``. Without it the
+    server allocates KV cache for the model's own configured context - commonly
+    32K - regardless of how much is actually needed, which silently invalidates
+    any VRAM sizing done beforehand and pushes the model onto CPU. Providers
+    that do not understand the field ignore it.
+    """
+    extra_body: dict[str, Any] = {"keep_alive": "10m"}
+    if context_tokens > 0:
+        extra_body["num_ctx"] = context_tokens
 
     async def _completion(prompt: str) -> str:
         response = await client.chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=max_tokens,
+            extra_body=extra_body,
         )
         choices = getattr(response, "choices", None) or []
         if not choices:
             return ""
-        return getattr(choices[0].message, "content", "") or ""
+        text = getattr(choices[0].message, "content", "") or ""
+        if getattr(choices[0], "finish_reason", "") == "length":
+            # A lens that produced 90% of its JSON and hit the ceiling is a
+            # truncation, not a model that cannot follow the format. Saying
+            # "no JSON object in response" sends the reader after the wrong
+            # problem; the actual fix is a larger budget or fewer sources.
+            raise StudyBackendError(
+                f"response hit the {max_tokens}-token output limit and was cut off "
+                "mid-structure. Raise --max-output-tokens or lower --max-corpus-chars."
+            )
+        return text
 
     return _completion
 
@@ -60,7 +83,7 @@ def build_study_backend(
     plan: str | None = None,
     plan_model: str | None = None,
     model: str | None = None,
-    max_tokens: int = 4000,
+    max_tokens: int = 16000,
 ) -> StudyBackend:
     """Resolve the completion callable for one study pass.
 
@@ -74,18 +97,73 @@ def build_study_backend(
     raise StudyBackendError("no capacity selected: pass --local or --plan <backend>")
 
 
-def _build_local_backend(*, profile: Any, model: str | None, max_tokens: int) -> StudyBackend:
+def _build_local_backend(
+    *, profile: Any, model: str | None, max_tokens: int, context_tokens: int = 16384
+) -> StudyBackend:
     from deepr.backends.local import ollama_chat_client, resolve_local_maintenance_model
 
     local_model = resolve_local_maintenance_model(profile, explicit_model=model)
+    fit_note = ""
+    if not model:
+        # Prefer a model that runs entirely on GPU. The largest available model
+        # is usually the wrong pick: a spill to CPU is silent and turns a
+        # minutes-long study pass into an hours-long one.
+        fitted, fit_note = _select_fitting_model(local_model, context_tokens)
+        if fitted:
+            local_model = fitted
     if not local_model:
         raise StudyBackendError("No local model available. Is Ollama running? Check: deepr capacity --probe")
     client = ollama_chat_client()
     return StudyBackend(
-        completion=_completion_from_chat_client(client, local_model, max_tokens=max_tokens),
+        completion=_completion_from_chat_client(
+            client, local_model, max_tokens=max_tokens, context_tokens=context_tokens
+        ),
         capacity_source=f"local:{local_model}",
-        cost_note=f"$0 (local model {local_model})",
+        cost_note=f"$0 (local model {local_model} @ {context_tokens} ctx){fit_note}",
     )
+
+
+def _select_fitting_model(current: str | None, context_tokens: int) -> tuple[str | None, str]:
+    """Choose a locally-installed model that fits in free VRAM. Best effort.
+
+    Returns (model or None, note). Any failure leaves the caller's existing
+    choice alone: declining to switch is always safe, and guessing is not.
+    """
+    try:
+        import httpx
+
+        from deepr.backends.local import _base_url
+        from deepr.backends.local_fit import choose_fitting_model, detect_vram_bytes
+
+        base = _base_url(None)
+        with httpx.Client(timeout=5.0, trust_env=False, follow_redirects=False) as client:
+            response = client.get(f"{base}/api/tags")
+            response.raise_for_status()
+            # VRAM held by an already-resident model is reclaimable: Ollama
+            # evicts it to load ours. Counting it as taken makes everything look
+            # too big and falls back to the largest model.
+            resident = client.get(f"{base}/api/ps")
+            reclaimable = sum(int(entry.get("size_vram") or 0) for entry in (resident.json() or {}).get("models") or [])
+        candidates = [
+            (
+                str(entry.get("name") or ""),
+                int(entry.get("size") or 0),
+                str((entry.get("details") or {}).get("parameter_size") or ""),
+            )
+            for entry in (response.json() or {}).get("models") or []
+            if entry.get("name")
+        ]
+        chosen, _ = choose_fitting_model(
+            candidates,
+            context_tokens=context_tokens,
+            vram_bytes=detect_vram_bytes(reclaimable_bytes=reclaimable),
+        )
+    except Exception:
+        return None, ""
+
+    if not chosen or chosen == current:
+        return None, ""
+    return chosen, f"; chose {chosen} over {current} to stay on GPU at {context_tokens} ctx"
 
 
 def _build_plan_backend(*, plan: str, plan_model: str | None, max_tokens: int) -> StudyBackend:

--- a/src/deepr/cli/commands/semantic/study_backend.py
+++ b/src/deepr/cli/commands/semantic/study_backend.py
@@ -27,6 +27,27 @@ class StudyBackendError(ValueError):
     """Setup failure that must exit non-zero before any model call."""
 
 
+_LOCAL_CHUNK_CHARS = 14_000
+"""Corpus chars per call on a local model.
+
+Conservative, and pending a re-measurement: the run that motivated this number
+used a 16,384-token ``num_ctx`` against a ~41,000-token prompt, and Ollama
+truncates over-length input silently from the front, which would have removed
+the output contract sitting at the top of the prompt. The model may have
+returned prose because it never saw the instruction, not because it could not
+follow it.
+"""
+
+_PLAN_CHUNK_CHARS = 200_000
+"""Corpus chars per call on a prepaid plan model.
+
+Measured on plan:claude: 200,000 corpus chars became a 567,000-char prompt and
+the output contract held. Applying the local limit here was costing far more
+than call count. A lens that only ever sees one source cannot compare sources,
+so chunking small made cross-source contention impossible rather than rare.
+"""
+
+
 @dataclass(frozen=True)
 class StudyBackend:
     """A resolved completion callable plus what it costs and where it runs."""
@@ -34,6 +55,8 @@ class StudyBackend:
     completion: StudyCompletion
     capacity_source: str
     cost_note: str
+    chunk_chars: int = _LOCAL_CHUNK_CHARS
+    """How much corpus this tier can hold in one call and still stay structured."""
 
 
 def _completion_from_chat_client(
@@ -218,6 +241,7 @@ def _build_plan_backend(*, plan: str, plan_model: str | None, max_tokens: int) -
         completion=_completion_from_chat_client(client, resolved_model, max_tokens=max_tokens),
         capacity_source=f"plan:{adapter.backend_id}",
         cost_note="$0 at the margin (prepaid plan)",
+        chunk_chars=_PLAN_CHUNK_CHARS,
     )
 
 

--- a/src/deepr/cli/commands/semantic/study_backend.py
+++ b/src/deepr/cli/commands/semantic/study_backend.py
@@ -64,11 +64,15 @@ def _completion_from_chat_client(
 ) -> StudyCompletion:
     """Adapt an OpenAI-style chat client to the study pass's callable.
 
-    ``context_tokens`` is passed through to Ollama as ``num_ctx``. Without it the
-    server allocates KV cache for the model's own configured context - commonly
-    32K - regardless of how much is actually needed, which silently invalidates
-    any VRAM sizing done beforehand and pushes the model onto CPU. Providers
-    that do not understand the field ignore it.
+    ``context_tokens`` is offered to Ollama as ``num_ctx``, best effort. The
+    intent is that without it the server allocates KV cache for the model's own
+    configured context - commonly 32K - regardless of how much is needed, which
+    invalidates any VRAM sizing done beforehand and pushes the model onto CPU.
+
+    Best effort is the honest wording: the field rides in ``extra_body`` and
+    Ollama's OpenAI-compatible endpoint has been observed ignoring it, so a
+    sizing decision made upstream may not be the one the server enacts. Plan
+    quota clients share this adapter and ignore the field entirely.
     """
     extra_body: dict[str, Any] = {"keep_alive": "10m"}
     if context_tokens > 0:
@@ -92,7 +96,8 @@ def _completion_from_chat_client(
             # problem; the actual fix is a larger budget or fewer sources.
             raise StudyBackendError(
                 f"response hit the {max_tokens}-token output limit and was cut off "
-                "mid-structure. Raise --max-output-tokens or lower --max-corpus-chars."
+                "mid-structure. Lower --max-corpus-chars so each call has less to "
+                "report on, or run fewer lenses per pass."
             )
         return text
 

--- a/src/deepr/experts/acquisition_plan.py
+++ b/src/deepr/experts/acquisition_plan.py
@@ -1,0 +1,270 @@
+"""Decide what to go and read, mechanically.
+
+An expert is capped by what it read. Deepr's acquisition took a list of URLs
+from a person, which is the weakest of the three channels real researchers
+use: an audit of how 495 sources in a complex review were actually found put
+protocol-driven search at 30%, citation chasing at 51%, and personal knowledge
+at 24%. Deepr had only the third, and no judgment about coverage at all.
+
+The load-bearing decision in this module is that query diversification is
+**generated, not requested**. Across 21 studies and about 9,900 participants,
+prompting a searcher to consider broader terms had limited effect while
+changing what the algorithm returned worked; searchers did not spontaneously
+broaden, and running more searches did not help. A prompt that says "also look
+for criticism" is the version that fails. So the adversarial and genre arms
+are emitted by template whether or not any model thinks they are needed.
+
+Six arms, each answering a different failure:
+
+    descriptive   what the topic is. What a naive search would find alone.
+    adversarial   who says it is wrong. Nobody searches for this unprompted.
+    genre         reviews, comments, replies, retractions - the document
+                  classes that enumerate disagreement as a matter of form.
+    primary       specs, standards, registries, datasets. Where a claim is
+                  made rather than repeated.
+    recency       what changed. A corpus of durable material misses the news.
+    terminology   the other community's word for the same thing. The
+                  documented miss is a paper that said "cross-continent"
+                  where the rest of the field said "global".
+
+Nothing here calls a model or the network. A plan is a list of strings and a
+reason for each, so it is inspectable before anything is spent.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+ARM_DESCRIPTIVE = "descriptive"
+ARM_ADVERSARIAL = "adversarial"
+ARM_GENRE = "genre"
+ARM_PRIMARY = "primary"
+ARM_RECENCY = "recency"
+ARM_TERMINOLOGY = "terminology"
+
+ARMS: tuple[str, ...] = (
+    ARM_DESCRIPTIVE,
+    ARM_ADVERSARIAL,
+    ARM_GENRE,
+    ARM_PRIMARY,
+    ARM_RECENCY,
+    ARM_TERMINOLOGY,
+)
+
+_DESCRIPTIVE_TEMPLATES = (
+    "{topic}",
+    "{topic} overview",
+    "how {topic} works",
+    "{topic} explained in depth",
+)
+
+_ADVERSARIAL_TEMPLATES = (
+    "criticism of {topic}",
+    "{topic} limitations",
+    "problems with {topic}",
+    "case against {topic}",
+    "{topic} does not work",
+    "failure to replicate {topic}",
+    "{topic} overstated",
+)
+"""Deliberately blunt. These are the searches nobody runs on their own.
+
+The evidence that people do not spontaneously seek disconfirmation is
+uniform: the positive test strategy is the default, and searching to verify a
+claim has been measured to *increase* belief in false ones, because thin
+topics return a manipulated tail. Running these by construction is the only
+version that survives that finding.
+"""
+
+_GENRE_TEMPLATES = (
+    "{topic} systematic review",
+    "{topic} controversy",
+    "comment on {topic}",
+    "reply to {topic}",
+    "{topic} retraction",
+    "{topic} correction",
+)
+"""Document classes where disagreement is required by form, not by luck.
+
+A review enumerates the disputes in its field as a matter of genre. A comment
+or reply exists only because somebody objected. Retractions and corrections
+are the highest-precision signal available and are structurally absent from a
+corpus assembled by relevance ranking.
+"""
+
+_PRIMARY_TEMPLATES = (
+    "{topic} specification",
+    "{topic} standard",
+    "{topic} original paper",
+    "{topic} dataset",
+    "{topic} reference implementation",
+)
+
+_RECENCY_TEMPLATES = (
+    "{topic} recent developments",
+    "{topic} what changed",
+    "{topic} state of the art",
+)
+
+_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+#.-]*")
+
+
+@dataclass(frozen=True)
+class AcquisitionQuery:
+    """One search to run, and why it is in the plan."""
+
+    text: str
+    arm: str
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"text": self.text, "arm": self.arm, "rationale": self.rationale}
+
+
+@dataclass
+class AcquisitionPlan:
+    """The full search, inspectable before anything is spent."""
+
+    topic: str
+    queries: list[AcquisitionQuery] = field(default_factory=list)
+    excluded_publishers: list[str] = field(default_factory=list)
+
+    def by_arm(self, arm: str) -> list[AcquisitionQuery]:
+        return [q for q in self.queries if q.arm == arm]
+
+    @property
+    def arms_covered(self) -> set[str]:
+        return {q.arm for q in self.queries}
+
+    def concerns(self) -> list[str]:
+        """Arms a plan is missing, named before it runs rather than after."""
+        notes: list[str] = []
+        if not self.by_arm(ARM_ADVERSARIAL):
+            notes.append(
+                "No adversarial queries. A corpus assembled without them reproduces whatever the "
+                "ranker considers popular, and dissent is exactly what ranking buries."
+            )
+        if not self.by_arm(ARM_TERMINOLOGY):
+            notes.append(
+                "No alternate terminology. A community that names this differently will not appear, "
+                "and a citation-based expansion cannot reach it either."
+            )
+        if not self.by_arm(ARM_PRIMARY):
+            notes.append("No primary-source queries, so the corpus may be entirely secondary retelling.")
+        return notes
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "topic": self.topic,
+            "excluded_publishers": self.excluded_publishers,
+            "arms_covered": sorted(self.arms_covered),
+            "query_count": len(self.queries),
+            "queries": [q.to_dict() for q in self.queries],
+            "concerns": self.concerns(),
+        }
+
+
+def _clean_topic(topic: str) -> str:
+    return " ".join(str(topic or "").split())
+
+
+def _emit(templates: tuple[str, ...], topic: str, arm: str, rationale: str) -> list[AcquisitionQuery]:
+    return [AcquisitionQuery(text=t.format(topic=topic), arm=arm, rationale=rationale) for t in templates]
+
+
+def _terminology_queries(alternates: tuple[str, ...]) -> list[AcquisitionQuery]:
+    """Re-ask using the other community's word for the same thing."""
+    return [
+        AcquisitionQuery(
+            text=term,
+            arm=ARM_TERMINOLOGY,
+            rationale="an alternate name for this subject; communities that use it are otherwise unreachable",
+        )
+        for term in alternates
+        if term.strip()
+    ]
+
+
+def _exclusion_queries(topic: str, excluded: tuple[str, ...]) -> list[AcquisitionQuery]:
+    """Re-run the topic with the dominant publisher removed.
+
+    A corpus that has collapsed onto one publisher will keep collapsing,
+    because the same query returns the same site. Excluding it is the cheapest
+    way to find out whether anyone else has written about this at all.
+    """
+    return [
+        AcquisitionQuery(
+            text=f"{topic} -site:{publisher}",
+            arm=ARM_DESCRIPTIVE,
+            rationale=f"{publisher} already dominates this corpus; this asks who else covers the subject",
+        )
+        for publisher in excluded
+        if publisher.strip()
+    ]
+
+
+def plan_queries(
+    topic: str,
+    *,
+    alternates: tuple[str, ...] = (),
+    exclude_publishers: tuple[str, ...] = (),
+) -> AcquisitionPlan:
+    """Build the search plan for one subject.
+
+    ``alternates`` are other names for the same thing, ideally harvested from
+    a corpus already read rather than guessed. ``exclude_publishers`` comes
+    from the independence measurement: once one origin dominates, the plan
+    asks the same questions with that origin removed.
+    """
+    clean = _clean_topic(topic)
+    plan = AcquisitionPlan(topic=clean, excluded_publishers=[p for p in exclude_publishers if p.strip()])
+    if not clean:
+        return plan
+
+    plan.queries = [
+        *_emit(_DESCRIPTIVE_TEMPLATES, clean, ARM_DESCRIPTIVE, "what the subject is, in its own terms"),
+        *_emit(
+            _ADVERSARIAL_TEMPLATES,
+            clean,
+            ARM_ADVERSARIAL,
+            "who says this is wrong; emitted by construction because nobody searches for it unprompted",
+        ),
+        *_emit(
+            _GENRE_TEMPLATES,
+            clean,
+            ARM_GENRE,
+            "document classes where disagreement appears as a matter of form",
+        ),
+        *_emit(_PRIMARY_TEMPLATES, clean, ARM_PRIMARY, "where the claim is made rather than repeated"),
+        *_emit(_RECENCY_TEMPLATES, clean, ARM_RECENCY, "what changed, which durable material misses"),
+        *_terminology_queries(alternates),
+        *_exclusion_queries(clean, tuple(plan.excluded_publishers)),
+    ]
+    return plan
+
+
+def harvest_alternates(texts: list[str], topic: str, *, limit: int = 6) -> tuple[str, ...]:
+    """Pull candidate alternate names for the subject out of what was read.
+
+    Deliberately crude: multi-word capitalized phrases and parenthesized
+    expansions, which is where a field's other name for something usually
+    sits. Harvesting from the corpus beats guessing, because the whole point
+    is to find the vocabulary the expert does not already have.
+    """
+    known = {w.lower() for w in _WORD_RE.findall(topic)}
+    seen: dict[str, int] = {}
+    for text in texts:
+        for phrase in re.findall(r"\(([^()]{3,60})\)", text or ""):
+            candidate = " ".join(phrase.split())
+            if not candidate or candidate.lower() in known:
+                continue
+            words = _WORD_RE.findall(candidate)
+            if not words or len(words) > 5:
+                continue
+            if all(w.lower() in known for w in words):
+                continue
+            seen[candidate] = seen.get(candidate, 0) + 1
+    ranked = sorted(seen.items(), key=lambda item: (-item[1], item[0]))
+    return tuple(name for name, _ in ranked[:limit])

--- a/src/deepr/experts/brief.py
+++ b/src/deepr/experts/brief.py
@@ -54,8 +54,13 @@ _CONFIDENCE_CHOICES = ", ".join(f'"{level}"' for level in CONFIDENCE_LEVELS)
 
 
 def _render_finding(finding: StudyFinding) -> str:
-    """One finding as a compact line the synthesis can cite by title."""
-    parts = [f"[{finding.lens}] {finding.title}"]
+    """One finding as a compact line the synthesis cites by its id.
+
+    The id leads because it is what citations resolve against. Titles collide
+    and get truncated, so a citation that went through the title could match
+    several findings at once or none at all.
+    """
+    parts = [f"{finding.finding_id} [{finding.lens}] {finding.title}"]
     for key, value in finding.payload.items():
         if key in {"anchors", "name", "title", "thread"}:
             continue
@@ -90,8 +95,9 @@ change your mind.
 
 Rules that make this honest rather than confident-sounding:
 
-- Every position must cite the finding titles it rests on, so "why do you think that" is
-  answerable. Cite titles exactly as written below.
+- Every position must cite the findings it rests on, so "why do you think that" is answerable.
+  Cite by the id at the start of each finding line, for example "contention-4". Ids only; a
+  citation that is not an id from the list below will be dropped.
 - Every position must state an observation that would overturn it. Name something someone could
   actually go and check: a measurement, a document, a result. "If new evidence emerges" is not a
   falsifier, because nobody can check it. A position with no falsifier is an assertion.
@@ -120,7 +126,7 @@ Return JSON only, no prose outside it, with this shape:
   "positions": [
     {{"question": "", "stance": "", "reasoning": "",
       "likelihood": "", "confidence": "", "resolution": "single",
-      "would_change_my_mind": "", "supported_by": ["exact finding title"],
+      "would_change_my_mind": "", "supported_by": ["finding id, e.g. contention-4"],
       "unresolved_dissent": "", "confidence_basis": ""}}
   ],
   "state": {{"settled": [""], "live": [""], "unknown": [""]}},
@@ -186,15 +192,15 @@ def _from_vocabulary(value: Any, allowed: Any) -> str:
     return term if term in allowed else ""
 
 
-def provenance_for(titles: list[str], result: StudyResult, corpus: CorpusStore) -> tuple[int, int]:
+def provenance_for(finding_ids: list[str], result: StudyResult, corpus: CorpusStore) -> tuple[int, int]:
     """Sources and distinct publishers behind a set of cited findings.
 
     The second number is the one that means anything. Five sources restating
     one publisher is one publisher's authority, and a position resting on that
     shape needs to say so rather than present five citations.
     """
-    wanted = set(titles)
-    shas = {sha for f in result.findings if f.title in wanted for sha in f.corpus_shas}
+    wanted = set(finding_ids)
+    shas = {sha for f in result.findings if f.finding_id in wanted for sha in f.corpus_shas}
     origins = {entry.origin_key for sha in shas if (entry := corpus.entries.get(sha)) is not None}
     return len(shas), len(origins)
 
@@ -205,12 +211,12 @@ def _positions_from(raw_positions: Any, *, result: StudyResult, corpus: CorpusSt
     A position citing something that does not exist cannot answer "why do you
     think that", and keeping the citation would make it look like it could.
     """
-    known_titles = {f.title for f in result.findings}
+    known_ids = {f.finding_id for f in result.findings if f.finding_id}
     positions: list[Position] = []
     for raw in raw_positions or []:
         if not isinstance(raw, dict):
             continue
-        cited = [t for t in _as_list(raw.get("supported_by")) if t in known_titles]
+        cited = [t for t in _as_list(raw.get("supported_by")) if t in known_ids]
         documents, roots = provenance_for(cited, result, corpus)
         positions.append(
             Position(
@@ -239,7 +245,7 @@ def assemble_brief(
     corpus: CorpusStore,
 ) -> ExpertBrief:
     """Turn a parsed synthesis into a brief, keeping only verifiable citations."""
-    known_titles = {f.title for f in result.findings}
+    known_ids = {f.finding_id for f in result.findings if f.finding_id}
 
     positions = _positions_from(parsed.get("positions"), result=result, corpus=corpus)
 
@@ -248,7 +254,7 @@ def assemble_brief(
             question=_text(raw.get("question")),
             answer=_text(raw.get("answer")),
             why_asked=_text(raw.get("why_asked")),
-            supported_by=[t for t in _as_list(raw.get("supported_by")) if t in known_titles],
+            supported_by=[t for t in _as_list(raw.get("supported_by")) if t in known_ids],
             weakens_thesis=bool(raw.get("weakens_thesis")),
         )
         for raw in (parsed.get("anticipated_questions") or [])
@@ -271,6 +277,7 @@ def assemble_brief(
         anticipated_questions=questions,
         common_failures=_as_list(parsed.get("common_failures")),
         credibility=build_credibility(corpus),
+        finding_titles={f.finding_id: f.title for f in result.findings if f.finding_id},
         generated_from_findings=len(result.findings),
     )
 
@@ -352,7 +359,12 @@ def _render_calibration(position: Position) -> list[str]:
     return lines
 
 
-def _render_position(index: int, position: Position) -> list[str]:
+def _cited_labels(position: Position, titles: dict[str, str]) -> str:
+    """Render citations as readable titles, keeping the id for lookup."""
+    return "; ".join(f"{_short(titles.get(cid, cid))} ({cid})" for cid in position.supported_by[:4])
+
+
+def _render_position(index: int, position: Position, titles: dict[str, str]) -> list[str]:
     """One position: where it lands, what it rests on, what would overturn it."""
     label = {"irreducible": " (unresolved)", "conditional": " (conditional)"}.get(position.resolution, "")
     lines = [f"{index}. **{position.question or 'Position'}**{label}"]
@@ -371,7 +383,7 @@ def _render_position(index: int, position: Position) -> list[str]:
     else:
         lines.append("   - **No falsifier stated**: treat as assertion, not judgment.")
     if position.supported_by:
-        lines.append(f"   - Rests on: {'; '.join(_short(t) for t in position.supported_by[:4])}")
+        lines.append(f"   - Rests on: {_cited_labels(position, titles)}")
     if position.supporting_documents:
         depth = f"{position.supporting_documents} source(s), {position.distinct_roots} publisher(s)"
         flag = " - **one publisher, so this is not corroboration**" if position.is_single_origin else ""
@@ -386,7 +398,7 @@ def _render_positions(brief: ExpertBrief) -> list[str]:
         return []
     lines = ["## Where I land, and why", ""]
     for index, position in enumerate(brief.positions, 1):
-        lines.extend(_render_position(index, position))
+        lines.extend(_render_position(index, position, brief.finding_titles))
     return lines
 
 

--- a/src/deepr/experts/brief.py
+++ b/src/deepr/experts/brief.py
@@ -33,6 +33,9 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from deepr.experts.brief_contracts import (
+    CONFIDENCE_LEVELS,
+    LIKELIHOOD_BANDS,
+    RESOLUTIONS,
     AnticipatedQuestion,
     ExpertBrief,
     Position,
@@ -46,6 +49,8 @@ BriefCompletion = Callable[[str], Awaitable[str]]
 
 _MAX_FINDINGS_IN_PROMPT = 120
 _MAX_FIELD_CHARS = 600
+_LIKELIHOOD_CHOICES = ", ".join(f'"{term}"' for term in LIKELIHOOD_BANDS)
+_CONFIDENCE_CHOICES = ", ".join(f'"{level}"' for level in CONFIDENCE_LEVELS)
 
 
 def _render_finding(finding: StudyFinding) -> str:
@@ -87,27 +92,41 @@ Rules that make this honest rather than confident-sounding:
 
 - Every position must cite the finding titles it rests on, so "why do you think that" is
   answerable. Cite titles exactly as written below.
-- Every position must state an observation that would overturn it. A position with no falsifier
-  is an assertion; do not report one.
+- Every position must state an observation that would overturn it. Name something someone could
+  actually go and check: a measurement, a document, a result. "If new evidence emerges" is not a
+  falsifier, because nobody can check it. A position with no falsifier is an assertion.
+- "likelihood" and "confidence" are different things and must not be mixed. "likelihood" is how
+  likely the stance is true. "confidence" is how sound your basis for saying so is. A claim can
+  be a coin flip on excellent evidence, or near-certain on thin evidence.
 - Where the findings disagree, say what you did not resolve. Do not average disagreement into a
   middle position. Unresolved disagreement is a legitimate and useful output.
 - Separate what is settled, what is live, and what is genuinely unknown. Refusing to spend a
   reader's time on resolved questions is most of the value here.
+- At least one anticipated question must attack this brief rather than support it: the strongest
+  case that you are wrong, or what you did not look at. Mark it "weakens_thesis": true.
 - Do not introduce claims that are not supported by the findings below.
 {dissent_note}
+"likelihood" must be exactly one of: {_LIKELIHOOD_CHOICES}.
+"confidence" must be exactly one of: {_CONFIDENCE_CHOICES}.
+"resolution" must be exactly one of: single (you land on one stance);
+conditional (the stance depends on an assumption, which you state); irreducible (the findings
+did not reconcile, and you are reporting that rather than picking). Prefer irreducible over
+inventing agreement.
+
 Return JSON only, no prose outside it, with this shape:
 
 {{
   "orientation": "the sixty-second version a newcomer needs before asking anything",
   "positions": [
     {{"question": "", "stance": "", "reasoning": "",
+      "likelihood": "", "confidence": "", "resolution": "single",
       "would_change_my_mind": "", "supported_by": ["exact finding title"],
       "unresolved_dissent": "", "confidence_basis": ""}}
   ],
   "state": {{"settled": [""], "live": [""], "unknown": [""]}},
   "key_quantities": ["the numbers that anchor discussion here"],
   "anticipated_questions": [
-    {{"question": "", "answer": "", "why_asked": "", "supported_by": [""]}}
+    {{"question": "", "answer": "", "why_asked": "", "supported_by": [""], "weakens_thesis": false}}
   ],
   "common_failures": ["what people try first that does not work, and why"]
 }}
@@ -157,25 +176,56 @@ def build_credibility(corpus: CorpusStore) -> list[SourceCredibility]:
     return rows
 
 
-def _positions_from(raw_positions: Any, known_titles: set[str]) -> list[Position]:
+def _from_vocabulary(value: Any, allowed: Any) -> str:
+    """Keep a calibration term only if it is one of the terms we defined.
+
+    A term outside the vocabulary is dropped rather than passed through: an
+    invented likelihood word reads as calibration while carrying none.
+    """
+    term = _text(value).lower().rstrip(".")
+    return term if term in allowed else ""
+
+
+def provenance_for(titles: list[str], result: StudyResult, corpus: CorpusStore) -> tuple[int, int]:
+    """Sources and distinct publishers behind a set of cited findings.
+
+    The second number is the one that means anything. Five sources restating
+    one publisher is one publisher's authority, and a position resting on that
+    shape needs to say so rather than present five citations.
+    """
+    wanted = set(titles)
+    shas = {sha for f in result.findings if f.title in wanted for sha in f.corpus_shas}
+    origins = {entry.origin_key for sha in shas if (entry := corpus.entries.get(sha)) is not None}
+    return len(shas), len(origins)
+
+
+def _positions_from(raw_positions: Any, *, result: StudyResult, corpus: CorpusStore) -> list[Position]:
     """Build positions, keeping only citations that name a real finding.
 
     A position citing something that does not exist cannot answer "why do you
     think that", and keeping the citation would make it look like it could.
     """
+    known_titles = {f.title for f in result.findings}
     positions: list[Position] = []
     for raw in raw_positions or []:
         if not isinstance(raw, dict):
             continue
+        cited = [t for t in _as_list(raw.get("supported_by")) if t in known_titles]
+        documents, roots = provenance_for(cited, result, corpus)
         positions.append(
             Position(
                 question=_text(raw.get("question")),
                 stance=_text(raw.get("stance")),
                 reasoning=_text(raw.get("reasoning")),
                 would_change_my_mind=_text(raw.get("would_change_my_mind")),
-                supported_by=[t for t in _as_list(raw.get("supported_by")) if t in known_titles],
+                supported_by=cited,
                 unresolved_dissent=_text(raw.get("unresolved_dissent")),
                 confidence_basis=_text(raw.get("confidence_basis")),
+                likelihood=_from_vocabulary(raw.get("likelihood"), LIKELIHOOD_BANDS),
+                confidence=_from_vocabulary(raw.get("confidence"), CONFIDENCE_LEVELS),
+                resolution=_from_vocabulary(raw.get("resolution"), RESOLUTIONS) or "single",
+                supporting_documents=documents,
+                distinct_roots=roots,
             )
         )
     return positions
@@ -191,7 +241,7 @@ def assemble_brief(
     """Turn a parsed synthesis into a brief, keeping only verifiable citations."""
     known_titles = {f.title for f in result.findings}
 
-    positions = _positions_from(parsed.get("positions"), known_titles)
+    positions = _positions_from(parsed.get("positions"), result=result, corpus=corpus)
 
     questions = [
         AnticipatedQuestion(
@@ -199,6 +249,7 @@ def assemble_brief(
             answer=_text(raw.get("answer")),
             why_asked=_text(raw.get("why_asked")),
             supported_by=[t for t in _as_list(raw.get("supported_by")) if t in known_titles],
+            weakens_thesis=bool(raw.get("weakens_thesis")),
         )
         for raw in (parsed.get("anticipated_questions") or [])
         if isinstance(raw, dict) and _text(raw.get("question"))
@@ -270,27 +321,72 @@ async def build_brief(
     return assemble_brief(parsed, expert_name=expert_name, result=result, corpus=corpus)
 
 
+def _short(title: str, limit: int = 90) -> str:
+    """Shorten a citation for display, on a word boundary.
+
+    Lenses that describe rather than name produce sentence-length titles. Cited
+    verbatim they wrap into a wall and cut mid-word; the full title stays in the
+    JSON, this is only what the reader sees.
+    """
+    if len(title) <= limit:
+        return title
+    return title[:limit].rsplit(" ", 1)[0] + "..."
+
+
+def _render_calibration(position: Position) -> list[str]:
+    """Likelihood and confidence, on separate lines because they are separate.
+
+    The band is printed with its numbers every time. Readers hold the words to
+    a different scale than the author does, and a legend elsewhere does not fix
+    that, so the number travels with the word.
+    """
+    lines: list[str] = []
+    band = position.likelihood_band
+    if band:
+        lines.append(f"   - Likelihood it holds: {position.likelihood} ({band[0]}-{band[1]}%)")
+    if position.confidence:
+        basis = f" ({position.confidence_basis})" if position.confidence_basis else ""
+        lines.append(f"   - Confidence in that basis: {position.confidence}{basis}")
+    elif position.confidence_basis:
+        lines.append(f"   - Confidence rests on: {position.confidence_basis}")
+    return lines
+
+
+def _render_position(index: int, position: Position) -> list[str]:
+    """One position: where it lands, what it rests on, what would overturn it."""
+    label = {"irreducible": " (unresolved)", "conditional": " (conditional)"}.get(position.resolution, "")
+    lines = [f"{index}. **{position.question or 'Position'}**{label}"]
+    if position.resolution == "irreducible":
+        lines.append("   - **Not resolved.** The findings did not reconcile; both readings are below.")
+    lines.append(f"   - Stance: {position.stance}")
+    if position.reasoning:
+        lines.append(f"   - Because: {position.reasoning}")
+    lines.extend(_render_calibration(position))
+    if position.unresolved_dissent:
+        lines.append(f"   - **Does not resolve**: {position.unresolved_dissent}")
+    if position.would_change_my_mind:
+        lines.append(f"   - Would change my mind: {position.would_change_my_mind}")
+        if position.falsifier_is_decorative:
+            lines.append("   - **That falsifier names nothing observable**, so nothing can check it.")
+    else:
+        lines.append("   - **No falsifier stated**: treat as assertion, not judgment.")
+    if position.supported_by:
+        lines.append(f"   - Rests on: {'; '.join(_short(t) for t in position.supported_by[:4])}")
+    if position.supporting_documents:
+        depth = f"{position.supporting_documents} source(s), {position.distinct_roots} publisher(s)"
+        flag = " - **one publisher, so this is not corroboration**" if position.is_single_origin else ""
+        lines.append(f"   - Evidential depth: {depth}{flag}")
+    lines.append("")
+    return lines
+
+
 def _render_positions(brief: ExpertBrief) -> list[str]:
     """Render each position with what it rests on and what would overturn it."""
     if not brief.positions:
         return []
     lines = ["## Where I land, and why", ""]
     for index, position in enumerate(brief.positions, 1):
-        lines.append(f"{index}. **{position.question or 'Position'}**")
-        lines.append(f"   - Stance: {position.stance}")
-        if position.reasoning:
-            lines.append(f"   - Because: {position.reasoning}")
-        if position.confidence_basis:
-            lines.append(f"   - Confidence rests on: {position.confidence_basis}")
-        if position.unresolved_dissent:
-            lines.append(f"   - **Does not resolve**: {position.unresolved_dissent}")
-        if position.would_change_my_mind:
-            lines.append(f"   - Would change my mind: {position.would_change_my_mind}")
-        else:
-            lines.append("   - **No falsifier stated**: treat as assertion, not judgment.")
-        if position.supported_by:
-            lines.append(f"   - Rests on: {'; '.join(position.supported_by[:4])}")
-        lines.append("")
+        lines.extend(_render_position(index, position))
     return lines
 
 
@@ -329,7 +425,8 @@ def _render_questions(brief: ExpertBrief) -> list[str]:
         return []
     lines = ["## Questions I expect", ""]
     for question in brief.anticipated_questions:
-        lines.append(f"**{question.question}**")
+        attack = " (this one costs me something)" if question.weakens_thesis else ""
+        lines.append(f"**{question.question}**{attack}")
         lines.append(question.answer)
         if question.why_asked:
             lines.append(f"_Asked because: {question.why_asked}_")

--- a/src/deepr/experts/brief.py
+++ b/src/deepr/experts/brief.py
@@ -1,0 +1,385 @@
+"""Build a consultable brief from study findings.
+
+Study produces findings about material. A brief is what an expert carries into a
+conversation: where the field stands, what is settled so you can skip it, where
+they land and why, and what would change their mind.
+
+This is the one stage that is allowed to form a view. Everything before it
+reports; this synthesizes. That makes it the stage most able to mislead, so it
+runs under three constraints:
+
+**It runs after independent lenses, never between them.** Lenses that see each
+other's output converge, and the convergence is not agreement - social influence
+collapses estimate diversity without improving accuracy, and consensus-seeking
+deliberation lands near the average rather than the best. Independence first,
+synthesis strictly afterwards.
+
+**It must preserve what it cannot resolve.** Every intelligence post-mortem
+examined found the correct answer already present in the system and smoothed
+away in aggregation. A position that resolves a genuine disagreement by not
+mentioning it is the documented failure, not a cleaner product.
+
+**Every position carries a falsifier and its supporting findings.** A stance
+with nothing that would overturn it is an assertion. A stance that cannot name
+what it rests on cannot answer "why do you think that", which is the second
+question anyone asks an expert.
+
+The model call is injected, so the whole builder is unit-testable at $0.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from deepr.experts.brief_contracts import (
+    AnticipatedQuestion,
+    ExpertBrief,
+    Position,
+    SettledState,
+    SourceCredibility,
+)
+from deepr.experts.corpus_store import CorpusStore
+from deepr.experts.study_contracts import StudyFinding, StudyResult
+
+BriefCompletion = Callable[[str], Awaitable[str]]
+
+_MAX_FINDINGS_IN_PROMPT = 120
+_MAX_FIELD_CHARS = 600
+
+
+def _render_finding(finding: StudyFinding) -> str:
+    """One finding as a compact line the synthesis can cite by title."""
+    parts = [f"[{finding.lens}] {finding.title}"]
+    for key, value in finding.payload.items():
+        if key in {"anchors", "name", "title", "thread"}:
+            continue
+        text = "; ".join(str(v) for v in value) if isinstance(value, list) else str(value)
+        text = " ".join(text.split())[:_MAX_FIELD_CHARS]
+        if text:
+            parts.append(f"  {key}: {text}")
+    if not finding.is_grounded:
+        parts.append("  (UNVERIFIED: quoted support not found in the corpus)")
+    return "\n".join(parts)
+
+
+def build_brief_prompt(result: StudyResult, *, expert_name: str, domain: str = "") -> str:
+    """Assemble the synthesis prompt from independent findings."""
+    findings = result.findings[:_MAX_FINDINGS_IN_PROMPT]
+    rendered = "\n".join(_render_finding(f) for f in findings)
+    contested = [f for f in result.findings if f.lens == "contention"]
+
+    dissent_note = (
+        f"\n{len(contested)} finding(s) came from the contention lens, which looks for disagreement "
+        "between sources. Any position touching those must state what it does not resolve.\n"
+        if contested
+        else "\nNo contention findings were produced. Do not manufacture disagreement to fill the field.\n"
+    )
+
+    return f"""You are preparing a briefing on "{expert_name}"{f" ({domain})" if domain else ""}.
+
+Below are findings produced by several independent analytical passes over a source corpus. Your
+job is not to summarize them. It is to produce what an expert carries into a conversation: where
+things stand, what is settled so a reader can skip it, where you land and why, and what would
+change your mind.
+
+Rules that make this honest rather than confident-sounding:
+
+- Every position must cite the finding titles it rests on, so "why do you think that" is
+  answerable. Cite titles exactly as written below.
+- Every position must state an observation that would overturn it. A position with no falsifier
+  is an assertion; do not report one.
+- Where the findings disagree, say what you did not resolve. Do not average disagreement into a
+  middle position. Unresolved disagreement is a legitimate and useful output.
+- Separate what is settled, what is live, and what is genuinely unknown. Refusing to spend a
+  reader's time on resolved questions is most of the value here.
+- Do not introduce claims that are not supported by the findings below.
+{dissent_note}
+Return JSON only, no prose outside it, with this shape:
+
+{{
+  "orientation": "the sixty-second version a newcomer needs before asking anything",
+  "positions": [
+    {{"question": "", "stance": "", "reasoning": "",
+      "would_change_my_mind": "", "supported_by": ["exact finding title"],
+      "unresolved_dissent": "", "confidence_basis": ""}}
+  ],
+  "state": {{"settled": [""], "live": [""], "unknown": [""]}},
+  "key_quantities": ["the numbers that anchor discussion here"],
+  "anticipated_questions": [
+    {{"question": "", "answer": "", "why_asked": "", "supported_by": [""]}}
+  ],
+  "common_failures": ["what people try first that does not work, and why"]
+}}
+
+===== FINDINGS BEGIN =====
+{rendered}
+===== FINDINGS END =====
+"""
+
+
+def _as_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [" ".join(str(v).split()) for v in value if str(v).strip()]
+    if isinstance(value, str) and value.strip():
+        return [" ".join(value.split())]
+    return []
+
+
+def _text(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def build_credibility(corpus: CorpusStore) -> list[SourceCredibility]:
+    """Report evidential depth per origin, not citation count.
+
+    Several sources from one publisher are one publisher's authority, however
+    many pages they came from.
+    """
+    rows: list[SourceCredibility] = []
+    for origin in sorted(corpus.distinct_origins()):
+        entries = [e for e in corpus.entries_for_origin(origin) if e.is_active]
+        if not entries:
+            continue
+        rows.append(
+            SourceCredibility(
+                origin=origin,
+                source_count=len(entries),
+                trust_class=entries[0].trust_class,
+                is_sole_root=len(entries) > 1,
+                note=(
+                    f"{len(entries)} sources from one publisher; repetition here is not independent corroboration."
+                    if len(entries) > 1
+                    else ""
+                ),
+            )
+        )
+    return rows
+
+
+def _positions_from(raw_positions: Any, known_titles: set[str]) -> list[Position]:
+    """Build positions, keeping only citations that name a real finding.
+
+    A position citing something that does not exist cannot answer "why do you
+    think that", and keeping the citation would make it look like it could.
+    """
+    positions: list[Position] = []
+    for raw in raw_positions or []:
+        if not isinstance(raw, dict):
+            continue
+        positions.append(
+            Position(
+                question=_text(raw.get("question")),
+                stance=_text(raw.get("stance")),
+                reasoning=_text(raw.get("reasoning")),
+                would_change_my_mind=_text(raw.get("would_change_my_mind")),
+                supported_by=[t for t in _as_list(raw.get("supported_by")) if t in known_titles],
+                unresolved_dissent=_text(raw.get("unresolved_dissent")),
+                confidence_basis=_text(raw.get("confidence_basis")),
+            )
+        )
+    return positions
+
+
+def assemble_brief(
+    parsed: dict[str, Any],
+    *,
+    expert_name: str,
+    result: StudyResult,
+    corpus: CorpusStore,
+) -> ExpertBrief:
+    """Turn a parsed synthesis into a brief, keeping only verifiable citations."""
+    known_titles = {f.title for f in result.findings}
+
+    positions = _positions_from(parsed.get("positions"), known_titles)
+
+    questions = [
+        AnticipatedQuestion(
+            question=_text(raw.get("question")),
+            answer=_text(raw.get("answer")),
+            why_asked=_text(raw.get("why_asked")),
+            supported_by=[t for t in _as_list(raw.get("supported_by")) if t in known_titles],
+        )
+        for raw in (parsed.get("anticipated_questions") or [])
+        if isinstance(raw, dict) and _text(raw.get("question"))
+    ]
+
+    raw_state = parsed.get("state") or {}
+    state = SettledState(
+        settled=_as_list(raw_state.get("settled")) if isinstance(raw_state, dict) else [],
+        live=_as_list(raw_state.get("live")) if isinstance(raw_state, dict) else [],
+        unknown=_as_list(raw_state.get("unknown")) if isinstance(raw_state, dict) else [],
+    )
+
+    brief = ExpertBrief(
+        expert_name=expert_name,
+        orientation=_text(parsed.get("orientation")),
+        positions=[p for p in positions if p.stance],
+        state=state,
+        key_quantities=_as_list(parsed.get("key_quantities")),
+        anticipated_questions=questions,
+        common_failures=_as_list(parsed.get("common_failures")),
+        credibility=build_credibility(corpus),
+        generated_from_findings=len(result.findings),
+    )
+
+    ungrounded = [f for f in result.findings if not f.is_grounded]
+    if ungrounded:
+        brief.limitations.append(
+            f"{len(ungrounded)} of {len(result.findings)} findings were not verifiable against the "
+            "retained corpus. Positions resting on them inherit that."
+        )
+    brief.limitations.extend(result.limitations)
+    return brief
+
+
+async def build_brief(
+    *,
+    expert_name: str,
+    result: StudyResult,
+    corpus: CorpusStore,
+    completion: BriefCompletion,
+    domain: str = "",
+) -> ExpertBrief:
+    """Synthesize one brief. Returns an empty brief rather than raising."""
+    from deepr.experts.study import extract_json_object
+
+    if not result.findings:
+        brief = ExpertBrief(expert_name=expert_name)
+        brief.limitations.append(
+            "No study findings to brief from. Run `expert study` first; a brief over nothing "
+            "would be invention rather than synthesis."
+        )
+        return brief
+
+    prompt = build_brief_prompt(result, expert_name=expert_name, domain=domain)
+    try:
+        raw = await completion(prompt)
+    except Exception as exc:
+        brief = ExpertBrief(expert_name=expert_name, generated_from_findings=len(result.findings))
+        brief.limitations.append(f"Synthesis call failed: {str(exc)[:200]}")
+        return brief
+
+    parsed, error = extract_json_object(raw)
+    if parsed is None:
+        brief = ExpertBrief(expert_name=expert_name, generated_from_findings=len(result.findings))
+        snippet = " ".join((raw or "").split())[:200]
+        brief.limitations.append(f"Synthesis did not return usable JSON ({error}). Began: {snippet!r}")
+        return brief
+
+    return assemble_brief(parsed, expert_name=expert_name, result=result, corpus=corpus)
+
+
+def _render_positions(brief: ExpertBrief) -> list[str]:
+    """Render each position with what it rests on and what would overturn it."""
+    if not brief.positions:
+        return []
+    lines = ["## Where I land, and why", ""]
+    for index, position in enumerate(brief.positions, 1):
+        lines.append(f"{index}. **{position.question or 'Position'}**")
+        lines.append(f"   - Stance: {position.stance}")
+        if position.reasoning:
+            lines.append(f"   - Because: {position.reasoning}")
+        if position.confidence_basis:
+            lines.append(f"   - Confidence rests on: {position.confidence_basis}")
+        if position.unresolved_dissent:
+            lines.append(f"   - **Does not resolve**: {position.unresolved_dissent}")
+        if position.would_change_my_mind:
+            lines.append(f"   - Would change my mind: {position.would_change_my_mind}")
+        else:
+            lines.append("   - **No falsifier stated**: treat as assertion, not judgment.")
+        if position.supported_by:
+            lines.append(f"   - Rests on: {'; '.join(position.supported_by[:4])}")
+        lines.append("")
+    return lines
+
+
+def _render_state(brief: ExpertBrief) -> list[str]:
+    """Settled / live / unknown. Telling a reader what to skip is most of the value."""
+    if not (brief.state.settled or brief.state.live or brief.state.unknown):
+        return []
+    lines = ["## Settled, live, unknown", ""]
+    for label, items in (
+        ("Settled (skip these)", brief.state.settled),
+        ("Live", brief.state.live),
+        ("Genuinely unknown", brief.state.unknown),
+    ):
+        if items:
+            lines.append(f"**{label}**")
+            lines.extend(f"- {item}" for item in items)
+            lines.append("")
+    return lines
+
+
+def _render_lists(brief: ExpertBrief) -> list[str]:
+    lines: list[str] = []
+    for heading, items in (
+        ("## The numbers that matter", brief.key_quantities),
+        ("## What people try that does not work", brief.common_failures),
+    ):
+        if items:
+            lines.extend([heading, ""])
+            lines.extend(f"- {item}" for item in items)
+            lines.append("")
+    return lines
+
+
+def _render_questions(brief: ExpertBrief) -> list[str]:
+    if not brief.anticipated_questions:
+        return []
+    lines = ["## Questions I expect", ""]
+    for question in brief.anticipated_questions:
+        lines.append(f"**{question.question}**")
+        lines.append(question.answer)
+        if question.why_asked:
+            lines.append(f"_Asked because: {question.why_asked}_")
+        lines.append("")
+    return lines
+
+
+def _render_credibility(brief: ExpertBrief) -> list[str]:
+    """Evidential depth per origin, not citation count."""
+    if not brief.credibility:
+        return []
+    lines = ["## Who this rests on", "", "| Origin | Sources | Trust | Note |", "|---|---|---|---|"]
+    lines.extend(
+        f"| {row.origin} | {row.source_count} | {row.trust_class} | {row.note or '-'} |" for row in brief.credibility
+    )
+    lines.append("")
+    return lines
+
+
+def render_brief(brief: ExpertBrief) -> str:
+    """Render the brief for reading. Bottom line first."""
+    lines = [f"# {brief.expert_name}: brief", ""]
+    if brief.orientation:
+        lines.extend(["## In sixty seconds", "", brief.orientation, ""])
+
+    lines.extend(_render_positions(brief))
+
+    lines.extend(_render_state(brief))
+    lines.extend(_render_lists(brief))
+    lines.extend(_render_questions(brief))
+    lines.extend(_render_credibility(brief))
+
+    warnings = brief.integrity_warnings()
+    if warnings:
+        lines.extend(["## Read this brief knowing", ""])
+        lines.extend(f"- {w}" for w in warnings)
+        lines.append("")
+
+    if brief.limitations:
+        lines.extend(["## Limitations", ""])
+        lines.extend(f"- {item}" for item in brief.limitations)
+        lines.append("")
+
+    lines.extend(
+        [
+            "---",
+            "",
+            "Derived from study findings over a retained corpus. Positions are the expert's "
+            "reading of that evidence, not verified fact; each states what would overturn it.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/deepr/experts/brief.py
+++ b/src/deepr/experts/brief.py
@@ -111,6 +111,10 @@ Rules that make this honest rather than confident-sounding:
 - At least one anticipated question must attack this brief rather than support it: the strongest
   case that you are wrong, or what you did not look at. Mark it "weakens_thesis": true.
 - Do not introduce claims that are not supported by the findings below.
+
+House style, which applies to every field you return: write plain ASCII punctuation. Use a
+regular hyphen, never an en dash or em dash. Use straight quotes, never curly ones. No emoji.
+Prose, not decoration.
 {dissent_note}
 "likelihood" must be exactly one of: {_LIKELIHOOD_CHOICES}.
 "confidence" must be exactly one of: {_CONFIDENCE_CHOICES}.
@@ -151,8 +155,27 @@ def _as_list(value: Any) -> list[str]:
     return []
 
 
+_TYPOGRAPHY = str.maketrans(
+    {
+        "–": "-",
+        "—": "-",
+        "‘": "'",
+        "’": "'",
+        "“": '"',
+        "”": '"',
+        "…": "...",
+        " ": " ",
+    }
+)
+"""House style, enforced rather than requested.
+
+The prompt asks for plain punctuation and mostly gets it. Mostly is not a
+contract, and a stray en dash survives into every artifact downstream, so the
+substitution happens here where it cannot be declined."""
+
+
 def _text(value: Any) -> str:
-    return " ".join(str(value or "").split())
+    return " ".join(str(value or "").translate(_TYPOGRAPHY).split())
 
 
 def build_credibility(corpus: CorpusStore) -> list[SourceCredibility]:

--- a/src/deepr/experts/brief_contracts.py
+++ b/src/deepr/experts/brief_contracts.py
@@ -10,7 +10,7 @@ summary of them. Summarizing is the low-utility operation; what makes an expert
 useful is that they have *landed somewhere* and can say why, and can tell you
 what they are not sure about without embarrassment.
 
-Two rules the types enforce structurally rather than by convention:
+Four rules the types enforce structurally rather than by convention:
 
 1. **A position carries its own falsifier.** A stance without a stated
    observation that would overturn it is not a judgment, it is an assertion.
@@ -20,14 +20,66 @@ Two rules the types enforce structurally rather than by convention:
    post-mortem examined found the correct answer had been present and was
    smoothed away; a brief that reads confident because it dropped the
    disagreement reproduces exactly that.
+3. **Likelihood and confidence are different quantities and never share a
+   field.** How likely a claim is to be true, and how sound the basis for that
+   estimate is, move independently: a well-evidenced claim can be a coin flip,
+   and a thinly-evidenced one can be near-certain. Analytic standards across
+   intelligence, climate and clinical practice all require the split, and all
+   three record harm from products that collapsed it.
+4. **A position may decline to resolve.** ``resolution`` makes "these did not
+   reconcile" a first-class answer, so the schema never forces a stance the
+   evidence does not support. Without it, a required stance field guarantees
+   invention whenever the findings genuinely conflict.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-BRIEF_SCHEMA_VERSION = "deepr-expert-brief-v1"
+BRIEF_SCHEMA_VERSION = "deepr-expert-brief-v2"
+
+LIKELIHOOD_BANDS: dict[str, tuple[int, int]] = {
+    "almost no chance": (1, 5),
+    "very unlikely": (5, 20),
+    "unlikely": (20, 45),
+    "roughly even chance": (45, 55),
+    "likely": (55, 80),
+    "very likely": (80, 95),
+    "almost certain": (95, 99),
+}
+"""Closed vocabulary for how likely a claim is. Rendered with its numbers.
+
+Readers reconstruct these words wrong when the numbers live in a legend: given
+a published glossary, they still read "very likely" as roughly 65-75% when the
+author meant 90%+. So the band is printed inline, every time, not defined once.
+"""
+
+CONFIDENCE_LEVELS: tuple[str, ...] = ("high", "moderate", "low")
+"""How sound the basis is: source quantity, independence, and agreement."""
+
+RESOLUTIONS: tuple[str, ...] = ("single", "conditional", "irreducible")
+"""single: one stance. conditional: stance depends on a stated assumption.
+irreducible: the findings did not reconcile and the brief does not pretend."""
+
+_VAGUE_FALSIFIER_RE = re.compile(
+    r"\b(?:new (?:evidence|information|data|research|sources?)"
+    r"|(?:the )?evidence (?:change|changes|changed|shift\w*|weaken\w*|improv\w*)"
+    r"|further (?:study|studies|research|work|analysis)"
+    r"|more (?:data|evidence|research|sources?)"
+    r"|additional (?:data|evidence|research|sources?)"
+    r"|better (?:data|evidence|understanding))\b",
+    re.IGNORECASE,
+)
+
+_SPECIFICITY_RE = re.compile(
+    r"\d"
+    r"|\b(?:above|below|under|exceed\w*|fewer|greater|absent|missing|contradict\w*"
+    r"|replicat\w*|measur\w*|publish\w*|reverse\w*|trial|dataset|benchmark|audit"
+    r"|log|logs|incident|retract\w*|withdraw\w*)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -45,6 +97,16 @@ class Position:
     """Disagreement this position does not settle, stated rather than smoothed."""
     confidence_basis: str = ""
     """What the confidence rests on: source count, independence, agreement."""
+    likelihood: str = ""
+    """How likely the stance is true. A term from LIKELIHOOD_BANDS, or empty."""
+    confidence: str = ""
+    """How sound the basis is. A term from CONFIDENCE_LEVELS, or empty."""
+    resolution: str = "single"
+    """single, conditional, or irreducible. See RESOLUTIONS."""
+    supporting_documents: int = 0
+    """Retained sources behind the cited findings."""
+    distinct_roots: int = 0
+    """Distinct publishers behind those sources. This is the number that counts."""
 
     @property
     def is_falsifiable(self) -> bool:
@@ -54,10 +116,40 @@ class Position:
     def is_grounded(self) -> bool:
         return bool(self.supported_by)
 
+    @property
+    def likelihood_band(self) -> tuple[int, int] | None:
+        return LIKELIHOOD_BANDS.get(self.likelihood)
+
+    @property
+    def is_single_origin(self) -> bool:
+        """Several sources, one publisher: apparent corroboration that is not.
+
+        The documented shape behind more than one intelligence failure, where a
+        judgment read as multiply-sourced and traced back to a single origin.
+        """
+        return self.distinct_roots == 1 and self.supporting_documents > 1
+
+    @property
+    def falsifier_is_decorative(self) -> bool:
+        """True when the falsifier is a formula rather than an observation.
+
+        Heuristic, and deliberately a warning rather than a rejection: it flags
+        stated falsifiers that reach for "if new evidence emerges" without ever
+        naming something that could be observed. A falsifier nobody could check
+        cannot overturn anything, which makes it an immunisation strategy
+        wearing the costume of rigour.
+        """
+        text = self.would_change_my_mind
+        if not text.strip():
+            return False
+        return bool(_VAGUE_FALSIFIER_RE.search(text)) and not _SPECIFICITY_RE.search(text)
+
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
         data["is_falsifiable"] = self.is_falsifiable
         data["is_grounded"] = self.is_grounded
+        data["is_single_origin"] = self.is_single_origin
+        data["likelihood_band"] = list(self.likelihood_band) if self.likelihood_band else None
         return data
 
 
@@ -75,6 +167,13 @@ class AnticipatedQuestion:
     why_asked: str = ""
     """What makes people ask this - often a common misconception worth naming."""
     supported_by: list[str] = field(default_factory=list)
+    weakens_thesis: bool = False
+    """True when the honest answer costs the brief something.
+
+    A question set is only preparation if at least one entry attacks. Questions
+    generated by turning the brief's own assertions interrogative are always
+    answerable, always on-thesis, and worthless.
+    """
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -146,19 +245,43 @@ class ExpertBrief:
     def ungrounded_positions(self) -> list[Position]:
         return [p for p in self.positions if not p.is_grounded]
 
+    def _position_warnings(self) -> list[str]:
+        """Problems with individual positions, counted rather than enumerated."""
+        checks = (
+            (
+                self.unfalsifiable_positions,
+                "state no observation that would overturn them. An unfalsifiable position is an "
+                "assertion, not a judgment.",
+            ),
+            (
+                self.ungrounded_positions,
+                "cite no supporting finding, so 'why do you think that' cannot be answered from the record.",
+            ),
+            (
+                [p for p in self.positions if p.falsifier_is_decorative],
+                "state a falsifier that names nothing observable. 'If new evidence emerges' cannot "
+                "be checked, so it cannot overturn anything.",
+            ),
+            (
+                [p for p in self.positions if p.is_single_origin],
+                "rest on several sources that trace to a single publisher. That reads as corroboration and is not.",
+            ),
+            (
+                [p for p in self.positions if p.stance and not p.likelihood],
+                "state a stance with no likelihood. A stance with no stated likelihood cannot be "
+                "scored later, and so was never a judgment.",
+            ),
+            (
+                [p for p in self.positions if p.resolution == "irreducible" and not p.unresolved_dissent],
+                "are marked irreducible but record no disagreement, which is a contradiction: "
+                "something must have failed to reconcile.",
+            ),
+        )
+        return [f"{len(group)} position(s) {message}" for group, message in checks if group]
+
     def integrity_warnings(self) -> list[str]:
         """Structural problems a reader must see. Never a verdict on correctness."""
-        warnings: list[str] = []
-        if self.unfalsifiable_positions:
-            warnings.append(
-                f"{len(self.unfalsifiable_positions)} position(s) state no observation that would "
-                "overturn them. An unfalsifiable position is an assertion, not a judgment."
-            )
-        if self.ungrounded_positions:
-            warnings.append(
-                f"{len(self.ungrounded_positions)} position(s) cite no supporting finding, so "
-                "'why do you think that' cannot be answered from the record."
-            )
+        warnings = self._position_warnings()
         sole_roots = [c for c in self.credibility if c.is_sole_root]
         if sole_roots:
             warnings.append(
@@ -170,6 +293,11 @@ class ExpertBrief:
                 "No position records unresolved dissent. That is possible, and it is also what a "
                 "brief looks like when disagreement has been averaged away; check the study "
                 "findings for contention the brief did not carry forward."
+            )
+        if self.anticipated_questions and not any(q.weakens_thesis for q in self.anticipated_questions):
+            warnings.append(
+                "No anticipated question weakens the brief's own position. A question set where "
+                "every answer reinforces the thesis is marketing, not preparation."
             )
         return warnings
 

--- a/src/deepr/experts/brief_contracts.py
+++ b/src/deepr/experts/brief_contracts.py
@@ -232,6 +232,8 @@ class ExpertBrief:
     common_failures: list[str] = field(default_factory=list)
     """What people try first that does not work."""
     credibility: list[SourceCredibility] = field(default_factory=list)
+    finding_titles: dict[str, str] = field(default_factory=dict)
+    """Cited finding id to its title, so the render can show words not handles."""
     limitations: list[str] = field(default_factory=list)
     generated_from_findings: int = 0
     cost_usd: float = 0.0

--- a/src/deepr/experts/brief_contracts.py
+++ b/src/deepr/experts/brief_contracts.py
@@ -1,0 +1,191 @@
+"""Typed shape of a consultable expert brief.
+
+The notebook is what you read to learn a subject. The brief is what makes a
+two-minute conversation with an expert worth having: where the field stands,
+which part of your question is already settled, what the expert thinks and why,
+and what would change their mind.
+
+A brief is derived from study findings and the retained corpus. It is not a
+summary of them. Summarizing is the low-utility operation; what makes an expert
+useful is that they have *landed somewhere* and can say why, and can tell you
+what they are not sure about without embarrassment.
+
+Two rules the types enforce structurally rather than by convention:
+
+1. **A position carries its own falsifier.** A stance without a stated
+   observation that would overturn it is not a judgment, it is an assertion.
+   ``Position`` cannot be constructed usefully without ``would_change_my_mind``.
+2. **Dissent survives.** Disagreement between lenses is recorded as unresolved
+   rather than averaged into a confident-sounding middle. Every intelligence
+   post-mortem examined found the correct answer had been present and was
+   smoothed away; a brief that reads confident because it dropped the
+   disagreement reproduces exactly that.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+BRIEF_SCHEMA_VERSION = "deepr-expert-brief-v1"
+
+
+@dataclass
+class Position:
+    """Where the expert lands on one question, and what would move it."""
+
+    question: str
+    stance: str
+    reasoning: str
+    would_change_my_mind: str
+    """The observation that would overturn this. Empty makes the position invalid."""
+    supported_by: list[str] = field(default_factory=list)
+    """Finding titles this rests on, so 'why do you think that' is answerable."""
+    unresolved_dissent: str = ""
+    """Disagreement this position does not settle, stated rather than smoothed."""
+    confidence_basis: str = ""
+    """What the confidence rests on: source count, independence, agreement."""
+
+    @property
+    def is_falsifiable(self) -> bool:
+        return bool(self.would_change_my_mind.strip())
+
+    @property
+    def is_grounded(self) -> bool:
+        return bool(self.supported_by)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["is_falsifiable"] = self.is_falsifiable
+        data["is_grounded"] = self.is_grounded
+        return data
+
+
+@dataclass
+class AnticipatedQuestion:
+    """A question the expert expects, with the answer already prepared.
+
+    The highest-value thing a briefer carries: the naive version of the question
+    has been asked a hundred times and has a crisp reply, so the conversation
+    starts past it.
+    """
+
+    question: str
+    answer: str
+    why_asked: str = ""
+    """What makes people ask this - often a common misconception worth naming."""
+    supported_by: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SettledState:
+    """What is resolved, what is live, and what is genuinely unknown.
+
+    Separating these is most of an expert's value in the first minute: it stops
+    the conversation spending time on questions the field closed years ago.
+    """
+
+    settled: list[str] = field(default_factory=list)
+    live: list[str] = field(default_factory=list)
+    unknown: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SourceCredibility:
+    """How much independent weight the corpus actually carries.
+
+    Citation count is not evidential depth. Intelligence post-mortems found
+    products that left readers with "an impression of many corroborating reports
+    where in fact there were very few sources", and a corpus of secondary
+    coverage reproduces that by default.
+    """
+
+    origin: str
+    source_count: int = 0
+    trust_class: str = ""
+    note: str = ""
+    """What this origin is reliable for, or what interest it may have."""
+    is_sole_root: bool = False
+    """True when several sources here trace to one publisher."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ExpertBrief:
+    """The consultable artifact. Derived, regenerable, and citation-bearing."""
+
+    expert_name: str
+    schema_version: str = BRIEF_SCHEMA_VERSION
+    orientation: str = ""
+    """The sixty-second version. What a newcomer needs before asking anything."""
+    positions: list[Position] = field(default_factory=list)
+    state: SettledState = field(default_factory=SettledState)
+    key_quantities: list[str] = field(default_factory=list)
+    anticipated_questions: list[AnticipatedQuestion] = field(default_factory=list)
+    common_failures: list[str] = field(default_factory=list)
+    """What people try first that does not work."""
+    credibility: list[SourceCredibility] = field(default_factory=list)
+    limitations: list[str] = field(default_factory=list)
+    generated_from_findings: int = 0
+    cost_usd: float = 0.0
+
+    @property
+    def unfalsifiable_positions(self) -> list[Position]:
+        """Positions with no stated falsifier. These are assertions, not judgments."""
+        return [p for p in self.positions if not p.is_falsifiable]
+
+    @property
+    def ungrounded_positions(self) -> list[Position]:
+        return [p for p in self.positions if not p.is_grounded]
+
+    def integrity_warnings(self) -> list[str]:
+        """Structural problems a reader must see. Never a verdict on correctness."""
+        warnings: list[str] = []
+        if self.unfalsifiable_positions:
+            warnings.append(
+                f"{len(self.unfalsifiable_positions)} position(s) state no observation that would "
+                "overturn them. An unfalsifiable position is an assertion, not a judgment."
+            )
+        if self.ungrounded_positions:
+            warnings.append(
+                f"{len(self.ungrounded_positions)} position(s) cite no supporting finding, so "
+                "'why do you think that' cannot be answered from the record."
+            )
+        sole_roots = [c for c in self.credibility if c.is_sole_root]
+        if sole_roots:
+            warnings.append(
+                f"{len(sole_roots)} origin(s) supply several sources each. Repetition within one "
+                "publisher is not independent corroboration."
+            )
+        if self.positions and not any(p.unresolved_dissent for p in self.positions):
+            warnings.append(
+                "No position records unresolved dissent. That is possible, and it is also what a "
+                "brief looks like when disagreement has been averaged away; check the study "
+                "findings for contention the brief did not carry forward."
+            )
+        return warnings
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "expert": self.expert_name,
+            "orientation": self.orientation,
+            "positions": [p.to_dict() for p in self.positions],
+            "state": self.state.to_dict(),
+            "key_quantities": self.key_quantities,
+            "anticipated_questions": [q.to_dict() for q in self.anticipated_questions],
+            "common_failures": self.common_failures,
+            "credibility": [c.to_dict() for c in self.credibility],
+            "generated_from_findings": self.generated_from_findings,
+            "cost_usd": self.cost_usd,
+            "integrity_warnings": self.integrity_warnings(),
+            "limitations": self.limitations,
+        }

--- a/src/deepr/experts/brief_contracts.py
+++ b/src/deepr/experts/brief_contracts.py
@@ -153,6 +153,24 @@ class Position:
         return data
 
 
+def _position_from(data: dict[str, Any]) -> Position:
+    """One position back from its persisted form, calibration intact."""
+    return Position(
+        question=data.get("question", ""),
+        stance=data.get("stance", ""),
+        reasoning=data.get("reasoning", ""),
+        would_change_my_mind=data.get("would_change_my_mind", ""),
+        supported_by=list(data.get("supported_by") or []),
+        unresolved_dissent=data.get("unresolved_dissent", ""),
+        confidence_basis=data.get("confidence_basis", ""),
+        likelihood=data.get("likelihood", ""),
+        confidence=data.get("confidence", ""),
+        resolution=data.get("resolution", "single"),
+        supporting_documents=int(data.get("supporting_documents", 0) or 0),
+        distinct_roots=int(data.get("distinct_roots", 0) or 0),
+    )
+
+
 @dataclass
 class AnticipatedQuestion:
     """A question the expert expects, with the answer already prepared.
@@ -303,10 +321,55 @@ class ExpertBrief:
             )
         return warnings
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExpertBrief:
+        """Rebuild a brief from its persisted form, so it can be consulted."""
+        state = data.get("state") or {}
+        brief = cls(
+            expert_name=data.get("expert", ""),
+            schema_version=data.get("schema_version", BRIEF_SCHEMA_VERSION),
+            orientation=data.get("orientation", ""),
+            state=SettledState(
+                settled=list(state.get("settled") or []),
+                live=list(state.get("live") or []),
+                unknown=list(state.get("unknown") or []),
+            ),
+            key_quantities=list(data.get("key_quantities") or []),
+            common_failures=list(data.get("common_failures") or []),
+            finding_titles=dict(data.get("finding_titles") or {}),
+            limitations=list(data.get("limitations") or []),
+            generated_from_findings=int(data.get("generated_from_findings", 0) or 0),
+        )
+        brief.positions = [_position_from(p) for p in (data.get("positions") or []) if isinstance(p, dict)]
+        brief.anticipated_questions = [
+            AnticipatedQuestion(
+                question=q.get("question", ""),
+                answer=q.get("answer", ""),
+                why_asked=q.get("why_asked", ""),
+                supported_by=list(q.get("supported_by") or []),
+                weakens_thesis=bool(q.get("weakens_thesis")),
+            )
+            for q in (data.get("anticipated_questions") or [])
+            if isinstance(q, dict)
+        ]
+        brief.credibility = [
+            SourceCredibility(
+                origin=c.get("origin", ""),
+                source_count=int(c.get("source_count", 0) or 0),
+                trust_class=c.get("trust_class", ""),
+                note=c.get("note", ""),
+                is_sole_root=bool(c.get("is_sole_root")),
+            )
+            for c in (data.get("credibility") or [])
+            if isinstance(c, dict)
+        ]
+        return brief
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "schema_version": self.schema_version,
             "expert": self.expert_name,
+            "finding_titles": self.finding_titles,
             "orientation": self.orientation,
             "positions": [p.to_dict() for p in self.positions],
             "state": self.state.to_dict(),

--- a/src/deepr/experts/briefed_perspective.py
+++ b/src/deepr/experts/briefed_perspective.py
@@ -1,0 +1,87 @@
+"""Build a council perspective from what the expert studied.
+
+A briefed expert leads with its brief. The belief store is a ledger of atomic
+claims and remains the fallback for experts that were never studied, but where
+a brief exists it is the better answer: it carries where the expert landed,
+what would overturn that, what it could not resolve, and behind each position
+the findings and the retained passage the claim can be checked against.
+
+Kept out of ``council`` so the consult path can grow without that module
+becoming the place everything lands.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+COVERAGE_CONFIDENCE = {"grounded": 0.75, "partial": 0.4, "uncovered": 0.0}
+"""Confidence in the packet, not in the answer.
+
+``grounded`` means a position exists and its support resolves to a retained
+passage. ``uncovered`` is zero deliberately: a perspective assembled from
+nothing must not be weighted as though it were evidence, which is what the
+old confidence-fallback path did by returning top-confidence beliefs
+regardless of whether they bore on the question.
+"""
+
+
+def confidence_for_coverage(coverage: str) -> float:
+    return COVERAGE_CONFIDENCE.get(coverage, 0.0)
+
+
+def load_consult_context(query: str, name: str) -> Any:
+    """Assemble the studied layers for this question, or None if unbriefed."""
+    from deepr.experts.consult_context import build_consult_context, load_brief, load_study
+    from deepr.experts.corpus_store import CorpusStore
+    from deepr.experts.paths import canonical_expert_dir
+
+    expert_dir = canonical_expert_dir(name)
+    brief = load_brief(expert_dir / "brief.json")
+    if brief is None:
+        return None
+    try:
+        corpus: Any = CorpusStore(name)
+    except Exception:  # pragma: no cover - a missing corpus is not a consult failure
+        corpus = None
+    return build_consult_context(
+        expert_name=name,
+        question=query,
+        brief=brief,
+        result=load_study(expert_dir / "study.json"),
+        corpus=corpus,
+    )
+
+
+def build_briefed_perspective(query: str, name: str, domain: str, perspective_cls: Any) -> Any:
+    """A perspective built from the study, or None to fall back to beliefs.
+
+    Never raises. A malformed artifact on disk must degrade to the belief
+    path rather than take the consult down with it.
+    """
+    try:
+        context = load_consult_context(query, name)
+    except Exception:  # pragma: no cover - defensive around on-disk artifacts
+        logger.debug("consult context unavailable for %s", name, exc_info=True)
+        return None
+    if context is None:
+        return None
+
+    from deepr.experts.consult_context import render_consult_packet
+
+    return perspective_cls(
+        expert_name=name,
+        domain=domain,
+        response=render_consult_packet(context),
+        confidence=confidence_for_coverage(context.coverage),
+        context={
+            "source": "brief",
+            "coverage": context.coverage,
+            "positions_included": len(context.positions),
+            "findings_included": len(context.findings),
+            "source_passages": len(context.sources),
+            "evidence_chars": context.evidence_chars(),
+        },
+    )

--- a/src/deepr/experts/card_pass.py
+++ b/src/deepr/experts/card_pass.py
@@ -1,0 +1,217 @@
+"""Build and keep one card per retained source.
+
+The pass is deliberately per-source and idempotent by content hash. A corpus
+that gains one document costs one model call, not a re-read of everything,
+which is what makes an expert something you grow rather than something you
+rebuild. Cards for sources that have not changed are loaded from disk and not
+re-derived, so a run over an unchanged corpus costs nothing at all.
+
+Failure is per-source too. A source that fails to read leaves an error card
+and the other forty-nine still get read, because a partial set of cards is
+worth having and an aborted run is not.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from deepr.experts.corpus_store import CorpusEntry, CorpusStore
+from deepr.experts.source_card import (
+    _MAX_CLAIMS,
+    _MAX_FIELD_CHARS,
+    _MAX_LIST_ITEMS,
+    CardClaim,
+    SourceCard,
+    build_card_prompt,
+)
+
+CardCompletion = Callable[[str], Awaitable[str]]
+ProgressCallback = Callable[[str], None]
+
+_DEFAULT_SOURCE_BUDGET = 60_000
+
+
+@dataclass
+class CardPassResult:
+    """What one pass produced, including what it did not have to do."""
+
+    expert_name: str
+    cards: list[SourceCard] = field(default_factory=list)
+    reused: int = 0
+    """Cards loaded from disk because the source had not changed."""
+    built: int = 0
+    failed: int = 0
+
+    @property
+    def exit_code(self) -> int:
+        if not self.cards:
+            return 2
+        return 1 if self.failed else 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "expert": self.expert_name,
+            "totals": {
+                "cards": len(self.cards),
+                "built": self.built,
+                "reused": self.reused,
+                "failed": self.failed,
+            },
+            "cards": [card.to_dict() for card in self.cards],
+        }
+
+
+def cards_dir(expert_dir: Path) -> Path:
+    return expert_dir / "cards"
+
+
+def card_path(expert_dir: Path, sha: str) -> Path:
+    return cards_dir(expert_dir) / f"{sha}.json"
+
+
+def load_card(expert_dir: Path, sha: str) -> SourceCard | None:
+    """A card already built for this exact content, or None."""
+    path = card_path(expert_dir, sha)
+    if not path.exists():
+        return None
+    try:
+        return SourceCard.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+
+
+def save_card(expert_dir: Path, card: SourceCard) -> Path:
+    path = card_path(expert_dir, card.sha256)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(card.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _text(value: Any) -> str:
+    return " ".join(str(value or "").split())[:_MAX_FIELD_CHARS]
+
+
+def _as_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [_text(v) for v in value if _text(v)][:_MAX_LIST_ITEMS]
+    return [_text(value)] if _text(value) else []
+
+
+def _claims_from(raw: Any, haystack: str) -> list[CardClaim]:
+    """Build claims, checking each anchor against the retained text.
+
+    Grounding is form, not merit: whether the phrase is really there. A claim
+    whose anchor is absent stays on the card and is labeled, because deciding
+    it is wrong is a judgment this layer does not get to make.
+    """
+    import re
+
+    normalized = re.sub(r"\s+", " ", haystack).strip().lower()
+    claims: list[CardClaim] = []
+    for item in (raw or [])[:_MAX_CLAIMS]:
+        if not isinstance(item, dict):
+            continue
+        statement = _text(item.get("statement"))
+        if not statement:
+            continue
+        anchor = _text(item.get("anchor"))
+        probe = re.sub(r"\s+", " ", anchor).strip().lower()
+        claims.append(
+            CardClaim(
+                statement=statement,
+                anchor=anchor,
+                hedged=bool(item.get("hedged")),
+                is_grounded=bool(probe) and len(probe) >= 12 and probe[:400] in normalized,
+            )
+        )
+    return claims
+
+
+def assemble_card(parsed: dict[str, Any], entry: CorpusEntry, text: str, truncated: int) -> SourceCard:
+    """Turn one parsed response into a card anchored to its source."""
+    return SourceCard(
+        sha256=entry.sha256,
+        origin_key=entry.origin_key,
+        title=entry.title,
+        what_it_is=_text(parsed.get("what_it_is")),
+        summary=_text(parsed.get("summary")),
+        establishes=_as_list(parsed.get("establishes")),
+        notable=_as_list(parsed.get("notable")),
+        stops_at=_text(parsed.get("stops_at")),
+        claims=_claims_from(parsed.get("claims"), text),
+        leans_on=_as_list(parsed.get("leans_on")),
+        truncated_chars=truncated,
+    )
+
+
+async def build_one_card(
+    entry: CorpusEntry,
+    text: str,
+    completion: CardCompletion,
+    *,
+    source_budget: int = _DEFAULT_SOURCE_BUDGET,
+) -> SourceCard:
+    """Read one source. Never raises: a failed read is a card with an error."""
+    from deepr.experts.study import extract_json_object
+
+    shown = text[:source_budget] if source_budget else text
+    truncated = max(0, len(text) - len(shown))
+    prompt = build_card_prompt(sha=entry.sha256, origin=entry.origin_key, title=entry.title, text=shown)
+
+    try:
+        raw = await completion(prompt)
+    except Exception as exc:
+        return SourceCard(
+            sha256=entry.sha256,
+            origin_key=entry.origin_key,
+            title=entry.title,
+            error=str(exc)[:200],
+        )
+
+    parsed, error = extract_json_object(raw)
+    if parsed is None:
+        snippet = " ".join((raw or "").split())[:160]
+        return SourceCard(
+            sha256=entry.sha256,
+            origin_key=entry.origin_key,
+            title=entry.title,
+            error=f"{error}. Began: {snippet!r}" if snippet else error,
+        )
+    return assemble_card(parsed, entry, shown, truncated)
+
+
+async def run_card_pass(
+    *,
+    expert_name: str,
+    corpus: CorpusStore,
+    expert_dir: Path,
+    completion: CardCompletion,
+    source_budget: int = _DEFAULT_SOURCE_BUDGET,
+    rebuild: bool = False,
+    on_progress: ProgressCallback | None = None,
+) -> CardPassResult:
+    """One card per active source, reusing cards whose source has not changed."""
+    result = CardPassResult(expert_name=expert_name)
+    material = corpus.load_study_material()
+
+    for index, (entry, text) in enumerate(material, 1):
+        if not rebuild and (existing := load_card(expert_dir, entry.sha256)) is not None:
+            result.cards.append(existing)
+            result.reused += 1
+            continue
+
+        if on_progress:
+            on_progress(f"reading source {index}/{len(material)} ({entry.origin_key})")
+        card = await build_one_card(entry, text, completion, source_budget=source_budget)
+        save_card(expert_dir, card)
+        result.cards.append(card)
+        if card.error or not card.is_read:
+            result.failed += 1
+        else:
+            result.built += 1
+
+    return result

--- a/src/deepr/experts/consult_context.py
+++ b/src/deepr/experts/consult_context.py
@@ -1,0 +1,257 @@
+"""What an expert brings to a conversation.
+
+The consult path used to assemble its evidence from eight claim strings with
+three source references each, truncated at 140 characters. That budget was set
+when a claim ledger was all an expert had and context windows were small. It
+was never revisited, so an expert with a retained corpus, a studied set of
+findings and a formed brief walked into every conversation carrying under four
+kilobytes of them.
+
+This module assembles the real thing, in four layers:
+
+    orientation   always present, never retrieved - where the field stands,
+                  what is settled so the reader can skip it
+    positions     where the expert landed, with the falsifier and the dissent
+                  it did not resolve
+    findings      the specifics a position compresses away
+    sources       the retained passage, quoted rather than paraphrased
+
+Two rules that shape the retrieval.
+
+**Orientation is not retrieved.** It is small, it is always relevant, and it
+is the move that makes a consultation worth more than a search: telling
+someone which part of their question is already closed. Ranking it against a
+query would sometimes drop it, which is the one thing it must never do.
+
+**Positions pull their own support.** When a position ranks, its findings and
+their corpus passages come with it whether or not they ranked separately.
+That is what makes "why do you think that" answerable in the same turn
+instead of the next one.
+
+Scoring is deterministic token overlap. No embeddings, no model, no network,
+so assembling context costs nothing and a consult that never reaches a model
+still says something true about what the expert holds.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from deepr.experts.brief_contracts import ExpertBrief, Position
+from deepr.experts.corpus_store import CorpusStore
+from deepr.experts.study_contracts import StudyFinding, StudyResult
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+_STOPWORDS = frozenset(
+    "a an and are as at be but by can do does for from has have how i if in is it its of on or "
+    "should so than that the their them then there these they this to was were what when where "
+    "which who why will with would you your".split()
+)
+
+_MAX_POSITIONS = 6
+_MAX_FINDINGS = 24
+_MAX_SOURCES = 8
+_SOURCE_SPAN_CHARS = 2_000
+
+
+def _tokens(text: str) -> set[str]:
+    return {w for w in _WORD_RE.findall((text or "").lower()) if w not in _STOPWORDS and len(w) > 2}
+
+
+def _overlap(query: set[str], text: str) -> int:
+    return len(query & _tokens(text))
+
+
+@dataclass
+class ConsultContext:
+    """Everything the expert carries into one turn, with its provenance."""
+
+    expert_name: str
+    orientation: str = ""
+    settled: list[str] = field(default_factory=list)
+    live: list[str] = field(default_factory=list)
+    unknown: list[str] = field(default_factory=list)
+    positions: list[Position] = field(default_factory=list)
+    findings: list[StudyFinding] = field(default_factory=list)
+    sources: list[tuple[str, str, str]] = field(default_factory=list)
+    """(sha, origin_key, passage) so a claim can be checked, not just asserted."""
+    integrity_warnings: list[str] = field(default_factory=list)
+    limitations: list[str] = field(default_factory=list)
+
+    @property
+    def coverage(self) -> str:
+        """grounded, partial, or uncovered.
+
+        A three-way answer rather than a yes/no, because "I have no position
+        but here is what bears on it" is the useful thing an expert says when
+        it cannot answer, and a binary gate cannot express it.
+        """
+        if any(p.is_grounded for p in self.positions):
+            return "grounded"
+        if self.findings or self.sources:
+            return "partial"
+        return "uncovered"
+
+    @property
+    def straddled_positions(self) -> list[Position]:
+        """Ranked positions whose stances differ enough to be worth separating.
+
+        When a question matches more than one position, answering the merged
+        version is how a real distinction gets averaged into mush. Naming both
+        and asking which one they are deciding is the reframe.
+        """
+        return self.positions[:2] if len(self.positions) > 1 else []
+
+    def evidence_chars(self) -> int:
+        """How much the expert is actually bringing. Reported, not guessed."""
+        return (
+            len(self.orientation)
+            + sum(len(p.stance) + len(p.reasoning) for p in self.positions)
+            + sum(len(f.title) for f in self.findings)
+            + sum(len(passage) for _, _, passage in self.sources)
+        )
+
+
+def load_brief(path: Path) -> ExpertBrief | None:
+    """Load a persisted brief, or None when the expert has never been briefed."""
+    if not path.exists():
+        return None
+    try:
+        return ExpertBrief.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+
+
+def load_study(path: Path) -> StudyResult | None:
+    if not path.exists():
+        return None
+    try:
+        return StudyResult.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+
+
+def rank_positions(question: str, brief: ExpertBrief) -> list[Position]:
+    """Positions this question actually touches, best first.
+
+    Unmatched positions are dropped rather than backfilled. Falling back to
+    the highest-confidence positions regardless of relevance is how a system
+    answers a question it has nothing to say about.
+    """
+    query = _tokens(question)
+    if not query:
+        return []
+    scored = [
+        (_overlap(query, f"{p.question} {p.stance} {p.reasoning}"), index, p) for index, p in enumerate(brief.positions)
+    ]
+    matched = [(score, index, p) for score, index, p in scored if score > 0]
+    matched.sort(key=lambda item: (-item[0], item[1]))
+    return [p for _, _, p in matched[:_MAX_POSITIONS]]
+
+
+def _finding_text(finding: StudyFinding) -> str:
+    payload = " ".join(str(v) for v in finding.payload.values() if isinstance(v, str))
+    return f"{finding.title} {payload}"
+
+
+def gather_findings(question: str, result: StudyResult, positions: list[Position]) -> list[StudyFinding]:
+    """Findings the question matches, plus every finding the positions rest on.
+
+    The second half is the point: support arrives with the position it
+    supports, so the expert can show its work in the same breath.
+    """
+    cited = {fid for p in positions for fid in p.supported_by}
+    by_id = {f.finding_id: f for f in result.findings if f.finding_id}
+    carried = [by_id[fid] for fid in sorted(cited) if fid in by_id]
+
+    query = _tokens(question)
+    already = {f.finding_id for f in carried}
+    scored = [
+        (_overlap(query, _finding_text(f)), index, f)
+        for index, f in enumerate(result.findings)
+        if f.finding_id not in already
+    ]
+    matched = sorted((s for s in scored if s[0] > 0), key=lambda item: (-item[0], item[1]))
+    room = max(0, _MAX_FINDINGS - len(carried))
+    return carried + [f for _, _, f in matched[:room]]
+
+
+def gather_sources(findings: list[StudyFinding], corpus: CorpusStore) -> list[tuple[str, str, str]]:
+    """The retained passages behind these findings.
+
+    Quoted rather than summarized. Any number, date or direct quotation in an
+    answer should come from here, because the derived layers are where detail
+    goes to get lost.
+    """
+    seen: list[tuple[str, str, str]] = []
+    used: set[str] = set()
+    for finding in findings:
+        for sha in finding.corpus_shas:
+            if sha in used or len(seen) >= _MAX_SOURCES:
+                continue
+            entry = corpus.entries.get(sha)
+            text = corpus.read(sha)
+            if entry is None or not text:
+                continue
+            used.add(sha)
+            seen.append((sha, entry.origin_key, text[:_SOURCE_SPAN_CHARS]))
+    return seen
+
+
+def build_consult_context(
+    *,
+    expert_name: str,
+    question: str,
+    brief: ExpertBrief | None,
+    result: StudyResult | None,
+    corpus: CorpusStore | None,
+) -> ConsultContext:
+    """Assemble one turn's evidence. $0, deterministic, no model call."""
+    context = ConsultContext(expert_name=expert_name)
+    if brief is not None:
+        context.orientation = brief.orientation
+        context.settled = list(brief.state.settled)
+        context.live = list(brief.state.live)
+        context.unknown = list(brief.state.unknown)
+        context.integrity_warnings = brief.integrity_warnings()
+        context.limitations = list(brief.limitations)
+        context.positions = rank_positions(question, brief)
+
+    if result is not None:
+        context.findings = gather_findings(question, result, context.positions)
+        if corpus is not None:
+            context.sources = gather_sources(context.findings, corpus)
+    return context
+
+
+def render_standing_header(context: ConsultContext) -> str:
+    """The part that is always present, whatever was asked.
+
+    Leads with what is settled. Telling someone which half of their question
+    is already closed is the cheapest useful thing an expert does, and it
+    cannot happen if this has to win a relevance ranking first.
+    """
+    lines: list[str] = []
+    if context.orientation:
+        lines += [f"Where {context.expert_name} stands, in brief:", context.orientation, ""]
+    if context.settled:
+        lines.append("Settled - do not spend the conversation here:")
+        lines += [f"- {item}" for item in context.settled]
+        lines.append("")
+    if context.live:
+        lines.append("Genuinely live, where an answer is a judgment and not a lookup:")
+        lines += [f"- {item}" for item in context.live]
+        lines.append("")
+    if context.unknown:
+        lines.append("Not known, by me or by the sources I hold:")
+        lines += [f"- {item}" for item in context.unknown]
+        lines.append("")
+    if context.integrity_warnings:
+        lines.append("Read anything I say knowing:")
+        lines += [f"- {w}" for w in context.integrity_warnings]
+        lines.append("")
+    return "\n".join(lines).strip()

--- a/src/deepr/experts/consult_context.py
+++ b/src/deepr/experts/consult_context.py
@@ -228,6 +228,72 @@ def build_consult_context(
     return context
 
 
+def _render_position_block(index: int, position: Position) -> list[str]:
+    """One position, with the two things that make it a judgment not a claim."""
+    band = position.likelihood_band
+    lines = [f"{index}. {position.question or 'Position'}", f"   Stance: {position.stance}"]
+    if position.reasoning:
+        lines.append(f"   Because: {position.reasoning}")
+    if band:
+        lines.append(f"   Likelihood it holds: {position.likelihood} ({band[0]}-{band[1]}%)")
+    if position.confidence:
+        lines.append(f"   Confidence in that basis: {position.confidence}")
+    if position.unresolved_dissent:
+        lines.append(f"   Does not resolve: {position.unresolved_dissent}")
+    if position.would_change_my_mind:
+        lines.append(f"   Would change my mind: {position.would_change_my_mind}")
+    else:
+        lines.append("   No falsifier stated: treat as assertion, not judgment.")
+    if position.is_single_origin:
+        lines.append(
+            f"   Rests on {position.supporting_documents} source(s) from one publisher, "
+            "which reads as corroboration and is not."
+        )
+    return lines
+
+
+def render_consult_packet(context: ConsultContext) -> str:
+    """Everything the expert brings to this turn, in reading order.
+
+    Orientation first, then where it landed, then the specifics, then the
+    passages. A reader who stops after the first section still has the part
+    that matters most, which is what is settled and therefore skippable.
+    """
+    blocks = [render_standing_header(context)]
+
+    if context.positions:
+        lines = ["Where I land on what you asked:", ""]
+        for index, position in enumerate(context.positions, 1):
+            lines += _render_position_block(index, position)
+            lines.append("")
+        blocks.append("\n".join(lines).strip())
+    elif context.coverage == "partial":
+        blocks.append(
+            "I have not formed a position on this. What follows is material from my sources that "
+            "bears on it, and it has not been reconciled into a view."
+        )
+    else:
+        blocks.append(
+            "I hold nothing on this question. Saying so is the honest answer; inventing one from "
+            "adjacent material would not be."
+        )
+
+    if context.findings:
+        lines = ["What my sources actually say:", ""]
+        lines += [f"- [{f.finding_id}] {f.title}" for f in context.findings[:12]]
+        blocks.append("\n".join(lines))
+
+    if context.sources:
+        lines = ["Passages, so you can check rather than take my word:", ""]
+        for sha, origin, passage in context.sources[:4]:
+            lines.append(f"--- {origin} ({sha[:12]}) ---")
+            lines.append(passage[:1200])
+            lines.append("")
+        blocks.append("\n".join(lines).strip())
+
+    return "\n\n".join(block for block in blocks if block)
+
+
 def render_standing_header(context: ConsultContext) -> str:
     """The part that is always present, whatever was asked.
 

--- a/src/deepr/experts/corpus_acquire.py
+++ b/src/deepr/experts/corpus_acquire.py
@@ -7,8 +7,13 @@ found. This module closes that.
 
 Uses the existing fetch stack rather than a second one, so the same address
 pinning, redirect handling, and content extraction apply as everywhere else in
-Deepr. Conditional-GET validators are recorded per source so a refresh is a
-304 rather than a re-download and a duplicate entry.
+Deepr.
+
+Refresh is idempotent by content, not by HTTP: an unchanged page re-fetches and
+re-hashes to the same sha, so nothing new is written. There are no
+conditional-GET validators - a re-fetch is a full download that is then
+discarded. That costs bandwidth and saves correctness, and the correctness is
+what the corroboration counts depend on.
 
 Costs network only. No model call, no metered surface.
 """
@@ -97,17 +102,18 @@ def _origin_key_for(url: str) -> str:
 
 
 def _as_source_text(page: Any, url: str) -> str:
-    """Render fetched content as the markdown the corpus retains."""
+    """Render fetched content as the markdown the corpus retains.
+
+    Nothing that varies between two fetches of an unchanged page may appear
+    here, because this text is what gets content-hashed. A ``fetched_at`` date
+    in the body made every refresh a new sha, so one page refreshed daily read
+    as seven independent sources by the end of a week, and every corroboration
+    count downstream inflated with it. Retrieval time is per-entry metadata and
+    lives on ``CorpusEntry``, where it does not change identity.
+    """
     title = (getattr(page, "title", "") or "").strip()
     text = (getattr(page, "text", "") or "").strip()
-    header = [
-        "---",
-        f"url: {url}",
-        f"title: {title}",
-        f"fetched_at: {datetime.now(UTC).date().isoformat()}",
-        "---",
-        "",
-    ]
+    header = ["---", f"url: {url}", f"title: {title}", "---", ""]
     if title:
         header.extend([f"# {title}", ""])
     return "\n".join(header) + text

--- a/src/deepr/experts/corpus_independence.py
+++ b/src/deepr/experts/corpus_independence.py
@@ -1,0 +1,135 @@
+"""How many independent sources a corpus actually holds.
+
+A count of documents is not a count of evidence. Three pages from one
+publisher share an editorial policy, a house style, and usually an author
+pool; they are one source wearing three hats. Every downstream number that
+reads as corroboration - agreement between findings, positions resting on
+several citations, trust ceilings lifted by a second reference - inherits
+that error and amplifies it.
+
+The measurement is old and cheap. Effective source count is the Hill number
+of order 1, ``exp(H)`` over the publisher share vector: the number of equally
+weighted publishers that would produce the observed concentration. Three
+pages from one publisher score 1.0 against a nominal 3. One number, computed
+with no model and no network, that fails the corpus before a study spends
+anything on it.
+
+Deliberately a report, not a refusal. Refusing to study a thin corpus would
+leave the operator with nothing; studying it while saying it is thin leaves
+them with findings and an accurate read on what those findings are worth.
+
+Duplicate publication is the documented cost of getting this wrong: in the
+clearest measurement, including duplicated reports of the same underlying
+study overstated efficacy by roughly a quarter, and the reports that got
+duplicated were the ones showing larger effects. Counting agreement without
+collapsing to origin is directionally wrong, not merely noisy.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from deepr.experts.corpus_store import CorpusEntry
+
+_TIER_WEIGHTS: dict[str, float] = {"primary": 1.0, "secondary": 0.5, "tertiary": 0.25}
+"""How much a source class is worth as evidence.
+
+Graded rather than binary because the alternative is treating an operator
+attested spec and an encyclopedia summary as interchangeable. Weights are a
+convention, not a measurement, and are reported alongside the raw counts so
+a reader can disagree with them.
+"""
+
+_THIN_EFFECTIVE_SOURCES = 2.0
+"""Below this, agreement in the corpus carries no independent weight."""
+
+_DOMINANT_SHARE = 0.6
+"""One publisher above this share sets what the corpus can conclude."""
+
+
+@dataclass
+class IndependenceReport:
+    """What the corpus holds, counted by origin rather than by document."""
+
+    source_count: int = 0
+    origin_count: int = 0
+    effective_source_count: float = 0.0
+    """exp(Shannon entropy) over origin shares. The number that means something."""
+    concentration: float = 0.0
+    """Herfindahl index over origin shares. 1.0 is a single publisher."""
+    dominant_origin: str = ""
+    dominant_share: float = 0.0
+    tier_counts: dict[str, int] = field(default_factory=dict)
+    mean_tier_weight: float = 0.0
+
+    @property
+    def is_thin(self) -> bool:
+        """True when agreement between these sources is not corroboration."""
+        return self.effective_source_count < _THIN_EFFECTIVE_SOURCES
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["is_thin"] = self.is_thin
+        return data
+
+    def concerns(self) -> list[str]:
+        """What a reader must know before trusting anything derived from this."""
+        notes: list[str] = []
+        if not self.source_count:
+            return ["Corpus is empty."]
+
+        if self.is_thin:
+            notes.append(
+                f"{self.source_count} source(s) collapse to {self.effective_source_count:.1f} "
+                "independent origin(s). Agreement between them is one publisher agreeing with "
+                "itself, and any finding that reads as corroborated here is not."
+            )
+        if self.dominant_share >= _DOMINANT_SHARE and self.origin_count > 1:
+            notes.append(
+                f"{self.dominant_origin} supplies {self.dominant_share:.0%} of this corpus, so it "
+                "sets what can be concluded. A contention lens will mostly find that publisher "
+                "disagreeing with itself."
+            )
+        if self.mean_tier_weight and self.mean_tier_weight <= _TIER_WEIGHTS["tertiary"]:
+            notes.append(
+                "This corpus is almost entirely tertiary material, which summarizes primary work "
+                "rather than reporting it. Findings inherit whatever the summary got wrong."
+            )
+        return notes
+
+
+def _shares(entries: list[CorpusEntry]) -> dict[str, float]:
+    counts = Counter(entry.origin_key for entry in entries if entry.origin_key)
+    total = sum(counts.values())
+    return {origin: n / total for origin, n in counts.items()} if total else {}
+
+
+def measure_independence(entries: list[CorpusEntry]) -> IndependenceReport:
+    """Count the corpus by origin, not by document.
+
+    Only active entries should be passed: a superseded revision is the same
+    source at an earlier moment, and counting it again would manufacture the
+    corroboration this exists to detect.
+    """
+    active = [entry for entry in entries if entry.is_active]
+    if not active:
+        return IndependenceReport()
+
+    shares = _shares(active)
+    entropy = -sum(share * math.log(share) for share in shares.values() if share > 0)
+    dominant = max(shares.items(), key=lambda item: (item[1], item[0]), default=("", 0.0))
+    tiers = Counter(entry.trust_class or "secondary" for entry in active)
+
+    return IndependenceReport(
+        source_count=len(active),
+        origin_count=len(shares),
+        effective_source_count=round(math.exp(entropy), 2) if shares else 0.0,
+        concentration=round(sum(share**2 for share in shares.values()), 3),
+        dominant_origin=dominant[0],
+        dominant_share=round(dominant[1], 3),
+        tier_counts=dict(sorted(tiers.items())),
+        mean_tier_weight=round(sum(_TIER_WEIGHTS.get(entry.trust_class, 0.5) for entry in active) / len(active), 3),
+    )

--- a/src/deepr/experts/corpus_store.py
+++ b/src/deepr/experts/corpus_store.py
@@ -246,10 +246,16 @@ class CorpusStore:
         """Active sources with their text, ordered deterministically.
 
         Ordering is by (origin_key, sha) so two study runs over an unchanged
-        corpus see identical material and stay comparable. When ``max_chars`` is
-        set, whole sources are included until the budget is reached; a source is
-        never truncated mid-way, because a lens reading half a document reports
-        absences that are artifacts of the cut.
+        corpus see identical material and stay comparable.
+
+        ``max_chars`` is a hard ceiling on the total returned, including within a
+        single source. An earlier version refused to split a source, reasoning
+        that a lens reading half a document reports absences caused by the cut.
+        That reasoning was right about the risk and wrong about the remedy: one
+        81k-char source silently returned four times a 45k budget, and the
+        oversized prompt made models abandon their output contract and write
+        prose instead. Splitting is handled by the caller, which chunks and
+        merges; this method's job is to respect the number it was given.
         """
         ordered = sorted(self.active_entries(), key=lambda e: (e.origin_key, e.sha256))
         out: list[tuple[CorpusEntry, str]] = []
@@ -258,8 +264,34 @@ class CorpusStore:
             text = self.read(entry.sha256)
             if text is None:
                 continue
-            if max_chars and used + len(text) > max_chars and out:
-                break
+            if max_chars:
+                remaining = max_chars - used
+                if remaining <= 0:
+                    break
+                if len(text) > remaining:
+                    text = text[:remaining]
             out.append((entry, text))
             used += len(text)
         return out
+
+    def iter_study_chunks(self, *, chunk_chars: int, max_chars: int = 0) -> list[list[tuple[CorpusEntry, str]]]:
+        """Split the corpus into slices small enough for one model call.
+
+        A lens given a whole corpus at once stops following its output contract:
+        measured, a 163k-char prompt produced a prose summary while a 43k-char
+        prompt produced valid structured output from the same model. Chunking is
+        what makes local capacity usable at all.
+
+        Slices never span sources, so every chunk carries its own provenance and
+        an anchor always resolves to one retained document.
+        """
+        chunks: list[list[tuple[CorpusEntry, str]]] = []
+        for entry, text in self.load_study_material(max_chars=max_chars):
+            if chunk_chars <= 0 or len(text) <= chunk_chars:
+                chunks.append([(entry, text)])
+                continue
+            for start in range(0, len(text), chunk_chars):
+                piece = text[start : start + chunk_chars]
+                if piece.strip():
+                    chunks.append([(entry, piece)])
+        return chunks

--- a/src/deepr/experts/corpus_store.py
+++ b/src/deepr/experts/corpus_store.py
@@ -275,23 +275,42 @@ class CorpusStore:
         return out
 
     def iter_study_chunks(self, *, chunk_chars: int, max_chars: int = 0) -> list[list[tuple[CorpusEntry, str]]]:
-        """Split the corpus into slices small enough for one model call.
+        """Group the corpus into slices small enough for one model call.
 
-        A lens given a whole corpus at once stops following its output contract:
-        measured, a 163k-char prompt produced a prose summary while a 43k-char
-        prompt produced valid structured output from the same model. Chunking is
-        what makes local capacity usable at all.
+        A lens given more than its capacity can hold stops following its output
+        contract, so the corpus is sliced. But a slice holding a single source
+        is a lens that cannot compare sources: cross-source disagreement becomes
+        impossible rather than rare, and a contention lens then reports
+        documents contradicting themselves.
 
-        Slices never span sources, so every chunk carries its own provenance and
-        an anchor always resolves to one retained document.
+        So sources are packed together up to the budget, and a source is split
+        only when it exceeds the budget on its own. On a capacity tier with room
+        for the whole corpus this yields one chunk, which is what makes
+        comparison possible at all.
         """
         chunks: list[list[tuple[CorpusEntry, str]]] = []
+        current: list[tuple[CorpusEntry, str]] = []
+        used = 0
+
+        def flush() -> None:
+            nonlocal current, used
+            if current:
+                chunks.append(current)
+                current, used = [], 0
+
         for entry, text in self.load_study_material(max_chars=max_chars):
-            if chunk_chars <= 0 or len(text) <= chunk_chars:
-                chunks.append([(entry, text)])
+            if chunk_chars > 0 and len(text) > chunk_chars:
+                # Too big to share a slice with anything; split it alone.
+                flush()
+                for start in range(0, len(text), chunk_chars):
+                    piece = text[start : start + chunk_chars]
+                    if piece.strip():
+                        chunks.append([(entry, piece)])
                 continue
-            for start in range(0, len(text), chunk_chars):
-                piece = text[start : start + chunk_chars]
-                if piece.strip():
-                    chunks.append([(entry, piece)])
+            if chunk_chars > 0 and current and used + len(text) > chunk_chars:
+                flush()
+            current.append((entry, text))
+            used += len(text)
+
+        flush()
         return chunks

--- a/src/deepr/experts/council.py
+++ b/src/deepr/experts/council.py
@@ -166,6 +166,19 @@ class ExpertPerspective:
     context: dict[str, Any] = field(default_factory=dict)
 
 
+_COVERAGE_CONFIDENCE = {"grounded": 0.75, "partial": 0.4, "uncovered": 0.0}
+"""Confidence in the packet, not in the answer.
+
+grounded means a position exists and its support resolves to a retained
+passage. uncovered is zero on purpose: a perspective assembled from nothing
+must not be weighted as if it were evidence.
+"""
+
+
+def _confidence_for_coverage(context: Any) -> float:
+    return _COVERAGE_CONFIDENCE.get(context.coverage, 0.0)
+
+
 def _render_synthesis_perspectives(perspectives: list[ExpertPerspective]) -> list[str]:
     return [
         f"**{perspective.expert_name}** ({perspective.domain}):\n{perspective.response[:1000]}"
@@ -331,6 +344,56 @@ class ExpertCouncil:
             lines.append(f"- [invalidated] {claim}{suffix}")
         return lines
 
+    @staticmethod
+    def _load_consult_context(query: str, name: str) -> Any:
+        """Assemble the studied layers for this question, or None if unbriefed."""
+        from deepr.experts.consult_context import build_consult_context, load_brief, load_study
+        from deepr.experts.corpus_store import CorpusStore
+        from deepr.experts.paths import canonical_expert_dir
+
+        expert_dir = canonical_expert_dir(name)
+        brief = load_brief(expert_dir / "brief.json")
+        if brief is None:
+            return None
+        try:
+            corpus: Any = CorpusStore(name)
+        except Exception:
+            corpus = None
+        return build_consult_context(
+            expert_name=name,
+            question=query,
+            brief=brief,
+            result=load_study(expert_dir / "study.json"),
+            corpus=corpus,
+        )
+
+    def _build_briefed_perspective(self, query: str, name: str, domain: str) -> ExpertPerspective | None:
+        """A perspective built from what the expert studied, not from claim strings."""
+        try:
+            context = self._load_consult_context(query, name)
+        except Exception:  # pragma: no cover - never break consult on a bad artifact
+            logger.debug("consult context unavailable for %s", name, exc_info=True)
+            return None
+        if context is None:
+            return None
+
+        from deepr.experts.consult_context import render_consult_packet
+
+        return ExpertPerspective(
+            expert_name=name,
+            domain=domain,
+            response=render_consult_packet(context),
+            confidence=_confidence_for_coverage(context),
+            context={
+                "source": "brief",
+                "coverage": context.coverage,
+                "positions_included": len(context.positions),
+                "findings_included": len(context.findings),
+                "source_passages": len(context.sources),
+                "evidence_chars": context.evidence_chars(),
+            },
+        )
+
     def build_stored_perspective(
         self,
         query: str,
@@ -355,6 +418,14 @@ class ExpertCouncil:
         non-current history so synthesis does not reuse retired claims as
         live facts (forgetting-aware memory research).
         """
+        # A briefed expert leads with the brief. The belief store is a ledger of
+        # atomic claims; the brief is where the expert landed, with the
+        # falsifier and the dissent it did not resolve, and behind each position
+        # the findings and the retained passage. Beliefs remain the fallback for
+        # experts that have never been studied.
+        if (briefed := self._build_briefed_perspective(query, name, domain)) is not None:
+            return briefed
+
         perspective_state = perspective_state or build_perspective_state_packet(name, limit=3)
         original_ideas = list(perspective_state["original_ideas"])
         belief_list = list(beliefs)

--- a/src/deepr/experts/council.py
+++ b/src/deepr/experts/council.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
+from deepr.experts.briefed_perspective import build_briefed_perspective
 from deepr.experts.constants import MAX_COUNCIL_CONCURRENCY, SYNTHESIS_BUDGET_FRACTION, UTILITY_MODEL
 from deepr.experts.consult_lifecycle import ConsultLifecycleError
 from deepr.experts.council_synthesis_costs import (
@@ -164,19 +165,6 @@ class ExpertPerspective:
     confidence: float = 0.9
     cost: float = 0.0
     context: dict[str, Any] = field(default_factory=dict)
-
-
-_COVERAGE_CONFIDENCE = {"grounded": 0.75, "partial": 0.4, "uncovered": 0.0}
-"""Confidence in the packet, not in the answer.
-
-grounded means a position exists and its support resolves to a retained
-passage. uncovered is zero on purpose: a perspective assembled from nothing
-must not be weighted as if it were evidence.
-"""
-
-
-def _confidence_for_coverage(context: Any) -> float:
-    return _COVERAGE_CONFIDENCE.get(context.coverage, 0.0)
 
 
 def _render_synthesis_perspectives(perspectives: list[ExpertPerspective]) -> list[str]:
@@ -344,56 +332,6 @@ class ExpertCouncil:
             lines.append(f"- [invalidated] {claim}{suffix}")
         return lines
 
-    @staticmethod
-    def _load_consult_context(query: str, name: str) -> Any:
-        """Assemble the studied layers for this question, or None if unbriefed."""
-        from deepr.experts.consult_context import build_consult_context, load_brief, load_study
-        from deepr.experts.corpus_store import CorpusStore
-        from deepr.experts.paths import canonical_expert_dir
-
-        expert_dir = canonical_expert_dir(name)
-        brief = load_brief(expert_dir / "brief.json")
-        if brief is None:
-            return None
-        try:
-            corpus: Any = CorpusStore(name)
-        except Exception:
-            corpus = None
-        return build_consult_context(
-            expert_name=name,
-            question=query,
-            brief=brief,
-            result=load_study(expert_dir / "study.json"),
-            corpus=corpus,
-        )
-
-    def _build_briefed_perspective(self, query: str, name: str, domain: str) -> ExpertPerspective | None:
-        """A perspective built from what the expert studied, not from claim strings."""
-        try:
-            context = self._load_consult_context(query, name)
-        except Exception:  # pragma: no cover - never break consult on a bad artifact
-            logger.debug("consult context unavailable for %s", name, exc_info=True)
-            return None
-        if context is None:
-            return None
-
-        from deepr.experts.consult_context import render_consult_packet
-
-        return ExpertPerspective(
-            expert_name=name,
-            domain=domain,
-            response=render_consult_packet(context),
-            confidence=_confidence_for_coverage(context),
-            context={
-                "source": "brief",
-                "coverage": context.coverage,
-                "positions_included": len(context.positions),
-                "findings_included": len(context.findings),
-                "source_passages": len(context.sources),
-                "evidence_chars": context.evidence_chars(),
-            },
-        )
-
     def build_stored_perspective(
         self,
         query: str,
@@ -423,7 +361,7 @@ class ExpertCouncil:
         # falsifier and the dissent it did not resolve, and behind each position
         # the findings and the retained passage. Beliefs remain the fallback for
         # experts that have never been studied.
-        if (briefed := self._build_briefed_perspective(query, name, domain)) is not None:
+        if (briefed := build_briefed_perspective(query, name, domain, ExpertPerspective)) is not None:
             return briefed
 
         perspective_state = perspective_state or build_perspective_state_packet(name, limit=3)

--- a/src/deepr/experts/notebook.py
+++ b/src/deepr/experts/notebook.py
@@ -37,6 +37,8 @@ NOTEBOOK_MARKER = "<!-- deepr:expert-notebook-v1 -->"
 # Reading order: orientation, then mechanism, then the things that bite, then
 # what is unsettled. Claims come last because they are the index, not the point.
 _SECTION_ORDER: tuple[tuple[str, str, str], ...] = (
+    ("orientation", "The shape of this subject", "Main threads, landmarks, vocabulary, and what is still moving."),
+    ("synopsis", "Source notes", "What each source says in its own terms, and what it is good for."),
     ("mechanism", "How this works", "The underlying model, beneath the vocabulary."),
     ("failure", "What breaks", "Trigger, symptom, correction, and how to detect it early."),
     ("contention", "Where sources disagree", "Both sides quoted, and what would settle it."),
@@ -51,6 +53,20 @@ _SECTION_ORDER: tuple[tuple[str, str, str], ...] = (
 
 # Fields rendered as labeled lines, in this order, when a finding carries them.
 _DETAIL_ORDER: tuple[str, ...] = (
+    # Notes and orientation come first: they are what a reader needs before any
+    # of the analytical fields below mean anything.
+    "description",
+    "says",
+    "establishes",
+    "scope",
+    "limits",
+    "settled",
+    "hedged",
+    "key_terms",
+    "landmarks",
+    "still_moving",
+    "read_next",
+    "why",
     "trigger",
     "symptom",
     "mechanism",

--- a/src/deepr/experts/source_card.py
+++ b/src/deepr/experts/source_card.py
@@ -166,6 +166,10 @@ anchor. A claim you cannot anchor should not be reported.
 
 Report only what this source contains. Do not add what you know from elsewhere.
 
+House style, which applies to every field you return: write plain ASCII punctuation. Use a
+regular hyphen, never an en dash or em dash. Use straight quotes, never curly ones. No emoji.
+Prose, not decoration.
+
 Return JSON only, no prose outside it, no code fence:
 
 {{

--- a/src/deepr/experts/source_card.py
+++ b/src/deepr/experts/source_card.py
@@ -1,0 +1,194 @@
+"""One card per source: what this document is, and what it establishes.
+
+The study pass reads chunks and merges findings. Findings are fragments, and
+fragments do not compose - nothing in the pipeline ever said "here is what
+this source is, taken whole." That leaves two problems. Cross-document work
+has no unit to reason over, and the corpus cannot grow, because the cost of
+understanding it scales with total text rather than with the number of
+documents.
+
+A card fixes both by making the *document* the unit:
+
+- **Bounded.** One call per source, one compact record out, however long the
+  source was. Fifty sources produce fifty cards that still fit in a prompt
+  when fifty sources of raw text never would.
+- **Incremental.** A new source adds a card and recomputes nothing else. An
+  expert grows a document at a time instead of being rebuilt.
+- **Readable.** The cards are the layer a person can actually read to learn
+  the subject, and cross-linked they are the wiki.
+
+A card is not a summary. Summarizing is the low-value operation: it compresses
+and loses the specifics that made the source worth keeping. A card records
+what the source *is*, what it establishes, what it leans on, and where it
+stops - the things you need to decide whether to go read it, and what it can
+be used to support.
+
+Every claim carries a verbatim anchor, checked against the retained text the
+same way study findings are. Decontextualisation is the known weak point in
+this shape of extraction - roughly one claim in five comes out mis-scoped
+regardless of technique - so the anchor is what lets a reader put a claim back
+in its setting rather than trusting the extraction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+CARD_SCHEMA_VERSION = "deepr-source-card-v1"
+
+_MAX_CLAIMS = 12
+_MAX_LIST_ITEMS = 8
+_MAX_FIELD_CHARS = 800
+
+
+@dataclass
+class CardClaim:
+    """One thing this source states, with the passage that states it."""
+
+    statement: str
+    anchor: str = ""
+    hedged: bool = False
+    """True when the source itself qualifies this rather than asserting it."""
+    is_grounded: bool = False
+    """Whether the anchor was found verbatim in the retained text."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SourceCard:
+    """A complete read of one document."""
+
+    sha256: str
+    origin_key: str
+    title: str = ""
+    schema_version: str = CARD_SCHEMA_VERSION
+    what_it_is: str = ""
+    """Kind of document, who produced it, and when, in the source's own terms."""
+    summary: str = ""
+    """What it says, for someone deciding whether to read it."""
+    establishes: list[str] = field(default_factory=list)
+    """What this source can actually be used to support."""
+    notable: list[str] = field(default_factory=list)
+    """What is surprising or load-bearing here, as opposed to merely present."""
+    stops_at: str = ""
+    """Scope and limits, including what the source says it does not cover."""
+    claims: list[CardClaim] = field(default_factory=list)
+    leans_on: list[str] = field(default_factory=list)
+    """Named upstream work this document rests on. The reuse graph starts here."""
+    truncated_chars: int = 0
+    """Source text not shown to the reader, when it exceeded the call budget."""
+    error: str = ""
+
+    @property
+    def is_read(self) -> bool:
+        """A card that carries nothing is a failed read, not a thin source."""
+        return bool(self.summary or self.establishes or self.claims)
+
+    @property
+    def grounded_claims(self) -> list[CardClaim]:
+        return [c for c in self.claims if c.is_grounded]
+
+    def concerns(self) -> list[str]:
+        """What a reader must know before leaning on this card."""
+        notes: list[str] = []
+        if self.error:
+            notes.append(f"This source was not read: {self.error}")
+            return notes
+        if self.claims and not self.grounded_claims:
+            notes.append(
+                "No claim on this card could be located in the retained text, so nothing here is "
+                "checkable against the source it came from."
+            )
+        if self.truncated_chars:
+            notes.append(
+                f"{self.truncated_chars:,} chars of this source were not read. The card describes the part that was."
+            )
+        return notes
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["is_read"] = self.is_read
+        data["grounded_claim_count"] = len(self.grounded_claims)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SourceCard:
+        card = cls(
+            sha256=data.get("sha256", ""),
+            origin_key=data.get("origin_key", ""),
+            title=data.get("title", ""),
+            schema_version=data.get("schema_version", CARD_SCHEMA_VERSION),
+            what_it_is=data.get("what_it_is", ""),
+            summary=data.get("summary", ""),
+            establishes=list(data.get("establishes") or []),
+            notable=list(data.get("notable") or []),
+            stops_at=data.get("stops_at", ""),
+            leans_on=list(data.get("leans_on") or []),
+            truncated_chars=int(data.get("truncated_chars", 0) or 0),
+            error=data.get("error", ""),
+        )
+        card.claims = [
+            CardClaim(
+                statement=c.get("statement", ""),
+                anchor=c.get("anchor", ""),
+                hedged=bool(c.get("hedged")),
+                is_grounded=bool(c.get("is_grounded")),
+            )
+            for c in (data.get("claims") or [])
+            if isinstance(c, dict)
+        ]
+        return card
+
+
+CARD_PROMPT = """Read this source and write the card an expert would keep on it.
+
+Not a summary. A card records what the source *is*, what it can be used to support, what is
+notable in it, and where it stops - the things someone needs to decide whether to go and read
+it, and what it may be cited for.
+
+- Write for a reader who has not seen this document and may never read it.
+- Preserve the specifics that make it usable later: named things, quantities, conditions,
+  dates, defined terms. A card that drops the numbers is a card nobody can use.
+- Separate what the source asserts from what it hedges. If it says "may" or "suggests", the
+  claim is hedged; record it as such rather than promoting it.
+- "establishes" is what this source can actually support, which is usually narrower than what
+  it discusses.
+- "notable" is what is surprising, load-bearing, or contrary to what a reader would expect.
+  Not everything present is notable.
+- "stops_at" is scope: what this source does not cover, and any limits it states about itself.
+- "leans_on" names the upstream work this document rests on, when it names any.
+
+Every claim needs an `anchor`: a phrase copied verbatim from the source. Do not paraphrase an
+anchor. A claim you cannot anchor should not be reported.
+
+Report only what this source contains. Do not add what you know from elsewhere.
+
+Return JSON only, no prose outside it, no code fence:
+
+{{
+  "what_it_is": "kind of document, who produced it, when",
+  "summary": "what it says, for someone deciding whether to read it",
+  "establishes": ["what this source can be used to support"],
+  "notable": ["what is surprising or load-bearing here"],
+  "stops_at": "scope and limits, including what it does not cover",
+  "claims": [{{"statement": "", "anchor": "verbatim phrase", "hedged": false}}],
+  "leans_on": ["named upstream work this rests on"]
+}}
+
+===== SOURCE {sha} | origin={origin}{title_part} =====
+{text}
+===== SOURCE ENDS =====
+"""
+
+
+def build_card_prompt(*, sha: str, origin: str, title: str, text: str) -> str:
+    """One source, one prompt. Bounded by the source, not by the corpus."""
+    return CARD_PROMPT.format(
+        sha=sha[:12],
+        origin=origin,
+        title_part=f" | title={title}" if title else "",
+        text=text,
+    )

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -260,8 +260,14 @@ def build_findings(
     lens: StudyLens,
     parsed: dict[str, Any],
     material: list[tuple[CorpusEntry, str]],
+    *,
+    start_index: int = 1,
 ) -> list[StudyFinding]:
-    """Turn one lens's parsed output into anchored findings."""
+    """Turn one lens's parsed output into anchored findings.
+
+    ``start_index`` continues numbering across chunks so ids stay unique for
+    the whole lens rather than restarting at every call.
+    """
     haystacks = [(entry.sha256, _normalize(text)) for entry, text in material]
     findings: list[StudyFinding] = []
     for item in _lens_items(lens, parsed):
@@ -274,6 +280,7 @@ def build_findings(
                 lens=lens.key,
                 axis=lens.axis,
                 kind=lens.output_field,
+                finding_id=f"{lens.key}-{start_index + len(findings)}",
                 title=_title_for(item, lens, shas),
                 payload={k: v for k, v in item.items() if k != "anchors"},
                 anchors=anchors,
@@ -374,6 +381,20 @@ async def run_study(
             f"{ungrounded} quoted anchor(s) were not found in the retained corpus. "
             "Those findings are labeled ungrounded, not removed; review before use."
         )
+    # A finding with no anchors at all contributes zero to the count above, so
+    # the warning could not fire for the worst case: a pass that ignored the
+    # anchor contract entirely. Nothing verifiable came back, and that has to
+    # be louder than silence.
+    if result.findings and not result.grounded_findings:
+        result.limitations.append(
+            f"None of the {len(result.findings)} finding(s) could be verified against the "
+            "retained corpus. Treat this pass as unusable rather than partial."
+        )
+    if len(result.findings) > 1 and not result.cross_source_findings:
+        result.limitations.append(
+            "No finding draws on more than one source, so nothing here compares sources. "
+            "Disagreement reported by this pass is disagreement within a single document."
+        )
 
     # Coverage, not just output volume. Relevance-driven reading reproduces
     # shared-information bias: what many sources say gets surfaced, and the lone
@@ -425,11 +446,28 @@ async def _run_lens_over_chunks(
             failures.append(f"chunk {index}: {error}. Began: {snippet!r}" if snippet else f"chunk {index}: {error}")
             continue
 
-        findings.extend(build_findings(lens, parsed, material))
+        # Ground against the chunk the lens was actually shown, not the whole
+        # corpus. Grounding against `material` let an anchor resolve to
+        # whichever source sorted first among those containing the phrase, so
+        # a finding could be credited to a document the lens never read. Shared
+        # boilerplate makes that the common case, not an edge case, and the
+        # coverage report then reports the true source as untouched.
+        findings.extend(build_findings(lens, parsed, chunk, start_index=len(findings) + 1))
 
     if findings or not failures:
         detail = f"{len(failures)} of {len(chunks)} chunk(s) failed: " + "; ".join(failures[:2]) if failures else ""
-        return LensOutcome(lens=lens.key, axis=lens.axis, status="ok", findings=findings, detail=detail)
+        # "ok" with nine of ten chunks failed is what a scheduler reads as a
+        # clean run. Partial is its own status so the exit code can say so.
+        status = "partial" if failures else "ok"
+        return LensOutcome(
+            lens=lens.key,
+            axis=lens.axis,
+            status=status,
+            findings=findings,
+            detail=detail,
+            chunks_total=len(chunks),
+            chunks_failed=len(failures),
+        )
     return LensOutcome(
         lens=lens.key,
         axis=lens.axis,

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -44,6 +44,22 @@ from deepr.utils.prompt_security import sanitize_untrusted_content
 StudyCompletion = Callable[[str], Awaitable[str]]
 """prompt -> raw model text. Injected so this module owns no provider."""
 
+ProgressCallback = Callable[[str], None]
+"""Called before each model call, so a long run is not a silent one."""
+
+
+def _lens_progress(
+    on_progress: ProgressCallback | None,
+    lens_key: str,
+    index: int,
+    total: int,
+) -> ProgressCallback | None:
+    """Label a lens's chunk progress with where the whole run has got to."""
+    if on_progress is None:
+        return None
+    return lambda note: on_progress(f"lens {index}/{total} {lens_key}: {note}")
+
+
 _MAX_ANCHOR_PROBE = 400
 """Anchors longer than this are prefix-matched: models paraphrase tails."""
 
@@ -147,29 +163,54 @@ def _anchor_matches(anchor: str, haystacks: list[tuple[str, str]]) -> str | None
     return None
 
 
-def _title_for(item: dict[str, Any], lens: StudyLens) -> str:
+_TITLE_KEYS: tuple[str, ...] = (
+    "name",
+    "title",
+    "thread",
+    "topic",
+    "term",
+    "landmark",
+    "about",
+    "concept",
+    "claim",
+    "tension",
+    "description",
+    "observation",
+    "expected",
+)
+"""Keys a lens might use to name its subject, best first.
+
+``source`` is deliberately absent. Lens prompts do not dictate key names, so
+the model picks them, and at least one lens uses ``source`` for provenance
+rather than subject. Titling from it produced forty findings all named after
+the same corpus hash.
+"""
+
+
+def _is_provenance(value: str, corpus_shas: list[str]) -> bool:
+    """True when a candidate title is really a source identifier.
+
+    Titles are how the brief cites findings, so a title that is a hash makes
+    every citation match every finding and citation checking stops meaning
+    anything. Cheap to check, and it catches the general case rather than the
+    one key that happened to collide.
+    """
+    candidate = value.strip().lower()
+    return any(sha.startswith(candidate) or candidate.startswith(sha) for sha in corpus_shas if sha)
+
+
+def _title_for(item: dict[str, Any], lens: StudyLens, corpus_shas: list[str] | None = None) -> str:
     """Best title for one finding.
 
-    Each lens names its subject with whatever noun fits its question - a failure
-    mode has a ``name``, an orientation thread has a ``thread``, a source note
-    has a ``source``. Checking only for ``name`` renders a titleless stub, which
+    Each lens names its subject with whatever noun fits its question: a failure
+    mode has a ``name``, an orientation thread has a ``thread``, a tension has a
+    ``description``. Checking only for ``name`` renders a titleless stub, which
     is how a lens that worked perfectly can look broken in the notebook.
     """
-    for key in (
-        "name",
-        "title",
-        "thread",
-        "topic",
-        "term",
-        "landmark",
-        "source",
-        "about",
-        "observation",
-        "expected",
-        "concept",
-    ):
+    shas = corpus_shas or []
+    for key in _TITLE_KEYS:
         value = item.get(key)
-        if isinstance(value, str) and value.strip():
+        if isinstance(value, str) and value.strip() and not _is_provenance(value, shas):
             return value.strip()[:200]
     return f"{lens.key} finding"
 
@@ -233,7 +274,7 @@ def build_findings(
                 lens=lens.key,
                 axis=lens.axis,
                 kind=lens.output_field,
-                title=_title_for(item, lens),
+                title=_title_for(item, lens, shas),
                 payload={k: v for k, v in item.items() if k != "anchors"},
                 anchors=anchors,
                 grounded_anchor_count=grounded,
@@ -253,11 +294,16 @@ async def run_study(
     max_corpus_chars: int = _DEFAULT_MAX_CORPUS_CHARS,
     chunk_chars: int = _DEFAULT_CHUNK_CHARS,
     capacity_source: str = "",
+    on_progress: ProgressCallback | None = None,
 ) -> StudyResult:
     """Run every requested lens over the retained corpus.
 
     A lens that fails is recorded and the pass continues: one bad parse should
     not discard the work of five other lenses.
+
+    ``on_progress`` is called before each model call. A chunked study over a
+    real corpus is tens of calls and runs for many minutes; without it the run
+    is silent, and a silent run is indistinguishable from a hung one.
     """
     lenses = resolve_lenses(lens_keys)
     material = corpus.load_study_material(max_chars=max_corpus_chars)
@@ -303,11 +349,23 @@ async def run_study(
             "Each lens saw one chunk at a time, so cross-chunk connections may be missed."
         )
 
-    for lens in lenses:
+    for index, lens in enumerate(lenses, 1):
         lens_started = time.monotonic()
-        outcome = await _run_lens_over_chunks(lens, chunks, material, completion)
+        outcome = await _run_lens_over_chunks(
+            lens,
+            chunks,
+            material,
+            completion,
+            on_progress=_lens_progress(on_progress, lens.key, index, len(lenses)),
+        )
         outcome.elapsed_s = time.monotonic() - lens_started
         result.outcomes.append(outcome)
+        if on_progress:
+            grounded = sum(1 for f in outcome.findings if f.is_grounded)
+            on_progress(
+                f"lens {index}/{len(lenses)} {lens.key}: {len(outcome.findings)} finding(s), "
+                f"{grounded} anchored, {outcome.elapsed_s:.0f}s"
+            )
 
     result.elapsed_s = time.monotonic() - started
     ungrounded = sum(f.ungrounded_anchor_count for f in result.findings)
@@ -336,6 +394,7 @@ async def _run_lens_over_chunks(
     chunks: list[list[tuple[CorpusEntry, str]]],
     material: list[tuple[CorpusEntry, str]],
     completion: StudyCompletion,
+    on_progress: ProgressCallback | None = None,
 ) -> LensOutcome:
     """Run one lens across every chunk, merging findings.
 
@@ -347,6 +406,8 @@ async def _run_lens_over_chunks(
     failures: list[str] = []
 
     for index, chunk in enumerate(chunks, 1):
+        if on_progress:
+            on_progress(f"chunk {index}/{len(chunks)}")
         prompt = build_study_prompt(lens, chunk)
         try:
             raw = await completion(prompt)

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -282,12 +282,18 @@ async def run_study(
 
         parsed, error = extract_json_object(raw)
         if parsed is None:
+            # Include what actually came back. "no JSON object in response" is
+            # true and useless: it does not distinguish a model that answered in
+            # prose, one that was cut off mid-structure, and one that returned
+            # nothing at all, and those need different fixes.
+            snippet = " ".join((raw or "").split())[:300]
+            detail = f"{error}. Response began: {snippet!r}" if snippet else f"{error}. Response was empty."
             result.outcomes.append(
                 LensOutcome(
                     lens=lens.key,
                     axis=lens.axis,
                     status="parse_failed",
-                    detail=error,
+                    detail=detail,
                     elapsed_s=time.monotonic() - lens_started,
                 )
             )

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -35,6 +35,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from deepr.experts.corpus_independence import measure_independence
 from deepr.experts.corpus_store import CorpusEntry, CorpusStore
 from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 from deepr.experts.study_coverage import build_coverage_report
@@ -339,11 +340,11 @@ async def run_study(
             f"Studied {len(material)} of {stats.active_count} retained sources "
             f"(corpus budget {max_corpus_chars} chars). Findings may miss material."
         )
-    if stats.distinct_origins < 2:
-        result.limitations.append(
-            "Corpus has a single origin, so the contention lens has nothing "
-            "independent to compare and agreement here is not corroboration."
-        )
+    # Counted by origin rather than by document, because a document count is
+    # not an evidence count and every downstream corroboration number is built
+    # on this one.
+    result.independence = measure_independence(corpus.active_entries())
+    result.limitations.extend(result.independence.concerns())
 
     # One call per lens per chunk. A lens handed a whole corpus stops following
     # its output contract - measured, a 163k-char prompt produced a prose

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -50,7 +50,16 @@ _MAX_ANCHOR_PROBE = 400
 _MIN_ANCHOR_LEN = 12
 """Shorter phrases match by coincidence and would make grounding meaningless."""
 
-_DEFAULT_MAX_CORPUS_CHARS = 120_000
+_DEFAULT_MAX_CORPUS_CHARS = 400_000
+
+_DEFAULT_CHUNK_CHARS = 14_000
+"""Corpus chars per model call.
+
+Measured: at ~163k prompt chars both a 14B and a 24B abandoned their JSON output
+contract and returned a prose summary; at ~43k prompt chars the same 24B
+returned valid structured output in 27 seconds. The limit that matters is
+instruction-following under prompt length, not the model's context window, and
+it binds well below the window."""
 
 
 def _utc_now_iso() -> str:
@@ -139,7 +148,26 @@ def _anchor_matches(anchor: str, haystacks: list[tuple[str, str]]) -> str | None
 
 
 def _title_for(item: dict[str, Any], lens: StudyLens) -> str:
-    for key in ("name", "title", "about", "observation", "expected", "concept"):
+    """Best title for one finding.
+
+    Each lens names its subject with whatever noun fits its question - a failure
+    mode has a ``name``, an orientation thread has a ``thread``, a source note
+    has a ``source``. Checking only for ``name`` renders a titleless stub, which
+    is how a lens that worked perfectly can look broken in the notebook.
+    """
+    for key in (
+        "name",
+        "title",
+        "thread",
+        "topic",
+        "term",
+        "landmark",
+        "source",
+        "about",
+        "observation",
+        "expected",
+        "concept",
+    ):
         value = item.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()[:200]
@@ -223,6 +251,7 @@ async def run_study(
     completion: StudyCompletion,
     lens_keys: list[str] | tuple[str, ...] | None = None,
     max_corpus_chars: int = _DEFAULT_MAX_CORPUS_CHARS,
+    chunk_chars: int = _DEFAULT_CHUNK_CHARS,
     capacity_source: str = "",
 ) -> StudyResult:
     """Run every requested lens over the retained corpus.
@@ -263,51 +292,22 @@ async def run_study(
             "independent to compare and agreement here is not corroboration."
         )
 
+    # One call per lens per chunk. A lens handed a whole corpus stops following
+    # its output contract - measured, a 163k-char prompt produced a prose
+    # summary where a 43k-char prompt produced valid structured output from the
+    # same model - so the corpus is sliced and findings are merged.
+    chunks = corpus.iter_study_chunks(chunk_chars=chunk_chars, max_chars=max_corpus_chars) or [material]
+    if len(chunks) > 1:
+        result.limitations.append(
+            f"Corpus was read in {len(chunks)} chunk(s) of up to {chunk_chars} chars. "
+            "Each lens saw one chunk at a time, so cross-chunk connections may be missed."
+        )
+
     for lens in lenses:
         lens_started = time.monotonic()
-        prompt = build_study_prompt(lens, material)
-        try:
-            raw = await completion(prompt)
-        except Exception as exc:
-            result.outcomes.append(
-                LensOutcome(
-                    lens=lens.key,
-                    axis=lens.axis,
-                    status="model_error",
-                    detail=str(exc)[:300],
-                    elapsed_s=time.monotonic() - lens_started,
-                )
-            )
-            continue
-
-        parsed, error = extract_json_object(raw)
-        if parsed is None:
-            # Include what actually came back. "no JSON object in response" is
-            # true and useless: it does not distinguish a model that answered in
-            # prose, one that was cut off mid-structure, and one that returned
-            # nothing at all, and those need different fixes.
-            snippet = " ".join((raw or "").split())[:300]
-            detail = f"{error}. Response began: {snippet!r}" if snippet else f"{error}. Response was empty."
-            result.outcomes.append(
-                LensOutcome(
-                    lens=lens.key,
-                    axis=lens.axis,
-                    status="parse_failed",
-                    detail=detail,
-                    elapsed_s=time.monotonic() - lens_started,
-                )
-            )
-            continue
-
-        result.outcomes.append(
-            LensOutcome(
-                lens=lens.key,
-                axis=lens.axis,
-                status="ok",
-                findings=build_findings(lens, parsed, material),
-                elapsed_s=time.monotonic() - lens_started,
-            )
-        )
+        outcome = await _run_lens_over_chunks(lens, chunks, material, completion)
+        outcome.elapsed_s = time.monotonic() - lens_started
+        result.outcomes.append(outcome)
 
     result.elapsed_s = time.monotonic() - started
     ungrounded = sum(f.ungrounded_anchor_count for f in result.findings)
@@ -329,3 +329,49 @@ async def run_study(
     )
     result.limitations.extend(result.coverage.concerns())
     return result
+
+
+async def _run_lens_over_chunks(
+    lens: StudyLens,
+    chunks: list[list[tuple[CorpusEntry, str]]],
+    material: list[tuple[CorpusEntry, str]],
+    completion: StudyCompletion,
+) -> LensOutcome:
+    """Run one lens across every chunk, merging findings.
+
+    A chunk that fails does not discard the chunks that succeeded: partial
+    findings from a large corpus beat none. The outcome is ``ok`` when any chunk
+    parsed, and carries a note about the ones that did not.
+    """
+    findings: list[StudyFinding] = []
+    failures: list[str] = []
+
+    for index, chunk in enumerate(chunks, 1):
+        prompt = build_study_prompt(lens, chunk)
+        try:
+            raw = await completion(prompt)
+        except Exception as exc:
+            failures.append(f"chunk {index}: {str(exc)[:160]}")
+            continue
+
+        parsed, error = extract_json_object(raw)
+        if parsed is None:
+            # Include what actually came back. "no JSON object in response" is
+            # true and useless: it does not distinguish a model that answered in
+            # prose, one that was cut off mid-structure, and one that returned
+            # nothing at all, and those need different fixes.
+            snippet = " ".join((raw or "").split())[:160]
+            failures.append(f"chunk {index}: {error}. Began: {snippet!r}" if snippet else f"chunk {index}: {error}")
+            continue
+
+        findings.extend(build_findings(lens, parsed, material))
+
+    if findings or not failures:
+        detail = f"{len(failures)} of {len(chunks)} chunk(s) failed: " + "; ".join(failures[:2]) if failures else ""
+        return LensOutcome(lens=lens.key, axis=lens.axis, status="ok", findings=findings, detail=detail)
+    return LensOutcome(
+        lens=lens.key,
+        axis=lens.axis,
+        status="parse_failed",
+        detail="; ".join(failures[:3]),
+    )

--- a/src/deepr/experts/study_contracts.py
+++ b/src/deepr/experts/study_contracts.py
@@ -41,6 +41,16 @@ class StudyFinding:
     ungrounded_anchor_count: int = 0
     corpus_shas: list[str] = field(default_factory=list)
     """Retained sources an anchor was actually found in."""
+    finding_id: str = ""
+    """Stable handle a brief cites, so citations do not go through the title.
+
+    Titles collide: several lenses fall back to a constant when the model names
+    nothing, and descriptive lenses emit sentence-length titles that get
+    truncated. Matching citations by title meant one citation could claim every
+    finding sharing that string, inflating evidential depth, while a title
+    holding a newline could never be matched at all and the brief blamed the
+    model for citing nothing.
+    """
 
     @property
     def is_grounded(self) -> bool:
@@ -52,6 +62,21 @@ class StudyFinding:
         data["is_grounded"] = self.is_grounded
         return data
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StudyFinding:
+        return cls(
+            lens=data.get("lens", ""),
+            axis=data.get("axis", ""),
+            kind=data.get("kind", ""),
+            title=data.get("title", ""),
+            payload=data.get("payload") or {},
+            anchors=data.get("anchors") or [],
+            grounded_anchor_count=int(data.get("grounded_anchor_count", 0) or 0),
+            ungrounded_anchor_count=int(data.get("ungrounded_anchor_count", 0) or 0),
+            corpus_shas=data.get("corpus_shas") or [],
+            finding_id=data.get("finding_id", ""),
+        )
+
 
 @dataclass
 class LensOutcome:
@@ -60,11 +85,19 @@ class LensOutcome:
     lens: str
     axis: str
     status: str
-    """ok | parse_failed | model_error | skipped"""
+    """ok | partial | parse_failed | model_error | skipped"""
     findings: list[StudyFinding] = field(default_factory=list)
     detail: str = ""
     elapsed_s: float = 0.0
     cost_usd: float = 0.0
+    chunks_total: int = 0
+    chunks_failed: int = 0
+    """How much of the corpus this lens actually got through.
+
+    Carried as counts rather than only in a prose ``detail`` string, so a run
+    that read a tenth of its corpus is legible to a scheduler and not just to
+    an attentive reader.
+    """
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -74,10 +107,25 @@ class LensOutcome:
             "detail": self.detail,
             "elapsed_s": round(self.elapsed_s, 2),
             "cost_usd": self.cost_usd,
+            "chunks_total": self.chunks_total,
+            "chunks_failed": self.chunks_failed,
             "finding_count": len(self.findings),
             "grounded_count": sum(1 for f in self.findings if f.is_grounded),
             "findings": [f.to_dict() for f in self.findings],
         }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LensOutcome:
+        return cls(
+            lens=data.get("lens", ""),
+            axis=data.get("axis", ""),
+            status=data.get("status", "ok"),
+            findings=[StudyFinding.from_dict(f) for f in (data.get("findings") or [])],
+            detail=data.get("detail", ""),
+            elapsed_s=float(data.get("elapsed_s", 0.0) or 0.0),
+            chunks_total=int(data.get("chunks_total", 0) or 0),
+            chunks_failed=int(data.get("chunks_failed", 0) or 0),
+        )
 
 
 @dataclass
@@ -107,18 +155,39 @@ class StudyResult:
         return [f for f in self.findings if f.is_grounded]
 
     @property
+    def cross_source_findings(self) -> list[StudyFinding]:
+        """Findings anchored in more than one retained source.
+
+        The headline number for whether this pass compared sources at all.
+        When every lens call sees a slice of a single document, this is zero by
+        construction, and a contention lens reporting forty findings is really
+        reporting forty documents disagreeing with themselves. Kept as a first
+        class metric so that regression is visible rather than plausible.
+        """
+        return [f for f in self.findings if len(set(f.corpus_shas)) > 1]
+
+    @property
     def failed_lenses(self) -> list[str]:
         return [o.lens for o in self.outcomes if o.status != "ok"]
 
     @property
     def exit_code(self) -> int:
-        """0 all lenses ok, 1 partial, 2 nothing worked."""
+        """0 clean, 1 degraded but usable, 2 nothing usable came back.
+
+        A lens that got through one chunk of ten used to report ``ok``, and a
+        pass whose every finding was unverifiable used to exit 0. Both are
+        indistinguishable from a clean run to the scheduler or maintenance loop
+        that reads this, which is the only consumer that cannot notice a
+        warning printed alongside it.
+        """
         if not self.outcomes:
             return 2
-        failed = len(self.failed_lenses)
-        if failed == 0:
+        if not self.findings or not self.grounded_findings:
+            return 2
+        degraded = [o for o in self.outcomes if o.status != "ok"]
+        if not degraded:
             return 0
-        return 2 if failed == len(self.outcomes) else 1
+        return 2 if len(degraded) == len(self.outcomes) and not self.findings else 1
 
     def axis_coverage(self) -> dict[str, int]:
         counts = {"interrogation": 0, "perspective": 0}
@@ -145,9 +214,36 @@ class StudyResult:
                 "lenses_failed": len(self.failed_lenses),
                 "findings": len(self.findings),
                 "grounded_findings": len(self.grounded_findings),
+                "cross_source_findings": len(self.cross_source_findings),
                 "axis_coverage": self.axis_coverage(),
             },
             "coverage": self.coverage.to_dict() if self.coverage is not None else None,
             "outcomes": [o.to_dict() for o in self.outcomes],
             "limitations": self.limitations,
         }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], *, expert_name: str = "") -> StudyResult:
+        """Rebuild a whole pass from study.json.
+
+        One rehydration, because there were two and they had already drifted:
+        both dropped coverage, so regenerating a notebook from the canonical
+        record produced a document missing the section that reports what the
+        pass never read.
+        """
+        from deepr.experts.study_coverage import CoverageReport
+
+        corpus = data.get("corpus") or {}
+        result = cls(
+            expert_name=data.get("expert") or expert_name,
+            corpus_sources=int(corpus.get("sources", 0) or 0),
+            corpus_origins=int(corpus.get("distinct_origins", 0) or 0),
+            corpus_chars=int(corpus.get("chars", 0) or 0),
+            capacity_source=data.get("capacity_source", ""),
+            started_at=data.get("started_at", ""),
+            elapsed_s=float(data.get("elapsed_s", 0.0) or 0.0),
+            limitations=list(data.get("limitations") or []),
+        )
+        result.outcomes = [LensOutcome.from_dict(o) for o in (data.get("outcomes") or [])]
+        result.coverage = CoverageReport.from_dict(data.get("coverage"))
+        return result

--- a/src/deepr/experts/study_contracts.py
+++ b/src/deepr/experts/study_contracts.py
@@ -16,6 +16,7 @@ meaning is not this module's job.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from dataclasses import fields as dataclass_fields
 from typing import Any
 
 STUDY_SCHEMA_VERSION = "deepr-expert-study-v1"
@@ -145,6 +146,8 @@ class StudyResult:
     limitations: list[str] = field(default_factory=list)
     coverage: Any = None
     """CoverageReport: what the pass read and cited versus what the corpus holds."""
+    independence: Any = None
+    """IndependenceReport: how many independent origins the corpus really holds."""
 
     @property
     def findings(self) -> list[StudyFinding]:
@@ -218,6 +221,7 @@ class StudyResult:
                 "axis_coverage": self.axis_coverage(),
             },
             "coverage": self.coverage.to_dict() if self.coverage is not None else None,
+            "independence": self.independence.to_dict() if self.independence is not None else None,
             "outcomes": [o.to_dict() for o in self.outcomes],
             "limitations": self.limitations,
         }
@@ -231,7 +235,10 @@ class StudyResult:
         record produced a document missing the section that reports what the
         pass never read.
         """
+        from deepr.experts.corpus_independence import IndependenceReport
         from deepr.experts.study_coverage import CoverageReport
+
+        _INDEPENDENCE_FIELDS = {f.name for f in dataclass_fields(IndependenceReport)}
 
         corpus = data.get("corpus") or {}
         result = cls(
@@ -246,4 +253,9 @@ class StudyResult:
         )
         result.outcomes = [LensOutcome.from_dict(o) for o in (data.get("outcomes") or [])]
         result.coverage = CoverageReport.from_dict(data.get("coverage"))
+        independence = data.get("independence")
+        if independence:
+            result.independence = IndependenceReport(
+                **{k: v for k, v in independence.items() if k in _INDEPENDENCE_FIELDS}
+            )
         return result

--- a/src/deepr/experts/study_coverage.py
+++ b/src/deepr/experts/study_coverage.py
@@ -27,6 +27,7 @@ Nothing here judges whether a finding is good. It counts what was consulted.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from dataclasses import fields as dataclass_fields
 from typing import Any
 
 from deepr.experts.corpus_store import CorpusEntry, CorpusStats
@@ -51,6 +52,19 @@ class CoverageReport:
     """Sources that are the only one from their origin. Hidden profiles live here."""
     uncited_singleton_origins: list[str] = field(default_factory=list)
     """Sole-source origins nothing cited. The highest-value review queue."""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> CoverageReport | None:
+        """Rebuild a coverage report from its serialized form.
+
+        Coverage is what stops a pass that read a third of its corpus from
+        reading as complete, so a rehydration that silently drops it produces
+        a document that looks more thorough than the run it describes.
+        """
+        if not data:
+            return None
+        fields = {f.name for f in dataclass_fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in fields})
 
     @property
     def source_coverage(self) -> float:

--- a/src/deepr/experts/study_lenses.py
+++ b/src/deepr/experts/study_lenses.py
@@ -47,6 +47,39 @@ class StudyLens:
 
 _INTERROGATION: tuple[StudyLens, ...] = (
     StudyLens(
+        key="synopsis",
+        axis="interrogation",
+        summary="What this source actually says, in its own terms",
+        output_field="notes",
+        prompt="""Read this material and write the notes a serious student would take on it.
+
+Not a compression of the text and not a verdict on it: an account of what it says, what it is
+for, what it establishes, and where it stops. Preserve the specifics that make it usable later -
+named things, quantities, conditions, dates, defined terms. Note what the source treats as
+settled versus what it hedges, and note its own stated scope or limits.
+
+Someone should be able to read your notes and know whether this source is worth returning to,
+and for what.
+
+Report only what this material contains.""",
+    ),
+    StudyLens(
+        key="orientation",
+        axis="interrogation",
+        summary="The shape of the subject: threads, landmarks, state of play",
+        output_field="orientation",
+        prompt="""Read this material as someone building a map of an unfamiliar subject.
+
+Produce orientation, not summary: what are the main threads and how do they relate; what are the
+landmark works, findings, or positions that everything else references; what vocabulary must be
+understood before the rest makes sense; what appears settled and what is visibly still moving;
+who or what the recurring reference points are.
+
+Also state what a newcomer would most usefully read or resolve next, and why that specifically.
+
+This is the overview a student writes before they can reason about the subject at all.""",
+    ),
+    StudyLens(
         key="mechanism",
         axis="interrogation",
         summary="How it actually works beneath the vocabulary",
@@ -184,6 +217,8 @@ as what would need checking and against which authority.""",
 LENSES: dict[str, StudyLens] = {lens.key: lens for lens in (*_INTERROGATION, *_PERSPECTIVE)}
 
 DEFAULT_LENS_KEYS: tuple[str, ...] = (
+    "synopsis",
+    "orientation",
     "mechanism",
     "failure",
     "contention",
@@ -191,8 +226,17 @@ DEFAULT_LENS_KEYS: tuple[str, ...] = (
     "operational",
     "adversarial",
 )
-"""A spread across both axes. Deliberately not every lens: a study pass costs one
-model call per lens, and a default that runs nine is a default nobody runs."""
+"""What a person does when they set out to know a subject, in order.
+
+Read and take notes (synopsis). Build a map of the territory (orientation). Then
+interrogate it: how it works, what breaks, where the sources disagree, what is
+missing. Then read it as the people who have to live with it (operational,
+adversarial).
+
+The analytical lenses came first in development and were, on their own, a
+mistake: they produce sharp observations about material the reader has no
+orientation in. Notes and a map are what make the rest legible, and they are the
+first thing a student writes."""
 
 
 # Subject-matter words. A lens naming any of these is tuned to one topic.

--- a/tests/unit/test_backends/test_local_fit.py
+++ b/tests/unit/test_backends/test_local_fit.py
@@ -1,0 +1,115 @@
+"""VRAM fit estimation: pick a model that runs on GPU, or decline to choose."""
+
+from deepr.backends.local_fit import (
+    choose_fitting_model,
+    detect_vram_bytes,
+    estimate_fit,
+    parse_param_billions,
+)
+
+_GB = 1_000_000_000
+_VRAM_24 = 24_564 * 1024 * 1024
+
+
+class TestParseParams:
+    def test_reads_ollama_parameter_size(self):
+        assert parse_param_billions("whatever:latest", parameter_size="27.4B") == 27.4
+
+    def test_falls_back_to_the_tag(self):
+        assert parse_param_billions("qwen3:30b") == 30.0
+        assert parse_param_billions("llama3:70b") == 70.0
+        assert parse_param_billions("devstral-small-2:24b") == 24.0
+
+    def test_hyphenated_name_does_not_confuse_the_tag(self):
+        assert parse_param_billions("qwen2.5-coder:32b") == 32.0
+
+    def test_unknown_size_is_zero_not_a_guess(self):
+        """Unknown must not be treated as small enough to fit."""
+        assert parse_param_billions("mistral-openorca:latest") == 0.0
+
+
+class TestEstimateFit:
+    def test_small_model_fits_with_room(self):
+        fit = estimate_fit(
+            name="qwen2.5:14b", weight_bytes=9 * _GB, param_b=14, context_tokens=32768, vram_bytes=_VRAM_24
+        )
+        assert fit.fits
+        assert fit.headroom_bytes > 0
+
+    def test_the_observed_spill_case_is_predicted(self):
+        """qwen2.5-coder:32b at 32K measured 27GB against 24GB and ran on CPU."""
+        fit = estimate_fit(
+            name="qwen2.5-coder:32b", weight_bytes=19 * _GB, param_b=32, context_tokens=32768, vram_bytes=_VRAM_24
+        )
+        assert not fit.fits
+        assert "would spill to CPU" in fit.explain()
+
+    def test_kv_cache_grows_with_context(self):
+        small = estimate_fit(name="m:24b", weight_bytes=15 * _GB, param_b=24, context_tokens=8192, vram_bytes=_VRAM_24)
+        large = estimate_fit(name="m:24b", weight_bytes=15 * _GB, param_b=24, context_tokens=65536, vram_bytes=_VRAM_24)
+        assert large.kv_bytes > small.kv_bytes
+        assert small.fits and not large.fits
+
+    def test_explain_states_the_arithmetic(self):
+        fit = estimate_fit(name="m:14b", weight_bytes=9 * _GB, param_b=14, context_tokens=32768, vram_bytes=_VRAM_24)
+        text = fit.explain()
+        assert "weights" in text and "KV" in text and "VRAM" in text
+
+
+class TestChooseFittingModel:
+    def _candidates(self):
+        return [
+            ("qwen2.5:14b", 9 * _GB, ""),
+            ("devstral-small-2:24b", 15 * _GB, ""),
+            ("qwen3.6:27b", 17 * _GB, ""),
+            ("qwen2.5-coder:32b", 19 * _GB, ""),
+            ("llama3:70b", 39 * _GB, ""),
+        ]
+
+    def test_picks_largest_that_fits_not_largest_overall(self):
+        chosen, estimates = choose_fitting_model(
+            self._candidates(), context_tokens=32768, vram_bytes=_VRAM_24
+        )
+        assert chosen is not None
+        assert chosen not in {"llama3:70b", "qwen2.5-coder:32b"}
+        assert estimates
+
+    def test_unknown_vram_declines_to_choose(self):
+        """Unknown VRAM must not silently downgrade the model."""
+        chosen, estimates = choose_fitting_model(self._candidates(), context_tokens=32768, vram_bytes=0)
+        assert chosen is None
+        assert estimates == []
+
+    def test_nothing_fits_returns_none_rather_than_a_bad_pick(self):
+        chosen, estimates = choose_fitting_model(
+            [("llama3:70b", 39 * _GB, "")], context_tokens=32768, vram_bytes=_VRAM_24
+        )
+        assert chosen is None
+        assert estimates and not estimates[0].fits
+
+    def test_models_with_unknown_size_are_not_chosen(self):
+        chosen, _ = choose_fitting_model(
+            [("mystery:latest", 2 * _GB, "")], context_tokens=8192, vram_bytes=_VRAM_24
+        )
+        assert chosen is None
+
+    def test_a_bigger_card_admits_a_bigger_model(self):
+        """KV at 32K for a 70B model is ~48G, so 80G admits it and 24G does not."""
+        chosen, _ = choose_fitting_model(self._candidates(), context_tokens=32768, vram_bytes=140 * _GB)
+        assert chosen == "llama3:70b"
+
+    def test_shorter_context_admits_a_bigger_model(self):
+        long_ctx, _ = choose_fitting_model(self._candidates(), context_tokens=65536, vram_bytes=_VRAM_24)
+        short_ctx, _ = choose_fitting_model(self._candidates(), context_tokens=4096, vram_bytes=_VRAM_24)
+        assert short_ctx is not None
+        assert long_ctx != short_ctx or short_ctx is not None
+
+
+class TestDetectVram:
+    def test_env_override_is_honoured(self, monkeypatch):
+        monkeypatch.setenv("DEEPR_VRAM_BYTES", str(12 * _GB))
+        assert detect_vram_bytes() == 12 * _GB
+
+    def test_bad_override_reads_as_unknown(self, monkeypatch):
+        monkeypatch.setenv("DEEPR_VRAM_BYTES", "not-a-number")
+        assert detect_vram_bytes() == 0

--- a/tests/unit/test_backends/test_local_fit.py
+++ b/tests/unit/test_backends/test_local_fit.py
@@ -67,9 +67,7 @@ class TestChooseFittingModel:
         ]
 
     def test_picks_largest_that_fits_not_largest_overall(self):
-        chosen, estimates = choose_fitting_model(
-            self._candidates(), context_tokens=32768, vram_bytes=_VRAM_24
-        )
+        chosen, estimates = choose_fitting_model(self._candidates(), context_tokens=32768, vram_bytes=_VRAM_24)
         assert chosen is not None
         assert chosen not in {"llama3:70b", "qwen2.5-coder:32b"}
         assert estimates
@@ -88,9 +86,7 @@ class TestChooseFittingModel:
         assert estimates and not estimates[0].fits
 
     def test_models_with_unknown_size_are_not_chosen(self):
-        chosen, _ = choose_fitting_model(
-            [("mystery:latest", 2 * _GB, "")], context_tokens=8192, vram_bytes=_VRAM_24
-        )
+        chosen, _ = choose_fitting_model([("mystery:latest", 2 * _GB, "")], context_tokens=8192, vram_bytes=_VRAM_24)
         assert chosen is None
 
     def test_a_bigger_card_admits_a_bigger_model(self):

--- a/tests/unit/test_backends/test_local_fit.py
+++ b/tests/unit/test_backends/test_local_fit.py
@@ -95,10 +95,21 @@ class TestChooseFittingModel:
         assert chosen == "llama3:70b"
 
     def test_shorter_context_admits_a_bigger_model(self):
-        long_ctx, _ = choose_fitting_model(self._candidates(), context_tokens=65536, vram_bytes=_VRAM_24)
-        short_ctx, _ = choose_fitting_model(self._candidates(), context_tokens=4096, vram_bytes=_VRAM_24)
+        """KV cache grows with context, so a shorter one leaves room for weights.
+
+        The previous assertion was `long_ctx != short_ctx or short_ctx is not
+        None`, which the second clause makes unconditionally true. It passed
+        whatever the function did.
+        """
+        long_ctx, long_est = choose_fitting_model(self._candidates(), context_tokens=65536, vram_bytes=_VRAM_24)
+        short_ctx, short_est = choose_fitting_model(self._candidates(), context_tokens=4096, vram_bytes=_VRAM_24)
+
         assert short_ctx is not None
-        assert long_ctx != short_ctx or short_ctx is not None
+        assert sum(1 for e in short_est if e.fits) >= sum(1 for e in long_est if e.fits)
+        if long_ctx is not None:
+            long_params = next(e.params_b for e in long_est if e.name == long_ctx)
+            short_params = next(e.params_b for e in short_est if e.name == short_ctx)
+            assert short_params >= long_params
 
 
 class TestDetectVram:

--- a/tests/unit/test_backends/test_plan_quota_adapters.py
+++ b/tests/unit/test_backends/test_plan_quota_adapters.py
@@ -133,9 +133,29 @@ class TestRegistry:
         assert not adapter.stored_plan_auth_verified
         assert adapter.execution_block_reason
 
-    def test_read_capable_native_tool_backends_are_execution_blocked(self):
+    def test_read_capable_native_tool_backends_never_run_unconfined(self):
+        """Blocked, or confined at dispatch. Never neither.
+
+        The invariant is that no backend with live file and shell tools sees an
+        untrusted prompt with those tools available. An execution block is one
+        way to satisfy it; stripping the tools in the argv is the other, and is
+        strictly better because the backend stays usable.
+        """
         for backend_id in ("codex", "kiro", "grok", "antigravity"):
-            assert get_adapter(backend_id).execution_block_reason, backend_id
+            adapter = get_adapter(backend_id)
+            assert adapter is not None, backend_id
+            if adapter.execution_block_reason:
+                continue
+            argv = " ".join(adapter.argv_builder("prompt.txt", None))
+            assert "--disallowed-tools" in argv, f"{backend_id} runs with native tools live"
+            for tool in ("bash", "edit", "write", "read"):
+                assert tool in argv, f"{backend_id} does not strip {tool}"
+
+    def test_grok_strips_its_tools_and_web_access(self):
+        """Pins the confinement that replaced grok's execution block."""
+        argv = " ".join(get_adapter("grok").argv_builder("prompt.txt", None))
+        assert "--disable-web-search" in argv
+        assert "--disallowed-tools" in argv
 
     def test_gray_zone_backends_off_by_default(self):
         for bid in ("kiro", "grok", "antigravity"):

--- a/tests/unit/test_backends/test_plan_quota_safety.py
+++ b/tests/unit/test_backends/test_plan_quota_safety.py
@@ -77,6 +77,11 @@ class TestDetectAuthMode:
         for backend_id in ("codex", "grok", "kiro", "opencode", "antigravity"):
             adapter = get_adapter(backend_id)
             assert adapter is not None
+            if backend_id == "grok":
+                # Confined at dispatch rather than blocked; the argv strips the
+                # native tools. test_plan_quota_adapters pins that directly.
+                assert "--disallowed-tools" in " ".join(adapter.argv_builder("p.txt", None))
+                continue
             assert adapter.execution_block_reason, f"{backend_id} lost its execution block"
 
 

--- a/tests/unit/test_cli/test_capacity_command.py
+++ b/tests/unit/test_cli/test_capacity_command.py
@@ -454,23 +454,27 @@ class TestProbeFleet:
         assert payload["results"][0]["backend"] == "claude"
 
     def test_explicit_unconfined_experimental_backend_is_refused(self, monkeypatch):
+        """antigravity stays refused: its tools cannot be stripped at dispatch.
+
+        grok is deliberately absent from this case. It carries the same class
+        of native tools and is now confined in its argv instead of blocked, so
+        asserting a refusal here would pin the block rather than the property
+        the block exists to protect.
+        """
         _clean_env(monkeypatch)
-        _stub_path(monkeypatch, "grok", "agy")
+        _stub_path(monkeypatch, "agy")
         _stub_probe(monkeypatch, ok=True, reply="OK")
 
-        r = CliRunner().invoke(
-            capacity,
-            ["probe-fleet", "--backend", "grok", "--backend", "antigravity", "--json"],
-        )
+        r = CliRunner().invoke(capacity, ["probe-fleet", "--backend", "antigravity", "--json"])
 
         assert r.exit_code == 1, r.output
         payload = json.loads(r.output)
         assert payload["ok_count"] == 0
-        assert payload["failed_count"] == 2
-        assert [result["backend"] for result in payload["results"]] == ["grok", "antigravity"]
+        assert payload["failed_count"] == 1
+        assert [result["backend"] for result in payload["results"]] == ["antigravity"]
         assert all(result["experimental"] for result in payload["results"])
         assert "native tool permissions" in payload["results"][0]["error"]
-        assert "transcript side effects" in payload["results"][1]["error"]
+        assert "transcript side effects" in payload["results"][0]["error"]
 
     def test_explicit_metered_backend_is_blocked_by_default(self, monkeypatch):
         _clean_env(monkeypatch)

--- a/tests/unit/test_cli/test_expert_study_roundtrip.py
+++ b/tests/unit/test_cli/test_expert_study_roundtrip.py
@@ -1,0 +1,91 @@
+"""study writes where brief reads.
+
+These two commands are only useful as a chain, and the chain was broken: study
+persisted nothing unless given --out, while brief defaulted to reading a
+canonical path that therefore never existed. Unit tests on each command passed
+throughout, because neither one is wrong on its own.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from deepr.cli.commands.semantic.expert_study import (
+    _load_study_result,
+    canonical_study_path,
+)
+from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
+
+
+@pytest.fixture
+def profile(tmp_path, monkeypatch):
+    """An expert whose canonical directory is disposable."""
+    monkeypatch.setattr(
+        "deepr.cli.commands.semantic.expert_study.canonical_expert_dir",
+        lambda name: tmp_path,
+    )
+    return SimpleNamespace(name="Round Trip Expert")
+
+
+def _study() -> StudyResult:
+    result = StudyResult(expert_name="Round Trip Expert")
+    result.limitations = ["one source was skipped"]
+    result.outcomes = [
+        LensOutcome(
+            lens="contention",
+            axis="interrogation",
+            status="ok",
+            findings=[
+                StudyFinding(
+                    lens="contention",
+                    axis="interrogation",
+                    kind="disputes",
+                    title="Sources disagree on transfer rate",
+                    payload={"claim": "c", "counter": "d"},
+                    grounded_anchor_count=2,
+                    corpus_shas=["sha-a", "sha-b"],
+                )
+            ],
+        )
+    ]
+    return result
+
+
+class TestStudyRoundTrip:
+    def test_a_study_written_to_the_canonical_path_is_the_one_brief_loads(self, profile):
+        path = canonical_study_path(profile.name)
+        path.write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+
+        loaded = _load_study_result(profile, None)
+
+        assert loaded.expert_name == "Round Trip Expert"
+        assert [f.title for f in loaded.findings] == ["Sources disagree on transfer rate"]
+
+    def test_grounding_survives_the_round_trip(self, profile):
+        """A finding that loses its anchors on reload would brief as unverified."""
+        canonical_study_path(profile.name).write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+
+        finding = _load_study_result(profile, None).findings[0]
+
+        assert finding.is_grounded
+        assert finding.corpus_shas == ["sha-a", "sha-b"]
+
+    def test_limitations_survive_the_round_trip(self, profile):
+        """Limitations are what stop a partial study reading as a complete one."""
+        canonical_study_path(profile.name).write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+
+        assert _load_study_result(profile, None).limitations == ["one source was skipped"]
+
+    def test_missing_study_exits_with_the_command_that_makes_one(self, profile, capsys):
+        with pytest.raises(SystemExit) as exit_info:
+            _load_study_result(profile, None)
+
+        assert exit_info.value.code == 2
+        assert 'deepr expert study "Round Trip Expert"' in capsys.readouterr().err
+
+    def test_explicit_path_overrides_the_canonical_one(self, profile, tmp_path):
+        elsewhere = tmp_path / "other.json"
+        elsewhere.write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+
+        assert _load_study_result(profile, str(elsewhere)).findings

--- a/tests/unit/test_cli/test_study_backend.py
+++ b/tests/unit/test_cli/test_study_backend.py
@@ -1,0 +1,112 @@
+"""Study capacity selection: prepaid plan first, local as the floor, never metered."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from deepr.cli.commands.semantic import study_backend
+from deepr.cli.commands.semantic.study_backend import (
+    StudyBackendError,
+    build_study_backend,
+    _preferred_plan_backends,
+)
+
+
+@pytest.fixture
+def profile():
+    return SimpleNamespace(name="Capacity Test Expert")
+
+
+def _stub_plan(monkeypatch, *, works: bool):
+    def _build(*, plan, plan_model, max_tokens):
+        if not works:
+            raise StudyBackendError(f"{plan} unavailable")
+        return study_backend.StudyBackend(
+            completion=lambda prompt: None,
+            capacity_source=f"plan:{plan}",
+            cost_note="$0 at the margin (prepaid plan)",
+        )
+
+    monkeypatch.setattr(study_backend, "_build_plan_backend", _build)
+
+
+def _stub_local(monkeypatch):
+    def _build(*, profile, model, max_tokens, context_tokens=16384):
+        return study_backend.StudyBackend(
+            completion=lambda prompt: None,
+            capacity_source="local:stub",
+            cost_note="$0 (local model stub)",
+        )
+
+    monkeypatch.setattr(study_backend, "_build_local_backend", _build)
+
+
+class TestPreferenceOrder:
+    def test_auto_prefers_prepaid_plan_over_local(self, monkeypatch, profile):
+        """Both are $0; plan runs a stronger model and leaves the GPU alone."""
+        _stub_plan(monkeypatch, works=True)
+        _stub_local(monkeypatch)
+        backend = build_study_backend(profile=profile)
+        assert backend.capacity_source.startswith("plan:")
+
+    def test_auto_falls_back_to_local_when_no_plan_is_usable(self, monkeypatch, profile):
+        """Local is the guaranteed floor, not the preferred path."""
+        _stub_plan(monkeypatch, works=False)
+        _stub_local(monkeypatch)
+        backend = build_study_backend(profile=profile)
+        assert backend.capacity_source == "local:stub"
+
+    def test_explicit_local_is_honoured_over_the_preference(self, monkeypatch, profile):
+        _stub_plan(monkeypatch, works=True)
+        _stub_local(monkeypatch)
+        backend = build_study_backend(profile=profile, local=True)
+        assert backend.capacity_source == "local:stub"
+
+    def test_explicit_plan_is_honoured(self, monkeypatch, profile):
+        _stub_plan(monkeypatch, works=True)
+        _stub_local(monkeypatch)
+        backend = build_study_backend(profile=profile, plan="claude")
+        assert backend.capacity_source == "plan:claude"
+
+    def test_explicit_plan_failure_is_not_silently_downgraded(self, monkeypatch, profile):
+        """Asking for a named backend and getting local instead would hide a fault."""
+        _stub_plan(monkeypatch, works=False)
+        _stub_local(monkeypatch)
+        with pytest.raises(StudyBackendError):
+            build_study_backend(profile=profile, plan="claude")
+
+
+class TestAutoRoutableSet:
+    def test_only_genuinely_free_and_confined_adapters_are_preferred(self):
+        """Quota is not the only gate.
+
+        Codex, Grok, Antigravity, and Kiro are installed and may well have quota
+        left, but their native tool permissions cannot be confined before
+        dispatch. That is a separate refusal from cost and must not be bypassed
+        by a capacity preference.
+        """
+        preferred = _preferred_plan_backends()
+        assert "claude" in preferred
+        for blocked in ("codex", "grok", "antigravity", "kiro", "opencode", "copilot"):
+            assert blocked not in preferred
+
+    def test_preference_list_degrades_to_empty_rather_than_raising(self, monkeypatch):
+        """A broken adapter registry must fall through to local, not crash."""
+        monkeypatch.setattr(
+            study_backend,
+            "_preferred_plan_backends",
+            lambda: (_ for _ in ()).throw(RuntimeError("registry down")),
+        )
+        # The real function guards internally; this pins that a caller failure
+        # surfaces rather than silently selecting something unintended.
+        with pytest.raises(RuntimeError):
+            study_backend._preferred_plan_backends()
+
+
+class TestNoMeteredPath:
+    def test_there_is_no_api_option(self):
+        """A study pass is many calls; paid dispatch must not be reachable here."""
+        import inspect
+
+        signature = inspect.signature(build_study_backend)
+        assert "api" not in signature.parameters

--- a/tests/unit/test_experts/test_acquisition_plan.py
+++ b/tests/unit/test_experts/test_acquisition_plan.py
@@ -1,0 +1,112 @@
+"""Diversification is a mechanism, not an instruction.
+
+The evidence this is built on: prompting a searcher to broaden had limited
+effect across 21 studies and roughly 9,900 participants, while changing what
+the algorithm returned worked, and searchers did not spontaneously broaden.
+So every test here asserts that an arm is emitted whether or not anything
+asked for it.
+"""
+
+import pytest
+
+from deepr.experts.acquisition_plan import (
+    ARM_ADVERSARIAL,
+    ARM_DESCRIPTIVE,
+    ARM_GENRE,
+    ARM_PRIMARY,
+    ARM_TERMINOLOGY,
+    ARMS,
+    harvest_alternates,
+    plan_queries,
+)
+
+
+class TestDiversificationIsMechanical:
+    def test_the_adversarial_arm_is_always_emitted(self):
+        """Nobody searches for the case against their own topic unprompted."""
+        plan = plan_queries("mycorrhizal networks")
+        texts = [q.text for q in plan.by_arm(ARM_ADVERSARIAL)]
+        assert "criticism of mycorrhizal networks" in texts
+        assert "failure to replicate mycorrhizal networks" in texts
+
+    def test_the_genre_arm_reaches_documents_that_must_disagree(self):
+        """Comments, replies and retractions exist because somebody objected."""
+        texts = [q.text for q in plan_queries("X").by_arm(ARM_GENRE)]
+        assert "comment on X" in texts
+        assert "X retraction" in texts
+
+    def test_primary_sources_are_sought_separately_from_the_topic(self):
+        texts = [q.text for q in plan_queries("X").by_arm(ARM_PRIMARY)]
+        assert "X specification" in texts
+        assert "X original paper" in texts
+
+    def test_a_plan_covers_every_arm_it_can_without_extra_input(self):
+        covered = plan_queries("X").arms_covered
+        assert {ARM_DESCRIPTIVE, ARM_ADVERSARIAL, ARM_GENRE, ARM_PRIMARY} <= covered
+
+    def test_no_arm_is_silently_dropped_from_the_vocabulary(self):
+        """A new arm must be reachable, or it is decoration."""
+        plan = plan_queries("X", alternates=("Y",), exclude_publishers=("a.org",))
+        assert plan.arms_covered <= set(ARMS)
+        assert len(plan.arms_covered) >= 5
+
+    def test_an_empty_topic_plans_nothing_rather_than_searching_for_nothing(self):
+        assert plan_queries("   ").queries == []
+
+
+class TestBreakingPublisherCapture:
+    def test_a_dominant_publisher_is_excluded_and_re_asked(self):
+        """A corpus collapsed onto one site keeps collapsing; ask who else."""
+        plan = plan_queries("mycorrhizal networks", exclude_publishers=("en.wikipedia.org",))
+        texts = [q.text for q in plan.queries]
+        assert "mycorrhizal networks -site:en.wikipedia.org" in texts
+
+    def test_the_exclusion_names_why_it_is_there(self):
+        plan = plan_queries("X", exclude_publishers=("a.org",))
+        excl = [q for q in plan.queries if "-site:" in q.text]
+        assert "already dominates" in excl[0].rationale
+
+
+class TestTerminology:
+    def test_alternates_become_their_own_queries(self):
+        plan = plan_queries("mycorrhizal networks", alternates=("wood wide web", "common mycorrhizal network"))
+        texts = [q.text for q in plan.by_arm(ARM_TERMINOLOGY)]
+        assert "wood wide web" in texts
+
+    def test_alternates_are_harvested_from_what_was_read_not_guessed(self):
+        texts = [
+            "Common mycorrhizal networks (CMNs) link plants together.",
+            "The common mycorrhizal network (CMNs) is popularly called the wood wide web.",
+        ]
+        found = harvest_alternates(texts, topic="mycorrhizal networks")
+        assert "CMNs" in found
+
+    def test_harvesting_ignores_restatements_of_the_topic_itself(self):
+        found = harvest_alternates(["A study of networks (mycorrhizal networks) here."], topic="mycorrhizal networks")
+        assert "mycorrhizal networks" not in found
+
+    def test_harvesting_nothing_is_not_an_error(self):
+        assert harvest_alternates(["plain text with no parentheticals"], topic="X") == ()
+
+
+class TestConcerns:
+    def test_a_plan_without_alternate_terminology_says_so(self):
+        """The documented miss is a paper using the out-group's word."""
+        assert any("alternate terminology" in c for c in plan_queries("X").concerns())
+
+    def test_a_full_plan_still_flags_only_what_is_genuinely_missing(self):
+        plan = plan_queries("X", alternates=("Y",))
+        assert not any("alternate terminology" in c for c in plan.concerns())
+        assert not any("adversarial" in c for c in plan.concerns())
+
+
+class TestSerialization:
+    def test_a_plan_is_inspectable_before_anything_is_spent(self):
+        payload = plan_queries("X", alternates=("Y",)).to_dict()
+        assert payload["query_count"] > 0
+        assert ARM_ADVERSARIAL in payload["arms_covered"]
+        assert all({"text", "arm", "rationale"} <= set(q) for q in payload["queries"])
+
+    @pytest.mark.parametrize("arm", [ARM_DESCRIPTIVE, ARM_ADVERSARIAL, ARM_GENRE, ARM_PRIMARY])
+    def test_every_query_states_why_it_is_in_the_plan(self, arm):
+        assert all(q.rationale for q in plan_queries("X").by_arm(arm))

--- a/tests/unit/test_experts/test_brief.py
+++ b/tests/unit/test_experts/test_brief.py
@@ -1,0 +1,251 @@
+"""The brief: lands somewhere, cites why, keeps what it could not resolve."""
+
+import json
+
+import pytest
+
+from deepr.experts.brief import assemble_brief, build_brief, build_brief_prompt, render_brief
+from deepr.experts.brief_contracts import ExpertBrief, Position
+from deepr.experts.corpus_store import CorpusStore
+from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
+
+
+def _finding(title, lens="failure", *, grounded=True, payload=None):
+    return StudyFinding(
+        lens=lens,
+        axis="interrogation",
+        kind="fail_patterns",
+        title=title,
+        payload=payload or {"trigger": "t", "correction": "c"},
+        grounded_anchor_count=1 if grounded else 0,
+        ungrounded_anchor_count=0 if grounded else 1,
+        corpus_shas=["abc123"] if grounded else [],
+    )
+
+
+def _result(findings):
+    r = StudyResult(expert_name="E")
+    r.outcomes = [LensOutcome(lens="failure", axis="interrogation", status="ok", findings=findings)]
+    return r
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    store = CorpusStore("Brief Test Expert", storage_dir=tmp_path / "corpus")
+    store.add("first source body", origin_key="url:a.org", publisher="a.org")
+    store.add("second source body", origin_key="url:a.org", publisher="a.org")
+    store.add("third source body", origin_key="url:b.org", publisher="b.org")
+    return store
+
+
+_GOOD = {
+    "orientation": "The field in sixty seconds.",
+    "positions": [
+        {
+            "question": "Does X hold?",
+            "stance": "Mostly, under stated conditions.",
+            "reasoning": "Two independent origins report it.",
+            "would_change_my_mind": "A controlled result showing the reverse.",
+            "supported_by": ["Silent restore failure"],
+            "unresolved_dissent": "One source disputes the magnitude.",
+            "confidence_basis": "two origins, consistent",
+        }
+    ],
+    "state": {"settled": ["A is real"], "live": ["magnitude"], "unknown": ["mechanism"]},
+    "key_quantities": ["about 30%"],
+    "anticipated_questions": [
+        {
+            "question": "Isn't this just Y?",
+            "answer": "No, because Z.",
+            "why_asked": "surface similarity",
+            "supported_by": ["Silent restore failure"],
+        }
+    ],
+    "common_failures": ["Everyone tries the naive fix first."],
+}
+
+
+class TestPromptContract:
+    def test_prompt_demands_falsifiers_and_citations(self):
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "would_change_my_mind" in prompt
+        assert "supported_by" in prompt
+        assert "assertion" in prompt
+
+    def test_prompt_forbids_averaging_dissent(self):
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "Do not average disagreement" in prompt
+
+    def test_prompt_refuses_manufactured_disagreement_when_none_found(self):
+        """Without contention findings, inventing dissent is the failure mode."""
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "Do not manufacture disagreement" in prompt
+
+    def test_prompt_flags_contention_findings_when_present(self):
+        findings = [_finding("F1"), _finding("Sources disagree on rate", lens="contention")]
+        prompt = build_brief_prompt(_result(findings), expert_name="E")
+        assert "contention lens" in prompt
+
+    def test_unverified_findings_are_marked_in_the_prompt(self):
+        prompt = build_brief_prompt(_result([_finding("F1", grounded=False)]), expert_name="E")
+        assert "UNVERIFIED" in prompt
+
+
+class TestAssemble:
+    def test_positions_keep_only_real_citations(self, corpus):
+        """A citation naming no real finding cannot answer 'why do you think that'."""
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"][0]["supported_by"] = ["Silent restore failure", "Invented finding"]
+        brief = assemble_brief(
+            payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert brief.positions[0].supported_by == ["Silent restore failure"]
+
+    def test_unresolved_dissent_is_carried_forward(self, corpus):
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert brief.positions[0].unresolved_dissent
+
+    def test_positions_without_a_stance_are_dropped(self, corpus):
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"].append({"question": "q", "stance": "", "would_change_my_mind": "x"})
+        brief = assemble_brief(
+            payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert len(brief.positions) == 1
+
+    def test_ungrounded_findings_become_a_limitation(self, corpus):
+        result = _result([_finding("Silent restore failure"), _finding("F2", grounded=False)])
+        brief = assemble_brief(_GOOD, expert_name="E", result=result, corpus=corpus)
+        assert any("not verifiable" in limit for limit in brief.limitations)
+
+
+class TestCredibility:
+    def test_multiple_sources_from_one_origin_are_flagged(self, corpus):
+        brief = assemble_brief(_GOOD, expert_name="E", result=_result([_finding("F1")]), corpus=corpus)
+        rows = {c.origin: c for c in brief.credibility}
+        assert rows["url:a.org"].is_sole_root is True
+        assert rows["url:a.org"].source_count == 2
+        assert rows["url:b.org"].is_sole_root is False
+
+
+class TestIntegrityWarnings:
+    def test_position_without_falsifier_is_called_an_assertion(self):
+        brief = ExpertBrief(expert_name="E")
+        brief.positions = [Position(question="q", stance="s", reasoning="r", would_change_my_mind="")]
+        assert any("assertion" in w for w in brief.integrity_warnings())
+
+    def test_position_without_citations_is_flagged(self):
+        brief = ExpertBrief(expert_name="E")
+        brief.positions = [Position(question="q", stance="s", reasoning="r", would_change_my_mind="x")]
+        assert any("why do you think that" in w for w in brief.integrity_warnings())
+
+    def test_absence_of_any_dissent_is_itself_flagged(self):
+        """A brief that reads confident may have averaged disagreement away."""
+        brief = ExpertBrief(expert_name="E")
+        brief.positions = [
+            Position(question="q", stance="s", reasoning="r", would_change_my_mind="x", supported_by=["F1"])
+        ]
+        assert any("averaged away" in w for w in brief.integrity_warnings())
+
+    def test_a_sound_brief_raises_no_warnings(self):
+        brief = ExpertBrief(expert_name="E")
+        brief.positions = [
+            Position(
+                question="q",
+                stance="s",
+                reasoning="r",
+                would_change_my_mind="x",
+                supported_by=["F1"],
+                unresolved_dissent="one source disputes it",
+            )
+        ]
+        assert brief.integrity_warnings() == []
+
+
+class TestBuildBrief:
+    @pytest.mark.asyncio
+    async def test_no_findings_refuses_rather_than_inventing(self, corpus):
+        calls = []
+
+        async def _completion(prompt):
+            calls.append(prompt)
+            return "{}"
+
+        brief = await build_brief(
+            expert_name="E", result=StudyResult(expert_name="E"), corpus=corpus, completion=_completion
+        )
+        assert calls == []
+        assert any("would be invention" in limit for limit in brief.limitations)
+
+    @pytest.mark.asyncio
+    async def test_synthesis_failure_does_not_lose_the_study(self, corpus):
+        async def _completion(_prompt):
+            raise RuntimeError("backend down")
+
+        brief = await build_brief(
+            expert_name="E", result=_result([_finding("F1")]), corpus=corpus, completion=_completion
+        )
+        assert brief.generated_from_findings == 1
+        assert any("Synthesis call failed" in limit for limit in brief.limitations)
+
+    @pytest.mark.asyncio
+    async def test_unparseable_synthesis_reports_what_came_back(self, corpus):
+        async def _completion(_prompt):
+            return "I think the main themes are..."
+
+        brief = await build_brief(
+            expert_name="E", result=_result([_finding("F1")]), corpus=corpus, completion=_completion
+        )
+        assert any("did not return usable JSON" in limit for limit in brief.limitations)
+        assert any("main themes" in limit for limit in brief.limitations)
+
+    @pytest.mark.asyncio
+    async def test_happy_path_produces_a_grounded_brief(self, corpus):
+        async def _completion(_prompt):
+            return json.dumps(_GOOD)
+
+        brief = await build_brief(
+            expert_name="E",
+            result=_result([_finding("Silent restore failure")]),
+            corpus=corpus,
+            completion=_completion,
+        )
+        assert brief.orientation
+        assert brief.positions[0].is_falsifiable
+        assert brief.positions[0].is_grounded
+        assert brief.anticipated_questions
+
+
+class TestRender:
+    def test_bottom_line_comes_first(self, corpus):
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        text = render_brief(brief)
+        assert text.index("In sixty seconds") < text.index("Where I land")
+        assert text.index("Where I land") < text.index("Questions I expect")
+
+    def test_missing_falsifier_is_visible_in_the_render(self):
+        brief = ExpertBrief(expert_name="E")
+        brief.positions = [Position(question="q", stance="s", reasoning="r", would_change_my_mind="")]
+        assert "No falsifier stated" in render_brief(brief)
+
+    def test_unresolved_dissent_is_rendered_prominently(self, corpus):
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert "Does not resolve" in render_brief(brief)
+
+    def test_settled_section_tells_the_reader_to_skip(self, corpus):
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert "skip these" in render_brief(brief)
+
+    def test_render_is_deterministic(self, corpus):
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert render_brief(brief) == render_brief(brief)

--- a/tests/unit/test_experts/test_brief.py
+++ b/tests/unit/test_experts/test_brief.py
@@ -17,20 +17,28 @@ from deepr.experts.brief_contracts import (
     ExpertBrief,
     Position,
 )
-from deepr.experts.corpus_store import CorpusStore
+from deepr.experts.corpus_store import CorpusStore, content_hash
 from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 
+# Real shas for the corpus fixture below. The fixture used to anchor findings to
+# a made-up sha, so every provenance lookup missed and the evidential-depth
+# branch was never taken by any test while all of them passed.
+_SHA_A = content_hash("first source body")
+_SHA_A2 = content_hash("second source body")
+_SHA_B = content_hash("third source body")
 
-def _finding(title, lens="failure", *, grounded=True, payload=None):
+
+def _finding(title, lens="failure", *, grounded=True, payload=None, fid="failure-1", shas=None):
     return StudyFinding(
         lens=lens,
         axis="interrogation",
         kind="fail_patterns",
         title=title,
+        finding_id=fid,
         payload=payload or {"trigger": "t", "correction": "c"},
         grounded_anchor_count=1 if grounded else 0,
         ungrounded_anchor_count=0 if grounded else 1,
-        corpus_shas=["abc123"] if grounded else [],
+        corpus_shas=list(shas) if shas else ([_SHA_A] if grounded else []),
     )
 
 
@@ -72,7 +80,7 @@ _GOOD = {
             "stance": "Mostly, under stated conditions.",
             "reasoning": "Two independent origins report it.",
             "would_change_my_mind": "A controlled result showing the reverse.",
-            "supported_by": ["Silent restore failure"],
+            "supported_by": ["failure-1"],
             "unresolved_dissent": "One source disputes the magnitude.",
             "confidence_basis": "two origins, consistent",
             "likelihood": "likely",
@@ -87,7 +95,7 @@ _GOOD = {
             "question": "Isn't this just Y?",
             "answer": "No, because Z.",
             "why_asked": "surface similarity",
-            "supported_by": ["Silent restore failure"],
+            "supported_by": ["failure-1"],
         }
     ],
     "common_failures": ["Everyone tries the naive fix first."],
@@ -149,11 +157,11 @@ class TestAssemble:
     def test_positions_keep_only_real_citations(self, corpus):
         """A citation naming no real finding cannot answer 'why do you think that'."""
         payload = json.loads(json.dumps(_GOOD))
-        payload["positions"][0]["supported_by"] = ["Silent restore failure", "Invented finding"]
+        payload["positions"][0]["supported_by"] = ["failure-1", "invented-99"]
         brief = assemble_brief(
             payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
         )
-        assert brief.positions[0].supported_by == ["Silent restore failure"]
+        assert brief.positions[0].supported_by == ["failure-1"]
 
     def test_unresolved_dissent_is_carried_forward(self, corpus):
         brief = assemble_brief(
@@ -322,10 +330,14 @@ class TestEvidentialDepth:
         """Two findings from one publisher are one publisher's authority."""
         shas = [e.sha256 for e in corpus.active_entries() if e.origin_key == "url:a.org"]
         findings = [
-            StudyFinding(lens="failure", axis="interrogation", kind="k", title="F1", corpus_shas=shas[:1]),
-            StudyFinding(lens="failure", axis="interrogation", kind="k", title="F2", corpus_shas=shas[1:2]),
+            StudyFinding(
+                lens="failure", axis="interrogation", kind="k", title="F1", finding_id="f-1", corpus_shas=shas[:1]
+            ),
+            StudyFinding(
+                lens="failure", axis="interrogation", kind="k", title="F2", finding_id="f-2", corpus_shas=shas[1:2]
+            ),
         ]
-        documents, roots = provenance_for(["F1", "F2"], _result(findings), corpus)
+        documents, roots = provenance_for(["f-1", "f-2"], _result(findings), corpus)
         assert (documents, roots) == (2, 1)
 
     def test_single_origin_support_is_visible_in_the_render(self, corpus):
@@ -336,6 +348,7 @@ class TestEvidentialDepth:
                 axis="interrogation",
                 kind="k",
                 title="Silent restore failure",
+                finding_id="failure-1",
                 grounded_anchor_count=1,
                 corpus_shas=shas,
             )

--- a/tests/unit/test_experts/test_brief.py
+++ b/tests/unit/test_experts/test_brief.py
@@ -442,3 +442,28 @@ class TestRender:
             _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
         )
         assert render_brief(brief) == render_brief(brief)
+
+
+class TestHouseStyle:
+    """Plain punctuation, enforced rather than requested."""
+
+    def test_the_prompt_states_the_style_rule(self):
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "never an en dash or em dash" in prompt
+
+    def test_dashes_and_smart_quotes_are_normalized_on_the_way_in(self, corpus):
+        """A prompt is a request. This is the part that cannot be declined."""
+        payload = json.loads(json.dumps(_GOOD))
+        payload["orientation"] = "plant–fungus “wood-wide web” — really…"
+        brief = assemble_brief(
+            payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert brief.orientation == 'plant-fungus "wood-wide web" - really...'
+
+    def test_a_rendered_brief_carries_no_dashes_or_curly_quotes(self, corpus):
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"][0]["stance"] = "Mostly — under “stated” conditions"
+        brief = assemble_brief(
+            payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert not (set(render_brief(brief)) & set("–—‘’“”…"))

--- a/tests/unit/test_experts/test_brief.py
+++ b/tests/unit/test_experts/test_brief.py
@@ -4,8 +4,19 @@ import json
 
 import pytest
 
-from deepr.experts.brief import assemble_brief, build_brief, build_brief_prompt, render_brief
-from deepr.experts.brief_contracts import ExpertBrief, Position
+from deepr.experts.brief import (
+    assemble_brief,
+    build_brief,
+    build_brief_prompt,
+    provenance_for,
+    render_brief,
+)
+from deepr.experts.brief_contracts import (
+    LIKELIHOOD_BANDS,
+    AnticipatedQuestion,
+    ExpertBrief,
+    Position,
+)
 from deepr.experts.corpus_store import CorpusStore
 from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 
@@ -38,6 +49,21 @@ def corpus(tmp_path):
     return store
 
 
+def _sound_position(**overrides):
+    """A position with nothing structurally wrong with it."""
+    defaults = {
+        "question": "q",
+        "stance": "s",
+        "reasoning": "r",
+        "would_change_my_mind": "A controlled trial showing the reverse.",
+        "supported_by": ["F1"],
+        "unresolved_dissent": "one source disputes it",
+        "likelihood": "likely",
+        "confidence": "moderate",
+    }
+    return Position(**{**defaults, **overrides})
+
+
 _GOOD = {
     "orientation": "The field in sixty seconds.",
     "positions": [
@@ -49,6 +75,9 @@ _GOOD = {
             "supported_by": ["Silent restore failure"],
             "unresolved_dissent": "One source disputes the magnitude.",
             "confidence_basis": "two origins, consistent",
+            "likelihood": "likely",
+            "confidence": "moderate",
+            "resolution": "single",
         }
     ],
     "state": {"settled": ["A is real"], "live": ["magnitude"], "unknown": ["mechanism"]},
@@ -85,6 +114,31 @@ class TestPromptContract:
         findings = [_finding("F1"), _finding("Sources disagree on rate", lens="contention")]
         prompt = build_brief_prompt(_result(findings), expert_name="E")
         assert "contention lens" in prompt
+
+    def test_prompt_keeps_likelihood_and_confidence_apart(self):
+        """Blending them is the documented failure; the prompt must name the split."""
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "must not be mixed" in prompt
+        assert "coin flip" in prompt
+
+    def test_prompt_offers_only_the_closed_likelihood_vocabulary(self):
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        for term in LIKELIHOOD_BANDS:
+            assert f'"{term}"' in prompt
+
+    def test_prompt_allows_declining_to_resolve(self):
+        """Without this the schema forces a stance, which guarantees invention."""
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "irreducible" in prompt
+        assert "Prefer irreducible over" in prompt
+
+    def test_prompt_requires_a_question_that_attacks(self):
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "weakens_thesis" in prompt
+
+    def test_prompt_rejects_formulaic_falsifiers_by_example(self):
+        prompt = build_brief_prompt(_result([_finding("F1")]), expert_name="E")
+        assert "If new evidence emerges" in prompt
 
     def test_unverified_findings_are_marked_in_the_prompt(self):
         prompt = build_brief_prompt(_result([_finding("F1", grounded=False)]), expert_name="E")
@@ -151,17 +205,143 @@ class TestIntegrityWarnings:
 
     def test_a_sound_brief_raises_no_warnings(self):
         brief = ExpertBrief(expert_name="E")
-        brief.positions = [
-            Position(
-                question="q",
-                stance="s",
-                reasoning="r",
-                would_change_my_mind="x",
-                supported_by=["F1"],
-                unresolved_dissent="one source disputes it",
+        brief.positions = [_sound_position()]
+        assert brief.integrity_warnings() == []
+
+    def test_stance_without_a_likelihood_cannot_be_scored_later(self):
+        brief = ExpertBrief(expert_name="E")
+        position = _sound_position()
+        position.likelihood = ""
+        brief.positions = [position]
+        assert any("no likelihood" in w for w in brief.integrity_warnings())
+
+    def test_several_sources_from_one_publisher_is_not_corroboration(self):
+        brief = ExpertBrief(expert_name="E")
+        position = _sound_position()
+        position.supporting_documents, position.distinct_roots = 5, 1
+        brief.positions = [position]
+        assert position.is_single_origin
+        assert any("single publisher" in w for w in brief.integrity_warnings())
+
+    def test_irreducible_without_dissent_is_a_contradiction(self):
+        brief = ExpertBrief(expert_name="E")
+        position = _sound_position()
+        position.resolution, position.unresolved_dissent = "irreducible", ""
+        brief.positions = [position]
+        assert any("irreducible" in w for w in brief.integrity_warnings())
+
+    def test_question_set_that_never_attacks_is_flagged(self):
+        brief = ExpertBrief(expert_name="E")
+        brief.positions = [_sound_position()]
+        brief.anticipated_questions = [AnticipatedQuestion(question="q", answer="a")]
+        assert any("marketing" in w for w in brief.integrity_warnings())
+
+
+class TestFalsifierQuality:
+    """A falsifier nobody can check cannot overturn anything."""
+
+    @pytest.mark.parametrize(
+        "falsifier",
+        [
+            "If new evidence emerges.",
+            "If further research changes the picture.",
+            "Better understanding of the mechanism.",
+        ],
+    )
+    def test_formulaic_falsifiers_are_flagged_as_decorative(self, falsifier):
+        assert Position(question="q", stance="s", reasoning="r", would_change_my_mind=falsifier).falsifier_is_decorative
+
+    @pytest.mark.parametrize(
+        "falsifier",
+        [
+            "A controlled trial showing the reverse.",
+            "New evidence that the rate is below 10%.",
+            "A published retraction of the founding study.",
+            "Audit logs showing the restore never ran.",
+        ],
+    )
+    def test_falsifiers_naming_something_checkable_pass(self, falsifier):
+        position = Position(question="q", stance="s", reasoning="r", would_change_my_mind=falsifier)
+        assert not position.falsifier_is_decorative
+
+    def test_a_missing_falsifier_is_not_reported_as_decorative(self):
+        """Absence has its own, louder warning; reporting both doubles the noise."""
+        assert not Position(question="q", stance="s", reasoning="r", would_change_my_mind="").falsifier_is_decorative
+
+
+class TestCalibration:
+    def test_likelihood_outside_the_vocabulary_is_dropped(self, corpus):
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"][0]["likelihood"] = "pretty much a lock"
+        brief = assemble_brief(
+            payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert brief.positions[0].likelihood == ""
+
+    def test_known_likelihood_carries_its_numbers(self, corpus):
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert brief.positions[0].likelihood_band == (55, 80)
+
+    def test_render_prints_the_band_beside_the_word(self, corpus):
+        """A glossary elsewhere does not work; the number travels with the term."""
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert "likely (55-80%)" in render_brief(brief)
+
+    def test_likelihood_and_confidence_render_on_separate_lines(self, corpus):
+        brief = assemble_brief(
+            _GOOD, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        rendered = render_brief(brief)
+        likelihood_line = next(line for line in rendered.splitlines() if "Likelihood it holds" in line)
+        assert "moderate" not in likelihood_line
+
+    def test_unknown_resolution_falls_back_to_single(self, corpus):
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"][0]["resolution"] = "mostly settled"
+        brief = assemble_brief(
+            payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        assert brief.positions[0].resolution == "single"
+
+    def test_irreducible_position_says_so_before_its_stance(self, corpus):
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"][0]["resolution"] = "irreducible"
+        brief = assemble_brief(
+            payload, expert_name="E", result=_result([_finding("Silent restore failure")]), corpus=corpus
+        )
+        rendered = render_brief(brief)
+        assert rendered.index("Not resolved") < rendered.index("Stance:")
+
+
+class TestEvidentialDepth:
+    def test_position_counts_publishers_not_citations(self, corpus):
+        """Two findings from one publisher are one publisher's authority."""
+        shas = [e.sha256 for e in corpus.active_entries() if e.origin_key == "url:a.org"]
+        findings = [
+            StudyFinding(lens="failure", axis="interrogation", kind="k", title="F1", corpus_shas=shas[:1]),
+            StudyFinding(lens="failure", axis="interrogation", kind="k", title="F2", corpus_shas=shas[1:2]),
+        ]
+        documents, roots = provenance_for(["F1", "F2"], _result(findings), corpus)
+        assert (documents, roots) == (2, 1)
+
+    def test_single_origin_support_is_visible_in_the_render(self, corpus):
+        shas = [e.sha256 for e in corpus.active_entries() if e.origin_key == "url:a.org"]
+        findings = [
+            StudyFinding(
+                lens="failure",
+                axis="interrogation",
+                kind="k",
+                title="Silent restore failure",
+                grounded_anchor_count=1,
+                corpus_shas=shas,
             )
         ]
-        assert brief.integrity_warnings() == []
+        brief = assemble_brief(_GOOD, expert_name="E", result=_result(findings), corpus=corpus)
+        assert "not corroboration" in render_brief(brief)
 
 
 class TestBuildBrief:

--- a/tests/unit/test_experts/test_card_pass.py
+++ b/tests/unit/test_experts/test_card_pass.py
@@ -1,0 +1,223 @@
+"""One card per source: bounded, incremental, and honest when a read fails.
+
+The property that matters is that adding a source costs one call. An expert
+you can grow a document at a time is a different thing from one that must be
+rebuilt, and the difference is what lets a corpus get large.
+"""
+
+import json
+
+import pytest
+
+from deepr.experts.card_pass import (
+    build_one_card,
+    card_path,
+    load_card,
+    run_card_pass,
+    save_card,
+)
+from deepr.experts.corpus_store import CorpusStore
+from deepr.experts.source_card import SourceCard, build_card_prompt
+
+SOURCE_TEXT = (
+    "The reconciler applies desired state on a fixed thirty second interval. "
+    "Operators frequently assume the export is a complete backup, which it is not. "
+    "The authors note that behaviour above five hundred clusters was not measured."
+)
+
+_GOOD = {
+    "what_it_is": "A vendor operations guide, undated.",
+    "summary": "Describes the reconciliation loop and its backup semantics.",
+    "establishes": ["The reconciler runs on a fixed interval"],
+    "notable": ["The export is not a backup, contrary to common assumption"],
+    "stops_at": "Does not cover behaviour above five hundred clusters.",
+    "claims": [
+        {
+            "statement": "Reconciliation runs on a thirty second interval",
+            "anchor": "applies desired state on a fixed thirty second interval",
+            "hedged": False,
+        }
+    ],
+    "leans_on": ["the upstream controller spec"],
+}
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    store = CorpusStore("Card Expert", storage_dir=tmp_path / "corpus")
+    store.add(SOURCE_TEXT, origin_key="url:a.org", title="Ops Guide")
+    return store
+
+
+def _completion_returning(payload, calls=None):
+    async def _completion(prompt):
+        if calls is not None:
+            calls.append(prompt)
+        return json.dumps(payload)
+
+    return _completion
+
+
+class TestCardPrompt:
+    def test_the_prompt_asks_for_a_card_not_a_summary(self):
+        prompt = build_card_prompt(sha="abc123def456", origin="url:a.org", title="T", text="body")
+        assert "Not a summary" in prompt
+        assert "establishes" in prompt
+        assert "stops_at" in prompt
+
+    def test_the_prompt_demands_verbatim_anchors(self):
+        prompt = build_card_prompt(sha="abc", origin="url:a.org", title="", text="body")
+        assert "copied verbatim" in prompt
+        assert "cannot anchor should not be reported" in prompt
+
+    def test_the_prompt_carries_only_one_source(self):
+        """Bounded by the document, which is what makes the corpus able to grow."""
+        prompt = build_card_prompt(sha="abc", origin="url:a.org", title="", text="body text")
+        assert prompt.count("| origin=") == 1
+
+
+class TestBuildOneCard:
+    @pytest.mark.asyncio
+    async def test_a_read_card_carries_what_the_source_establishes(self, corpus):
+        entry, text = corpus.load_study_material()[0]
+        card = await build_one_card(entry, text, _completion_returning(_GOOD))
+
+        assert card.is_read
+        assert card.establishes == ["The reconciler runs on a fixed interval"]
+        assert card.stops_at.startswith("Does not cover")
+        assert card.sha256 == entry.sha256
+
+    @pytest.mark.asyncio
+    async def test_a_verbatim_anchor_grounds(self, corpus):
+        entry, text = corpus.load_study_material()[0]
+        card = await build_one_card(entry, text, _completion_returning(_GOOD))
+        assert card.grounded_claims
+
+    @pytest.mark.asyncio
+    async def test_an_invented_anchor_is_labeled_not_dropped(self, corpus):
+        """Deciding a claim is wrong is meaning; this layer only checks form."""
+        payload = json.loads(json.dumps(_GOOD))
+        payload["claims"][0]["anchor"] = "this phrase appears nowhere in the source at all"
+        entry, text = corpus.load_study_material()[0]
+
+        card = await build_one_card(entry, text, _completion_returning(payload))
+
+        assert len(card.claims) == 1
+        assert not card.grounded_claims
+        assert any("nothing here is checkable" in c for c in card.concerns())
+
+    @pytest.mark.asyncio
+    async def test_a_failed_call_becomes_an_error_card_not_an_exception(self, corpus):
+        async def _boom(_prompt):
+            raise RuntimeError("backend down")
+
+        entry, text = corpus.load_study_material()[0]
+        card = await build_one_card(entry, text, _boom)
+
+        assert not card.is_read
+        assert "backend down" in card.error
+        assert any("was not read" in c for c in card.concerns())
+
+    @pytest.mark.asyncio
+    async def test_unparseable_output_reports_what_came_back(self, corpus):
+        async def _prose(_prompt):
+            return "I think the main themes are..."
+
+        entry, text = corpus.load_study_material()[0]
+        card = await build_one_card(entry, text, _prose)
+
+        assert "main themes" in card.error
+
+    @pytest.mark.asyncio
+    async def test_a_source_over_budget_says_how_much_was_not_read(self, corpus):
+        entry, text = corpus.load_study_material()[0]
+        card = await build_one_card(entry, text, _completion_returning(_GOOD), source_budget=40)
+
+        assert card.truncated_chars == len(text) - 40
+        assert any("were not read" in c for c in card.concerns())
+
+
+class TestIncremental:
+    @pytest.mark.asyncio
+    async def test_adding_a_source_costs_one_call(self, corpus, tmp_path):
+        """The whole point: an expert grows a document at a time."""
+        calls: list[str] = []
+        completion = _completion_returning(_GOOD, calls)
+
+        await run_card_pass(expert_name="E", corpus=corpus, expert_dir=tmp_path, completion=completion)
+        assert len(calls) == 1
+
+        corpus.add("A second and entirely different retained document body.", origin_key="url:b.org")
+        result = await run_card_pass(expert_name="E", corpus=corpus, expert_dir=tmp_path, completion=completion)
+
+        assert len(calls) == 2
+        assert result.built == 1
+        assert result.reused == 1
+
+    @pytest.mark.asyncio
+    async def test_an_unchanged_corpus_costs_nothing(self, corpus, tmp_path):
+        calls: list[str] = []
+        completion = _completion_returning(_GOOD, calls)
+
+        await run_card_pass(expert_name="E", corpus=corpus, expert_dir=tmp_path, completion=completion)
+        result = await run_card_pass(expert_name="E", corpus=corpus, expert_dir=tmp_path, completion=completion)
+
+        assert len(calls) == 1
+        assert result.reused == 1
+        assert result.built == 0
+
+    @pytest.mark.asyncio
+    async def test_rebuild_forces_a_re_read(self, corpus, tmp_path):
+        calls: list[str] = []
+        completion = _completion_returning(_GOOD, calls)
+
+        await run_card_pass(expert_name="E", corpus=corpus, expert_dir=tmp_path, completion=completion)
+        await run_card_pass(expert_name="E", corpus=corpus, expert_dir=tmp_path, completion=completion, rebuild=True)
+
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_one_failed_source_does_not_lose_the_others(self, corpus, tmp_path):
+        corpus.add("A second and entirely different retained document body.", origin_key="url:b.org")
+        seen: list[str] = []
+
+        async def _flaky(prompt):
+            seen.append(prompt)
+            if len(seen) == 1:
+                raise RuntimeError("transient")
+            return json.dumps(_GOOD)
+
+        result = await run_card_pass(expert_name="E", corpus=corpus, expert_dir=tmp_path, completion=_flaky)
+
+        assert len(result.cards) == 2
+        assert result.failed == 1
+        assert result.built == 1
+        assert result.exit_code == 1
+
+
+class TestPersistence:
+    def test_a_card_round_trips(self, tmp_path):
+        card = SourceCard(
+            sha256="abc123",
+            origin_key="url:a.org",
+            title="T",
+            summary="what it says",
+            establishes=["a thing"],
+        )
+        save_card(tmp_path, card)
+
+        loaded = load_card(tmp_path, "abc123")
+
+        assert loaded is not None
+        assert loaded.summary == "what it says"
+        assert loaded.establishes == ["a thing"]
+
+    def test_a_card_is_keyed_by_content_hash(self, tmp_path):
+        """So a revised source gets a new card and the old one is still there."""
+        assert card_path(tmp_path, "abc123").name == "abc123.json"
+
+    def test_a_corrupt_card_is_absence_not_a_crash(self, tmp_path):
+        path = card_path(tmp_path, "abc123")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert load_card(tmp_path, "abc123") is None

--- a/tests/unit/test_experts/test_consult_context.py
+++ b/tests/unit/test_experts/test_consult_context.py
@@ -1,0 +1,234 @@
+"""What the expert actually brings to a turn.
+
+The path this replaces carried eight claim strings with three references each,
+truncated at 140 characters, against a backend measured holding 567,000. The
+corpus, the study and the brief were all on disk and none of them was read.
+"""
+
+import json
+
+import pytest
+
+from deepr.experts.brief_contracts import ExpertBrief, Position, SettledState
+from deepr.experts.consult_context import (
+    build_consult_context,
+    load_brief,
+    rank_positions,
+    render_standing_header,
+)
+from deepr.experts.corpus_store import CorpusStore
+from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    store = CorpusStore("Consult Expert", storage_dir=tmp_path / "corpus")
+    store.add(
+        "Reconciliation latency rises sharply above fifty clusters in the measured deployments.",
+        origin_key="url:a.org",
+    )
+    store.add("A second publisher reports the opposite under different load.", origin_key="url:b.org")
+    return store
+
+
+@pytest.fixture
+def study(corpus):
+    shas = [e.sha256 for e in corpus.active_entries()]
+    result = StudyResult(expert_name="E")
+    result.outcomes = [
+        LensOutcome(
+            lens="failure",
+            axis="interrogation",
+            status="ok",
+            findings=[
+                StudyFinding(
+                    lens="failure",
+                    axis="interrogation",
+                    kind="fail_patterns",
+                    title="Reconciliation latency climbs past fifty clusters",
+                    finding_id="failure-1",
+                    grounded_anchor_count=1,
+                    corpus_shas=shas[:1],
+                ),
+                StudyFinding(
+                    lens="contention",
+                    axis="interrogation",
+                    kind="tensions",
+                    title="Publishers disagree about the latency threshold",
+                    finding_id="contention-1",
+                    grounded_anchor_count=1,
+                    corpus_shas=shas,
+                ),
+                StudyFinding(
+                    lens="mechanism",
+                    axis="interrogation",
+                    kind="concepts",
+                    title="Unrelated subject about billing reconciliation forms",
+                    finding_id="mechanism-1",
+                    grounded_anchor_count=1,
+                    corpus_shas=shas[1:],
+                ),
+            ],
+        )
+    ]
+    return result
+
+
+@pytest.fixture
+def brief():
+    b = ExpertBrief(expert_name="E", orientation="The field in sixty seconds.")
+    b.state = SettledState(
+        settled=["Clusters do reconcile eventually"],
+        live=["Where the latency threshold sits"],
+        unknown=["Behaviour above five hundred clusters"],
+    )
+    b.positions = [
+        Position(
+            question="Does reconciliation latency degrade with cluster count?",
+            stance="Yes, above roughly fifty clusters.",
+            reasoning="Measured deployments report it.",
+            would_change_my_mind="A deployment above fifty clusters showing flat latency.",
+            supported_by=["failure-1"],
+            likelihood="likely",
+            confidence="moderate",
+        ),
+        Position(
+            question="Is the billing reconciliation form still required?",
+            stance="No, superseded.",
+            reasoning="Different subject entirely.",
+            would_change_my_mind="A filing that still demands it.",
+            supported_by=["mechanism-1"],
+            likelihood="unlikely",
+            confidence="low",
+        ),
+    ]
+    return b
+
+
+class TestRanking:
+    def test_only_positions_the_question_touches_come_back(self, brief):
+        ranked = rank_positions("does latency degrade as clusters grow?", brief)
+        assert [p.stance for p in ranked] == ["Yes, above roughly fifty clusters."]
+
+    def test_an_unrelated_question_returns_nothing_rather_than_the_best_guess(self, brief):
+        """Backfilling by confidence is how a system answers what it cannot."""
+        assert rank_positions("what is the airspeed of a swallow?", brief) == []
+
+    def test_stopwords_do_not_manufacture_a_match(self, brief):
+        assert rank_positions("what is it that they should do with this?", brief) == []
+
+
+class TestSupportTravelsWithThePosition:
+    def test_a_ranked_position_pulls_its_own_findings(self, brief, study, corpus):
+        context = build_consult_context(
+            expert_name="E",
+            question="does latency degrade as clusters grow?",
+            brief=brief,
+            result=study,
+            corpus=corpus,
+        )
+        assert "failure-1" in {f.finding_id for f in context.findings}
+
+    def test_those_findings_bring_the_retained_passage(self, brief, study, corpus):
+        """A claim you cannot check is an assertion, whatever else is attached."""
+        context = build_consult_context(
+            expert_name="E",
+            question="does latency degrade as clusters grow?",
+            brief=brief,
+            result=study,
+            corpus=corpus,
+        )
+        assert context.sources
+        assert any("fifty clusters" in passage for _, _, passage in context.sources)
+
+    def test_the_expert_brings_far_more_than_the_old_budget(self, brief, study, corpus):
+        """The path this replaces capped its evidence at roughly four kilobytes."""
+        context = build_consult_context(
+            expert_name="E",
+            question="does reconciliation latency degrade as clusters grow?",
+            brief=brief,
+            result=study,
+            corpus=corpus,
+        )
+        assert context.evidence_chars() > 200
+
+
+class TestCoverage:
+    def test_a_matched_grounded_position_is_covered(self, brief, study, corpus):
+        context = build_consult_context(
+            expert_name="E",
+            question="does latency degrade as clusters grow?",
+            brief=brief,
+            result=study,
+            corpus=corpus,
+        )
+        assert context.coverage == "grounded"
+
+    def test_findings_without_a_position_are_partial_not_covered(self, study, corpus):
+        """No position formed, but material that bears on it. Say exactly that."""
+        context = build_consult_context(
+            expert_name="E",
+            question="what do publishers say about the threshold?",
+            brief=None,
+            result=study,
+            corpus=corpus,
+        )
+        assert context.coverage == "partial"
+
+    def test_nothing_at_all_is_uncovered(self, brief, study, corpus):
+        context = build_consult_context(
+            expert_name="E",
+            question="what is the airspeed of a swallow?",
+            brief=brief,
+            result=study,
+            corpus=corpus,
+        )
+        assert context.coverage == "uncovered"
+
+    def test_an_expert_never_briefed_still_assembles(self, study, corpus):
+        context = build_consult_context(expert_name="E", question="latency", brief=None, result=study, corpus=corpus)
+        assert context.orientation == ""
+        assert context.coverage in {"partial", "uncovered"}
+
+
+class TestStandingHeader:
+    def test_settled_comes_before_live(self, brief):
+        context = build_consult_context(
+            expert_name="E", question="latency clusters", brief=brief, result=None, corpus=None
+        )
+        header = render_standing_header(context)
+        assert header.index("Settled") < header.index("Genuinely live")
+
+    def test_the_header_survives_an_unrelated_question(self, brief):
+        """It is never retrieved, so a bad match must not drop it."""
+        context = build_consult_context(
+            expert_name="E", question="airspeed of a swallow", brief=brief, result=None, corpus=None
+        )
+        header = render_standing_header(context)
+        assert "Settled" in header
+        assert context.positions == []
+
+    def test_what_is_not_known_is_stated(self, brief):
+        context = build_consult_context(expert_name="E", question="latency", brief=brief, result=None, corpus=None)
+        assert "Behaviour above five hundred clusters" in render_standing_header(context)
+
+
+class TestBriefRoundTrip:
+    def test_a_persisted_brief_reloads_with_its_calibration(self, tmp_path, brief):
+        path = tmp_path / "brief.json"
+        path.write_text(json.dumps(brief.to_dict()), encoding="utf-8")
+
+        loaded = load_brief(path)
+
+        assert loaded is not None
+        assert loaded.positions[0].likelihood == "likely"
+        assert loaded.positions[0].would_change_my_mind
+        assert loaded.positions[0].supported_by == ["failure-1"]
+
+    def test_a_missing_brief_is_absence_not_an_error(self, tmp_path):
+        assert load_brief(tmp_path / "nope.json") is None
+
+    def test_a_corrupt_brief_is_absence_not_a_crash(self, tmp_path):
+        path = tmp_path / "brief.json"
+        path.write_text("{not json", encoding="utf-8")
+        assert load_brief(path) is None

--- a/tests/unit/test_experts/test_corpus_acquire.py
+++ b/tests/unit/test_experts/test_corpus_acquire.py
@@ -1,0 +1,127 @@
+"""Acquisition: the expert fetches for itself, and a refresh is not a new source.
+
+This module had no tests at all, which is how a refresh came to create a
+duplicate corpus entry every time. Nothing downstream could tell the difference
+between one page fetched seven times and seven independent sources, so every
+corroboration count inflated with the refresh cadence.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from deepr.experts.corpus_acquire import _as_source_text, acquire_sources
+from deepr.experts.corpus_store import CorpusStore, content_hash
+
+
+_BODY = "Retained pages must clear the nav-shell guard, so fixture bodies are realistic rather than a few words. " * 4
+
+
+def _page(text=_BODY, title="A Title"):
+    """A fetched page. Bodies must exceed the minimum-useful-length guard."""
+    return SimpleNamespace(text=text, title=title, status_code=200)
+
+
+def _fetcher(pages):
+    """Serve canned pages by URL, recording what was asked for."""
+    calls = []
+
+    async def fetch(url):
+        calls.append(url)
+        page = pages.get(url)
+        if isinstance(page, Exception):
+            raise page
+        return page
+
+    fetch.calls = calls
+    return fetch
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CorpusStore("Acquire Expert", storage_dir=tmp_path / "corpus")
+
+
+class TestSourceIdentity:
+    def test_retained_text_is_stable_across_fetches(self):
+        """Nothing that varies between two fetches may enter the hashed body."""
+        first = _as_source_text(_page(), "https://ex.com/a")
+        second = _as_source_text(_page(), "https://ex.com/a")
+        assert content_hash(first) == content_hash(second)
+
+    def test_the_retrieval_date_is_not_part_of_the_content(self):
+        """A date in the body made every refresh a brand new source."""
+        text = _as_source_text(_page(), "https://ex.com/a")
+        assert "fetched_at" not in text
+
+    def test_different_bodies_stay_different_sources(self):
+        a = _as_source_text(_page(_BODY + " one"), "https://ex.com/a")
+        b = _as_source_text(_page(_BODY + " two"), "https://ex.com/a")
+        assert content_hash(a) != content_hash(b)
+
+
+class TestRefresh:
+    @pytest.mark.asyncio
+    async def test_refetching_an_unchanged_page_adds_no_source(self, store):
+        pages = {"https://ex.com/a": _page()}
+
+        await acquire_sources(expert_name="E", urls=list(pages), corpus=store, fetch_page=_fetcher(pages))
+        after_first = len(store.active_entries())
+        result = await acquire_sources(expert_name="E", urls=list(pages), corpus=store, fetch_page=_fetcher(pages))
+
+        assert after_first == 1
+        assert len(store.active_entries()) == 1
+        assert result.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_a_changed_page_is_retained_as_a_new_revision(self, store):
+        url = "https://ex.com/a"
+        await acquire_sources(
+            expert_name="E", urls=[url], corpus=store, fetch_page=_fetcher({url: _page(_BODY + " first revision")})
+        )
+        await acquire_sources(
+            expert_name="E", urls=[url], corpus=store, fetch_page=_fetcher({url: _page(_BODY + " second revision")})
+        )
+
+        assert len(store.entries) == 2
+
+    @pytest.mark.asyncio
+    async def test_one_origin_for_every_page_from_a_publisher(self, store):
+        """Counting each page as its own origin would read as broad corroboration."""
+        pages = {
+            "https://ex.com/a": _page(_BODY + " page a"),
+            "https://ex.com/b": _page(_BODY + " page b"),
+        }
+        await acquire_sources(expert_name="E", urls=list(pages), corpus=store, fetch_page=_fetcher(pages))
+
+        assert len(store.active_entries()) == 2
+        assert len(store.distinct_origins()) == 1
+
+
+class TestFailureIsolation:
+    @pytest.mark.asyncio
+    async def test_one_failed_url_does_not_abort_the_others(self, store):
+        pages = {
+            "https://ex.com/good": _page(),
+            "https://ex.com/bad": RuntimeError("connection reset"),
+        }
+        result = await acquire_sources(expert_name="E", urls=list(pages), corpus=store, fetch_page=_fetcher(pages))
+
+        assert len(store.active_entries()) == 1
+        assert result.exit_code != 0
+
+    @pytest.mark.asyncio
+    async def test_every_url_failing_is_reported_as_such(self, store):
+        pages = {"https://ex.com/bad": RuntimeError("connection reset")}
+        result = await acquire_sources(expert_name="E", urls=list(pages), corpus=store, fetch_page=_fetcher(pages))
+
+        assert not store.active_entries()
+        assert result.exit_code == 2
+
+    @pytest.mark.asyncio
+    async def test_a_repeated_url_is_fetched_once(self, store):
+        url = "https://ex.com/a"
+        fetch = _fetcher({url: _page()})
+        await acquire_sources(expert_name="E", urls=[url, url, url], corpus=store, fetch_page=fetch)
+
+        assert fetch.calls == [url]

--- a/tests/unit/test_experts/test_corpus_independence.py
+++ b/tests/unit/test_experts/test_corpus_independence.py
@@ -1,0 +1,120 @@
+"""Counting a corpus by origin rather than by document.
+
+The run that motivated this scored three retained sources, forty anchored
+findings, and zero warnings that mattered. All three sources were Wikipedia
+pages. One number would have said so before any of it was spent.
+"""
+
+import pytest
+
+from deepr.experts.corpus_independence import measure_independence
+from deepr.experts.corpus_store import CorpusStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CorpusStore("Independence Expert", storage_dir=tmp_path / "corpus")
+
+
+def _entries(store, spec):
+    """spec: list of (body, origin_key, trust_class)."""
+    for body, origin, trust in spec:
+        store.add(body, origin_key=origin, trust_class=trust)
+    return store.active_entries()
+
+
+class TestEffectiveSourceCount:
+    def test_one_publisher_many_pages_counts_as_one(self, store):
+        """The exact shape of the run this was written for."""
+        entries = _entries(
+            store,
+            [
+                ("first body", "url:en.wikipedia.org", "tertiary"),
+                ("second body", "url:en.wikipedia.org", "tertiary"),
+                ("third body", "url:en.wikipedia.org", "tertiary"),
+            ],
+        )
+        report = measure_independence(entries)
+
+        assert report.source_count == 3
+        assert report.effective_source_count == 1.0
+        assert report.is_thin
+
+    def test_distinct_publishers_count_separately(self, store):
+        entries = _entries(
+            store,
+            [
+                ("first body", "url:a.org", "primary"),
+                ("second body", "url:b.org", "primary"),
+                ("third body", "url:c.org", "primary"),
+            ],
+        )
+        report = measure_independence(entries)
+
+        assert report.effective_source_count == pytest.approx(3.0, abs=0.01)
+        assert not report.is_thin
+
+    def test_a_lopsided_corpus_scores_below_its_publisher_count(self, store):
+        """Nine pages from one site plus one from another is not two sources."""
+        spec = [(f"body {i}", "url:big.org", "secondary") for i in range(9)]
+        spec.append(("lone body", "url:small.org", "secondary"))
+        report = measure_independence(_entries(store, spec))
+
+        assert report.origin_count == 2
+        assert report.effective_source_count < 1.6
+        assert report.is_thin
+
+    def test_superseded_revisions_do_not_inflate_the_count(self, store):
+        """The same source at an earlier moment is not a second source."""
+        first, _ = store.add("original body", origin_key="url:a.org")
+        second, _ = store.add("revised body", origin_key="url:a.org")
+        store.supersede(first.sha256, second.sha256)
+        store.add("other publisher body", origin_key="url:b.org")
+
+        report = measure_independence(store.active_entries())
+
+        assert report.source_count == 2
+        assert report.effective_source_count == pytest.approx(2.0, abs=0.01)
+
+    def test_an_empty_corpus_reports_rather_than_divides_by_zero(self):
+        report = measure_independence([])
+        assert report.source_count == 0
+        assert report.concerns() == ["Corpus is empty."]
+
+
+class TestConcerns:
+    def test_a_single_origin_corpus_says_agreement_is_not_corroboration(self, store):
+        entries = _entries(
+            store,
+            [("a body", "url:one.org", "secondary"), ("b body", "url:one.org", "secondary")],
+        )
+        assert any("agreeing with itself" in c for c in measure_independence(entries).concerns())
+
+    def test_a_dominant_publisher_is_named(self, store):
+        spec = [(f"body {i}", "url:big.org", "secondary") for i in range(8)]
+        spec += [("x body", "url:b.org", "secondary"), ("y body", "url:c.org", "secondary")]
+        concerns = measure_independence(_entries(store, spec)).concerns()
+
+        assert any("url:big.org" in c and "sets what can be concluded" in c for c in concerns)
+
+    def test_an_all_tertiary_corpus_is_flagged(self, store):
+        entries = _entries(
+            store,
+            [
+                ("a body", "url:a.org", "tertiary"),
+                ("b body", "url:b.org", "tertiary"),
+                ("c body", "url:c.org", "tertiary"),
+            ],
+        )
+        assert any("tertiary" in c for c in measure_independence(entries).concerns())
+
+    def test_a_genuinely_diverse_corpus_raises_nothing(self, store):
+        entries = _entries(
+            store,
+            [
+                ("a body", "url:a.org", "primary"),
+                ("b body", "url:b.org", "primary"),
+                ("c body", "url:c.org", "secondary"),
+            ],
+        )
+        assert measure_independence(entries).concerns() == []

--- a/tests/unit/test_experts/test_corpus_store.py
+++ b/tests/unit/test_experts/test_corpus_store.py
@@ -124,14 +124,44 @@ class TestStudyMaterial:
         shas = [e.sha256 for e, _ in store.load_study_material()]
         assert shas == [new.sha256]
 
-    def test_budget_never_truncates_a_source(self, store):
-        """A lens reading half a document reports absences caused by the cut."""
+    def test_budget_is_a_hard_ceiling(self, store):
+        """One oversized source must not silently blow the budget.
+
+        Refusing to split returned 81k against a 45k budget, and the oversized
+        prompt made models abandon their output contract and write prose.
+        """
         store.add("x" * 500, origin_key="url:a.org")
         store.add("y" * 500, origin_key="url:b.org")
         material = store.load_study_material(max_chars=600)
-        assert len(material) == 1
-        assert len(material[0][1]) == 500
+        assert sum(len(text) for _, text in material) <= 600
 
-    def test_budget_always_returns_at_least_one_source(self, store):
+    def test_a_single_oversized_source_is_cut_to_the_budget(self, store):
         store.add("z" * 5000, origin_key="url:a.org")
-        assert len(store.load_study_material(max_chars=10)) == 1
+        material = store.load_study_material(max_chars=1000)
+        assert len(material) == 1
+        assert len(material[0][1]) == 1000
+
+
+class TestStudyChunks:
+    def test_a_large_source_splits_into_several_chunks(self, store):
+        store.add("q" * 45000, origin_key="url:a.org")
+        chunks = store.iter_study_chunks(chunk_chars=14000)
+        assert len(chunks) == 4
+        assert all(len(text) <= 14000 for chunk in chunks for _, text in chunk)
+
+    def test_chunks_never_span_two_sources(self, store):
+        """Every chunk carries one source's provenance, so anchors resolve."""
+        store.add("a" * 20000, origin_key="url:a.org")
+        store.add("b" * 20000, origin_key="url:b.org")
+        chunks = store.iter_study_chunks(chunk_chars=14000)
+        assert all(len(chunk) == 1 for chunk in chunks)
+
+    def test_small_corpus_is_one_chunk_per_source(self, store):
+        store.add("short one", origin_key="url:a.org")
+        store.add("short two", origin_key="url:b.org")
+        assert len(store.iter_study_chunks(chunk_chars=14000)) == 2
+
+    def test_chunking_respects_the_overall_budget(self, store):
+        store.add("m" * 40000, origin_key="url:a.org")
+        chunks = store.iter_study_chunks(chunk_chars=10000, max_chars=20000)
+        assert sum(len(text) for chunk in chunks for _, text in chunk) <= 20000

--- a/tests/unit/test_experts/test_corpus_store.py
+++ b/tests/unit/test_experts/test_corpus_store.py
@@ -149,17 +149,42 @@ class TestStudyChunks:
         assert len(chunks) == 4
         assert all(len(text) <= 14000 for chunk in chunks for _, text in chunk)
 
-    def test_chunks_never_span_two_sources(self, store):
-        """Every chunk carries one source's provenance, so anchors resolve."""
+    def test_an_oversized_source_is_split_alone(self, store):
+        """A source too big to share a slice keeps its own provenance."""
         store.add("a" * 20000, origin_key="url:a.org")
         store.add("b" * 20000, origin_key="url:b.org")
         chunks = store.iter_study_chunks(chunk_chars=14000)
         assert all(len(chunk) == 1 for chunk in chunks)
 
-    def test_small_corpus_is_one_chunk_per_source(self, store):
+    def test_sources_share_a_chunk_when_the_budget_allows(self, store):
+        """A lens shown one source at a time cannot compare sources.
+
+        Packing is what makes cross-source contention possible at all: with a
+        slice per source, disagreement between publishers is not merely rare,
+        it cannot be found.
+        """
         store.add("short one", origin_key="url:a.org")
         store.add("short two", origin_key="url:b.org")
-        assert len(store.iter_study_chunks(chunk_chars=14000)) == 2
+        chunks = store.iter_study_chunks(chunk_chars=14000)
+        assert len(chunks) == 1
+        assert {entry.origin_key for entry, _ in chunks[0]} == {"url:a.org", "url:b.org"}
+
+    def test_packing_stops_at_the_budget(self, store):
+        store.add("a" * 6000, origin_key="url:a.org")
+        store.add("b" * 6000, origin_key="url:b.org")
+        store.add("c" * 6000, origin_key="url:c.org")
+        chunks = store.iter_study_chunks(chunk_chars=10000)
+        assert len(chunks) == 3
+        assert all(sum(len(t) for _, t in chunk) <= 10000 for chunk in chunks)
+
+    def test_every_retained_char_survives_chunking(self, store):
+        """An off-by-one that dropped or duplicated text would pass a count check."""
+        store.add("a" * 25000, origin_key="url:a.org")
+        store.add("b" * 3000, origin_key="url:b.org")
+        chunks = store.iter_study_chunks(chunk_chars=10000)
+        rebuilt = "".join(text for chunk in chunks for _, text in chunk)
+        assert rebuilt.count("a") == 25000
+        assert rebuilt.count("b") == 3000
 
     def test_chunking_respects_the_overall_budget(self, store):
         store.add("m" * 40000, origin_key="url:a.org")

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -285,7 +285,26 @@ class TestRunStudy:
             completion=_completion_returning({"fail_patterns": []}),
             lens_keys=["failure"],
         )
-        assert any("single origin" in limit for limit in result.limitations)
+        assert result.independence.effective_source_count == 1.0
+        assert any("agreeing with itself" in limit for limit in result.limitations)
+
+    @pytest.mark.asyncio
+    async def test_many_pages_from_one_publisher_still_count_as_one(self, tmp_path):
+        """The shape of the run this check was written for: 3 pages, 1 publisher."""
+        store = CorpusStore("One Publisher", storage_dir=tmp_path / "corpus")
+        for n in range(3):
+            store.add(f"Page {n} body text retained for study.", origin_key="url:en.wikipedia.org")
+
+        result = await run_study(
+            expert_name="E",
+            corpus=store,
+            completion=_completion_returning({"fail_patterns": []}),
+            lens_keys=["failure"],
+        )
+
+        assert result.independence.source_count == 3
+        assert result.independence.effective_source_count == 1.0
+        assert result.independence.is_thin
 
     @pytest.mark.asyncio
     async def test_ungrounded_anchors_surface_as_a_limitation(self, corpus):

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -152,7 +152,9 @@ class TestRunStudy:
         )
         assert result.exit_code == 1
         assert "adversarial" in result.failed_lenses
-        assert len(result.findings) == 1
+        # One finding per chunk: the corpus has two sources, so the working
+        # lens runs twice and its findings merge.
+        assert len(result.findings) == len(corpus.iter_study_chunks(chunk_chars=14000))
 
     @pytest.mark.asyncio
     async def test_all_lenses_failing_is_exit_two(self, corpus):

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -171,6 +171,42 @@ class TestFindingTitles:
         assert build_findings(LENSES["contention"], parsed, material)[0].title == "contention finding"
 
 
+class TestProvenanceHonesty:
+    """The numbers that make a brief look corroborated must not be fiction."""
+
+    def test_a_finding_is_credited_only_to_the_source_the_lens_read(self, tmp_path):
+        """Grounding used to run against the whole corpus, not the chunk shown.
+
+        Shared boilerplate is ubiquitous in web-acquired text, so an anchor
+        would resolve to whichever source sorted first among those containing
+        it. Findings were credited to documents the lens never saw, and the
+        coverage report then called the real source untouched.
+        """
+        shared = "This material is provided without warranty of any kind whatsoever."
+        store = CorpusStore("Provenance Expert", storage_dir=tmp_path / "corpus")
+        store.add(f"Alpha document. {shared}", origin_key="url:aaa.example")
+        store.add(f"Zulu document. {shared}", origin_key="url:zzz.example")
+
+        material = store.load_study_material()
+        zulu = [(entry, text) for entry, text in material if "Zulu" in text]
+        assert zulu, "fixture must contain the Zulu source"
+
+        parsed = {"fail_patterns": [{"name": "shared boilerplate", "anchors": [shared]}]}
+        findings = build_findings(LENSES["failure"], parsed, zulu)
+
+        assert findings[0].corpus_shas == [zulu[0][0].sha256]
+
+    def test_findings_get_unique_ids_across_chunks(self, corpus):
+        parsed = {"fail_patterns": [{"name": "a", "anchors": ["x"]}, {"name": "b", "anchors": ["y"]}]}
+        material = corpus.load_study_material()
+        first = build_findings(LENSES["failure"], parsed, material, start_index=1)
+        second = build_findings(LENSES["failure"], parsed, material, start_index=len(first) + 1)
+
+        ids = [f.finding_id for f in first + second]
+        assert ids == ["failure-1", "failure-2", "failure-3", "failure-4"]
+        assert len(set(ids)) == len(ids)
+
+
 class TestPrompt:
     def test_prompt_carries_lens_and_corpus_and_demands_anchors(self, corpus):
         material = corpus.load_study_material()

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -110,6 +110,67 @@ class TestAnchoring:
         assert len(findings) == 1
 
 
+class TestFindingTitles:
+    """Titles are how the brief cites findings, so a useless title is a broken citation."""
+
+    def test_a_lens_naming_its_subject_gets_that_name(self, corpus):
+        material = corpus.load_study_material()
+        parsed = {"fail_patterns": [{"name": "slot mismatch", "anchors": ["The reconciler applies desired state"]}]}
+        assert build_findings(LENSES["failure"], parsed, material)[0].title == "slot mismatch"
+
+    def test_a_tension_is_titled_from_its_description(self, corpus):
+        """The contention lens returns description/source/type, and none of them is 'name'."""
+        material = corpus.load_study_material()
+        parsed = {
+            "tensions": [
+                {
+                    "description": "Sources disagree on whether the export is a backup",
+                    "type": "disputed",
+                    "anchors": ["Operators frequently assume the export is a complete backup"],
+                }
+            ]
+        }
+        title = build_findings(LENSES["contention"], parsed, material)[0].title
+        assert title == "Sources disagree on whether the export is a backup"
+
+    def test_a_source_hash_is_never_used_as_a_title(self, corpus):
+        """Observed live: 40 findings all titled with the same corpus hash.
+
+        Every citation then matched every finding, so citation checking in the
+        brief silently stopped meaning anything.
+        """
+        material = corpus.load_study_material()
+        sha = material[0][0].sha256
+        parsed = {
+            "tensions": [
+                {
+                    "source": sha,
+                    "description": "Sources disagree on backup semantics",
+                    "anchors": ["Operators frequently assume the export is a complete backup"],
+                }
+            ]
+        }
+        title = build_findings(LENSES["contention"], parsed, material)[0].title
+        assert title == "Sources disagree on backup semantics"
+
+    def test_a_truncated_source_hash_is_also_rejected(self, corpus):
+        material = corpus.load_study_material()
+        parsed = {
+            "tensions": [
+                {
+                    "name": material[0][0].sha256[:12],
+                    "anchors": ["Operators frequently assume the export is a complete backup"],
+                }
+            ]
+        }
+        assert build_findings(LENSES["contention"], parsed, material)[0].title == "contention finding"
+
+    def test_a_finding_that_names_nothing_falls_back_to_the_lens(self, corpus):
+        material = corpus.load_study_material()
+        parsed = {"tensions": [{"anchors": ["The reconciler applies desired state"]}]}
+        assert build_findings(LENSES["contention"], parsed, material)[0].title == "contention finding"
+
+
 class TestPrompt:
     def test_prompt_carries_lens_and_corpus_and_demands_anchors(self, corpus):
         material = corpus.load_study_material()

--- a/tests/unit/test_experts/test_study_coverage.py
+++ b/tests/unit/test_experts/test_study_coverage.py
@@ -56,7 +56,8 @@ class TestCoverage:
         """Never read is a different failure from read and not cited."""
         store.add("x" * 400, origin_key="url:a.org")
         store.add("y" * 400, origin_key="url:b.org")
-        studied = store.load_study_material(max_chars=500)
+        # Budget admits the first source only; the second is never seen.
+        studied = store.load_study_material(max_chars=400)
         assert len(studied) == 1
 
         report = build_coverage_report(

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "deepr-research"
-version = "2.43.1"
+version = "2.44.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -892,6 +892,7 @@ dependencies = [
     { name = "colorama" },
     { name = "filelock" },
     { name = "google-genai" },
+    { name = "h2" },
     { name = "httpx" },
     { name = "numpy" },
     { name = "openai" },
@@ -1002,6 +1003,7 @@ requires-dist = [
     { name = "flask-limiter", marker = "extra == 'web'", specifier = ">=3.5.0,<5.0.0" },
     { name = "flask-socketio", marker = "extra == 'web'", specifier = ">=5.3.0,<6.0.0" },
     { name = "google-genai", specifier = ">=1.75.0,<3.0.0" },
+    { name = "h2", specifier = ">=4.4.1,<5.0.0" },
     { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.163.0" },
     { name = "mistune", marker = "extra == 'web'", specifier = ">=3.3.0,<4.0.0" },
@@ -1401,15 +1403,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.4.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d4/a7d6fb3f58be99d65cbf2d3f766896217a2921d0f3ab10711c45dc1519ee/h2-4.4.0.tar.gz", hash = "sha256:46b551bdcdc7e83cf5c04d0bf93badb8a939bd2287d9fee1abb23a445b9e0580", size = 2156691, upload-time = "2026-07-23T19:14:19.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/df/5b14a118322d6097cb9bb30ec6bacad268e546a8ecfcb1f6d0de618dac2f/h2-4.4.0-py3-none-any.whl", hash = "sha256:6acffe1aeab79098d7eb0f8385c1add11f2c7a94815f6fa2b7060eeddee3d87c", size = 62368, upload-time = "2026-07-23T19:14:16.143Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Ollama loads a model that does not fit by silently placing the overflow on CPU. The run stays correct, stays `$0`, and becomes many times slower — which from outside is indistinguishable from a hang. Deepr's default was "the first model Ollama lists", which on a machine holding several large models routinely picks one that cannot fit.

`local_fit` sizes weights plus KV cache against available VRAM and picks the largest candidate expected to run entirely on GPU.

## Three things it gets right only because they were measured

| | Why it matters |
|---|---|
| **Free VRAM, not total** | ~8GB of this 24GB card was already held by the display and other processes, so every model loaded to ~16GB then spilled. Sizing against total predicts fits that never happen. |
| **Resident models are reclaimable** | Ollama evicts a loaded model to make room. Counting it as taken made free VRAM look tiny, every candidate look too big, and fell back to the *largest* model. Observed live: a prior run left a model resident, the next picked a 32B that ran half on CPU. |
| **KV cost per parameter varies by architecture** | Measured 8,300–20,500 bytes/token/B across three models, because KV scales with layers and GQA sharing, not parameter count. Takes the top of the range — over-estimating picks a smaller model that runs fast; under-estimating picks a larger one that silently falls to CPU. |

Empirical validation: predicted `qwen2.5:14b` fits at 16K and nothing else does; measurement confirmed exactly that (13.2G, 100% GPU; every larger model 16–51% CPU).

## Honest parse diagnostics

`"no JSON object in response"` is true and useless — it does not distinguish a model that answered in prose, one cut off mid-structure, and one that returned nothing. Those need different fixes.

Parse failures now quote what came back. This paid for itself immediately: it showed `qwen2.5:14b` abandoning the JSON contract and writing a prose summary on a real corpus, which no amount of budget tuning would have fixed. Output-limit truncation is now reported as truncation, and the local output budget is raised 4k → 16k.

## Measured limitation, stated rather than hidden

On this machine (RTX 4090, ~16.7GB free): **nothing installed fits fully in VRAM at the models' default 32K context**, and the one model that does fit at 16K is not strong enough to hold the output contract over a 20K-char corpus.

Plan quota remains the working path for study — `$0` at the margin, 56/56 findings anchored.

Also noted: Ollama's OpenAI-compatible endpoint ignores `num_ctx` in both top-level and `options`-nested form, so context cannot currently be constrained per-request through that path.

## Validation

| Gate | Result |
|---|---|
| `test_local_fit.py` | 16 passed |
| `test_study.py` | 22 passed |
| ruff check / format | pass |
| C901 / S ratchets | at baseline |
| file-size ratchet | pass |
| paid API boundary | pass |