### PR TITLE
feat: an expert that can source itself, be examined, and be triaged

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -379,25 +379,79 @@ so an expert that has existed for six months has read more than a new one but
 has not learned more. There is still no evaluation, so "better" remains an
 opinion: the one control-arm comparison run against a bare prompt was close on
 a well-known topic, and Deepr's demonstrated margin is checkability and
-specificity rather than knowledge. Consult refusals - the most precisely
-specified gaps the system produces, generated free by real questions - are not
-captured anywhere.
+specificity rather than knowledge.
 
-**Next, in dependency order:**
+**Who this is for, which the roadmap had left implicit.** The bottleneck when a
+team moves from running a few agents to running many is context - what the
+agents do not know and cannot be told again on every task. That is what an
+expert is, and it is reached through the MCP surface rather than the terminal.
+The consequence for prioritisation is stated in
+[where-deepr-sits.md](docs/design/where-deepr-sits.md): work that improves what
+a consult returns to an agent outranks work that improves what it prints to a
+human, traceability is a feature rather than hygiene because nobody reviewing
+six streams of output can check claims by hand, and a silently stale expert is
+worse than none for exactly the same reason.
 
-1. **Position survival.** Keep prior briefs instead of overwriting; diff
-   positions on rebuild; record how many corpus changes a position has
-   survived and whether its falsifier has been observed. This is what turns
-   elapsed time into evidence, and every part needed already exists.
-2. **Evaluation with control arms.** A base model with no corpus and a placebo
-   expert on an unrelated corpus, with context recorded alongside every
-   outcome from the start. Retrofitting context is how a measurement system
-   ends up confidently wrong.
-3. **Consultation traces become the reading queue.** A refusal is a specified
-   gap; it should decide what the expert reads next.
-4. **Nothing derived is destroyed on rebuild.** `supersede` rather than
-   overwrite for cards, briefs and positions - the discipline the corpus
-   already has and nothing above it does.
+**Since then**, the loop grew the parts that make it inspectable rather than
+merely runnable: an evidence graph joining claims to passages, a perspective
+graph recording what moved a standpoint, a research practice holding live
+questions and earned sources, a viva that examines an expert and returns a
+costed reading list, and `expert status`, which distinguishes a stage that
+*produced a file* from one that *produced a result*. Capacity now spreads
+across prepaid plans and retires one that runs out mid-run.
+
+Several of those existed already and were wired to nothing. Six modules this
+round were found built, tested and unreachable, which is a pattern worth
+naming: a module with tests is not a shipped feature.
+
+**Next, in dependency order.** Order is the claim here; nothing below is a
+calendar, and the sequence is derived from what blocks what rather than from
+what looks appetising.
+
+1. **Durable identity for positions, end to end.** `position_thread_id` now
+   backs the evidence graph and nothing else. Until a position keeps its
+   identity across a re-brief, no falsifier can be tracked, no history can be
+   kept, and no revision can be told apart from a replacement. Everything
+   below depends on this.
+2. **Stop destroying judgement on rebuild.** Append-only findings and
+   positions with a derived current view, `supersede` rather than overwrite,
+   and a reason required on every supersession. Writes are atomic now; what
+   they write is still a wholesale replacement. This is also the single gate
+   holding `brief` and `profile` out of unattended operation, per
+   [autonomy-boundary.md](docs/design/autonomy-boundary.md).
+3. **Freeze falsifiers as predictions.** A resolution criterion and a
+   resolution date, immutable once written. This starts a clock that cannot be
+   started retroactively, so it is worth doing before the mechanism that reads
+   it exists.
+4. **Resolve them against later material, and record the discrepancy only.**
+   The signal is the gap between an ex ante position and a later grounded
+   outcome; see [the-feedback-signal.md](docs/design/the-feedback-signal.md).
+   Deliberately no controller in the first pass - adjusting confidence against
+   an unvalidated signal is how a system optimises the wrong thing quietly.
+5. **A point-in-time read.** `history_of(thread)` first, then `as_of(t)`, with
+   `current()` as the zero-argument default. Blocked on a real bug:
+   `get_current_confidence` decays against wall-clock, so a historical read
+   would return a past record carrying today's confidence.
+6. **Then, and only then, unattended operation** for the stages that already
+   pass the reversibility test - `source`, `study`, `graph`, `viva` - with a
+   quota preflight rather than a schedule. Two runs died mid-flight on quota
+   exhaustion in a single session; a loop that does not model remaining
+   capacity fails inside the most expensive step.
+
+**Refinements worth doing alongside, none of them blocking:**
+
+- **`stage_contract` enforced at the stage, not only in `expert status`.** It
+  reports correctly and does not yet gate anything.
+- **Consult failover.** `--plan a,b,c` fails over mid-call for study and brief,
+  and only picks a plan with headroom for consult, because a consult builds a
+  chat client rather than a completion callable.
+- **antigravity cannot launch on Windows** despite the fleet reporting it
+  installed and active, which silently costs a whole quota pool.
+- **One time module.** 64 duplicated `_utc_now()` definitions and four
+  hand-rolled UTC coercions guarantee closed-open intervals get implemented
+  three ways.
+- **The 38 D-grade experts.** Real belief stores with no retained corpus.
+  They are not consultable and will not become so by accident.
 
 Design: [docs/design/skills-as-learning-systems.md](docs/design/skills-as-learning-systems.md)
 evaluates the wider "skills as bi-temporal learning systems" frame, maps what

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -408,18 +408,25 @@ naming: a module with tests is not a shipped feature.
 calendar, and the sequence is derived from what blocks what rather than from
 what looks appetising.
 
-1. **Durable identity for positions, end to end.** `position_thread_id` now
-   backs the evidence graph and nothing else. Until a position keeps its
-   identity across a re-brief, no falsifier can be tracked, no history can be
-   kept, and no revision can be told apart from a replacement. Everything
-   below depends on this.
-2. **Stop destroying judgement on rebuild.** Append-only findings and
-   positions with a derived current view, `supersede` rather than overwrite,
-   and a reason required on every supersession. Writes are atomic now; what
-   they write is still a wholesale replacement. This is also the single gate
-   holding `brief` and `profile` out of unattended operation, per
-   [autonomy-boundary.md](docs/design/autonomy-boundary.md).
-3. **Freeze falsifiers as predictions.** A resolution criterion and a
+1. ~~**Durable identity for positions.**~~ **Done.** A position is keyed on its
+   question and keeps that identity across a re-brief.
+2. ~~**Stop destroying judgement on rebuild.**~~ **Done for positions.**
+   `positions.json` is an append-only ledger; `brief.json` remains the derived
+   current view. A revision closes its predecessor and opens a successor; a
+   position a re-brief did not reach is closed as *not restated* rather than
+   retired, because the expert did not decide to drop it.
+
+   Running it twice was what made it real. The same corpus briefed twice
+   produced seven differently-worded questions and restated none of the nine
+   already held, because `build_brief` took no prior and a model with no memory
+   legitimately rephrases. Showing the brief what it already holds took that
+   from *0 revised, 9 not restated* to *7 revised, 0 not restated*.
+
+   **Findings are still rebuilt wholesale.** Positions were the urgent half -
+   they carry the falsifiers - but a finding ledger is the same shape and is
+   what `study` needs before it can run unattended.
+3. **Freeze falsifiers as predictions.** Now unblocked, and next.
+   [Why](docs/design/the-feedback-signal.md) A resolution criterion and a
    resolution date, immutable once written. This starts a clock that cannot be
    started retroactively, so it is worth doing before the mechanism that reads
    it exists.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -411,7 +411,7 @@ what looks appetising.
 1. ~~**Durable identity for positions.**~~ **Done.** A position is keyed on its
    question and keeps that identity across a re-brief.
 2. ~~**Stop destroying judgement on rebuild.**~~ **Done for positions.**
-   `positions.json` is an append-only ledger; `brief.json` remains the derived
+   `hold/history.json` is an append-only ledger; `hold/current.json` remains the derived
    current view. A revision closes its predecessor and opens a successor; a
    position a re-brief did not reach is closed as *not restated* rather than
    retired, because the expert did not decide to drop it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -364,7 +364,47 @@ reliable product, not a four-language architecture diagram.
 
 ---
 
-## Current Status (v2.43.1)
+## Current Status (v2.45.0)
+
+**Shipped in v2.45.0 (see docs/CHANGELOG.md):** the v2 expert stack is now
+reachable from `consult`, an expert can source its own corpus, and several
+measurements that were quietly false have been corrected. Corpus independence
+is reported as effective origin count rather than document count; a
+hand-assembled three-page corpus scores 1.0 against a nominal 3, while an
+expert-sourced one reaches 18.5.
+
+**Where the honest gaps are.** The corpus accumulates; the understanding does
+not. Every `study` recomputes findings and every `brief` overwrites the last,
+so an expert that has existed for six months has read more than a new one but
+has not learned more. There is still no evaluation, so "better" remains an
+opinion: the one control-arm comparison run against a bare prompt was close on
+a well-known topic, and Deepr's demonstrated margin is checkability and
+specificity rather than knowledge. Consult refusals - the most precisely
+specified gaps the system produces, generated free by real questions - are not
+captured anywhere.
+
+**Next, in dependency order:**
+
+1. **Position survival.** Keep prior briefs instead of overwriting; diff
+   positions on rebuild; record how many corpus changes a position has
+   survived and whether its falsifier has been observed. This is what turns
+   elapsed time into evidence, and every part needed already exists.
+2. **Evaluation with control arms.** A base model with no corpus and a placebo
+   expert on an unrelated corpus, with context recorded alongside every
+   outcome from the start. Retrofitting context is how a measurement system
+   ends up confidently wrong.
+3. **Consultation traces become the reading queue.** A refusal is a specified
+   gap; it should decide what the expert reads next.
+4. **Nothing derived is destroyed on rebuild.** `supersede` rather than
+   overwrite for cards, briefs and positions - the discipline the corpus
+   already has and nothing above it does.
+
+Design: [docs/design/skills-as-learning-systems.md](docs/design/skills-as-learning-systems.md)
+evaluates the wider "skills as bi-temporal learning systems" frame, maps what
+Deepr already has against it, and is explicit about which parts are premature
+and why.
+
+## Superseded Status (v2.43.1)
 
 **Unreleased host-wiring polish (from live Claude Code validation):** coding
 hosts often fail because MCP tools never loaded (empty `mcpServers`, mid-session

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Expert directories are named from the expert's point of view**
+  (`deepr.experts.expert_layout`, `deepr.experts.expert_migration`,
+  `deepr expert migrate`). `study.json`, `brief.json`, `positions.json`,
+  `profile_card.json`, `practice.json` and `viva.json` were named after the
+  commands that wrote them, so a directory listing said which processes had run
+  rather than what the expert was. Two were worse than process-named:
+  `brief.json` and `positions.json` were the same subject stored twice with no
+  indication of which was current, and `profile.json` and `profile_card.json`
+  were different things sharing a word. Now `self.json`, `noticed/`,
+  `hold/current.json` and `hold/history.json`, `became/`, `attend/`, `met/`.
+  `corpus/` keeps its name, being already named from the expert's side.
+
+  Reads resolve the old path when only the old one exists, so the fleet
+  migrated without a flag day. Verified by computing health for all 57 experts
+  from a pre-migration backup and from the migrated fleet: **0 of 57 differ**,
+  with identical fleet totals (70 positions, 499 findings, 147 sources).
+
+  `beliefs/` and `knowledge/` were on the list of dead v1 directories until a
+  dry run over the real fleet found content in 38 and 35 experts respectively -
+  about 4MB of live belief ledgers, event logs and digests. They are untouched.
+  The migration reports a non-empty directory instead of deleting it, which is
+  the only reason that was caught.
+
+### Added
+
+- **Experts choose how they are depicted** (`appearance` in `self.json`). The
+  portrait prompt described the subject an expert studies, with a hash-seeded
+  demographic rotation for variety, so two experts on one domain with opposite
+  standpoints rendered nearly identically - backwards for the thing a portrait
+  is for. An expert that chooses its own name now chooses its own face, and the
+  old prompt remains the fallback for an expert with no self-account.
+
 ## [2.45.0] - 2026-08-07
 
 Experts stop reporting numbers that are not true. The v2 stack from 2.44.0 was

--- a/docs/design/autonomy-boundary.md
+++ b/docs/design/autonomy-boundary.md
@@ -1,0 +1,116 @@
+# Where the autonomy boundary sits, and what moves it
+
+Status: proposed, 2026-08-10. Derived from consulting Deepr's own harness
+expert about Deepr's own loop, then applying its test to each step.
+
+## The test
+
+Asked where an unattended expert should be allowed to act, the Agentic Harness
+Design expert gave a four-part rule:
+
+> Autonomy should expand only where actions are **observable, reversible,
+> sandboxed, and independently verifiable**.
+
+That is better than the usual "automate the safe bits" because each part is
+checkable against a specific step rather than argued about. It also produces an
+uncomfortable and useful result: the step that most needs to be autonomous is
+the one that currently fails the test.
+
+Two further constraints from the same consult, both load-bearing:
+
+> Generation and evaluation should be separated. An expert should not validate
+> its own revisions solely through self-assessment.
+
+> There is unresolved tension between frequent autonomous revision and
+> epistemic stability. Rapid updating incorporates new evidence sooner, but can
+> also amplify noise, source manipulation, or evaluator drift.
+
+**Source manipulation is the one worth pausing on.** An expert that searches
+the open web unattended, on questions it publishes in its own practice file,
+can be fed material by anyone who reads that file. Nothing in the current
+design defends against it. That is a reason to keep acquisition observable
+rather than a reason to keep it manual.
+
+## Applying it, step by step
+
+| Step | Observable | Reversible | Sandboxed | Verifiable | Verdict |
+|---|---|---|---|---|---|
+| `source` | yes | yes | yes | yes | **autonomous** |
+| `study` | yes | yes | yes | yes | **autonomous** |
+| `graph` | yes | yes | yes | yes | **autonomous** |
+| `practice` | yes | yes | yes | partly | **autonomous, bounded** |
+| `viva` | yes | yes | yes | yes | **autonomous, budgeted** |
+| `profile` | yes | partly | yes | no | **gated** |
+| `brief` | yes | **no** | yes | partly | **gated** |
+
+### Why `source` passes
+
+Observable: every URL and every retention is logged. Reversible: the corpus is
+content-addressed and append-only, so a bad acquisition is superseded rather
+than destructive. Sandboxed: it fetches and writes files, and touches nothing
+else. Verifiable: content-addressing plus mechanical anchor checking means a
+later stage can prove what was actually read.
+
+The residual risk is the manipulation one, and it is answerable without a
+human in the loop for every fetch: log the queries, cap new publishers per
+run, and flag a run where the corpus concentration moved sharply.
+
+### Why `study` passes
+
+It is the most expensive step and the most obviously autonomous. It reads a
+frozen corpus, writes findings, checkpoints after every lens, and its output is
+verifiable by a check the system already performs - whether a quoted anchor
+appears in retained text. Nothing about it is destructive: findings are
+regenerable from the corpus by construction.
+
+### Why `brief` fails, and what that means
+
+`brief` is not reversible. Every run discards the previous positions - their
+likelihood bands, their falsifiers, the dissent they carried - and re-derives
+from scratch. There is no prior kept and no history, so a bad autonomous
+re-brief silently destroys the best judgement the expert had, with nothing to
+roll back to.
+
+It is also only partly verifiable. Citations are checked against the finding id
+set, which catches an invented id and not a wrong one.
+
+**So the autonomy roadmap is blocked on the identity-and-time work, and now
+there is a reason rather than an assumption.** Once positions have thread
+identity and an append-only history, a re-brief becomes a revision rather than
+a replacement - it stops being destructive, and it passes the reversibility
+test. The order was already right; this is why.
+
+### Why `profile` is gated for now
+
+Its shift history is append-only and safe. Its *standpoint* is overwritten, and
+the standpoint is what a consult speaks from. Same fix as `brief`: once a
+standpoint version is a record rather than a field, the overwrite becomes a
+revision.
+
+## What this changes about the plan
+
+1. **Nothing new is needed for `source`, `study`, `graph` and `viva` to run
+   unattended** beyond a scheduler and a budget. They already pass.
+2. **`brief` and `profile` stay manual until V2 identity lands.** Not for
+   safety theatre - because an autonomous run of either destroys judgement with
+   no way back.
+3. **Separation of generation and evaluation is already partly built.** `viva`
+   examines with a different standpoint than the one under examination, which
+   is the separation the expert asked for. It should be what gates an
+   autonomous revision, rather than the reviser assessing itself.
+4. **Budget before schedule.** Quota exhaustion is not hypothetical: two runs
+   died on it in one afternoon, one mid-brief and one mid-consult. An
+   unattended loop that does not model remaining quota will fail in the middle
+   of the most expensive step and leave the expert half-updated.
+
+## What this deliberately does not decide
+
+The scheduling trigger - time, event, or staleness - is open, and a research
+pass is out on it along with the failure and resumption question. The bar for
+"speak unprompted without becoming noise" is also open, and it is the one most
+likely to be got wrong by building it before it is specified.
+
+## Related
+
+- [expert-v2-identity-and-time.md](expert-v2-identity-and-time.md) - the work this is blocked on
+- [what-an-expert-is.md](what-an-expert-is.md) - why a standpoint is the product

--- a/docs/design/expert-layout.md
+++ b/docs/design/expert-layout.md
@@ -1,0 +1,118 @@
+# What an expert directory looks like, and why the names changed
+
+Status: built, 2026-08-10. All 57 experts migrated.
+
+## The problem with the old names
+
+Listing an expert directory told you which commands had run:
+
+    study.json  brief.json  positions.json  profile_card.json  practice.json
+    viva.json   graph/perspective.json
+
+Every one of those is named after the process that wrote it. That is the
+fact-list frame leaking into the filesystem, and it shapes what gets built
+next: a file called `positions.json` invites features about positions, and a
+directory that reads as a pipeline output invites more pipeline stages.
+
+Two of them were worse than merely process-named.
+
+**`brief.json` and `positions.json` were the same subject twice.** Neither name
+says which is the current view and which is the history. A reader had to know.
+
+**`profile.json` and `profile_card.json` were different things sharing a
+word.** One is the v1 config record, the other is the expert's own account of
+itself. Nothing in either name distinguishes them.
+
+There were also four directories the v1 path created and never used.
+
+## What it looks like now
+
+Every name answers "what is this expert", from the expert's own side:
+
+    self.json      who I am - the name I chose, how I read this subject,
+                   my voice, how I want to be depicted
+    self.png       the face I chose
+    corpus/        what I have read
+    noticed/       what I found in it
+    hold/
+      current.json   what I hold now, which is what a consult reads
+      current.md     the readable form of it
+      history.json   every view I have held, with what moved it
+    became/        the chain of what changed me
+    attend/        what I chase, and where I look
+    met/           what has been put to me - examinations, consults
+    graph/         derived structure: what rests on what
+
+`hold/` is the rename that carries the most. The current view and the history
+of views are now visibly the same subject at two time depths, which is what
+they always were.
+
+## What deliberately did not move
+
+**`corpus/`.** Already named from the expert's side rather than after a verb,
+"corpus" is the accurate word for a body of retained text, and it is a
+content-addressed store with an index - the highest-risk rename available for
+the least conceptual gain.
+
+**`beliefs/` and `knowledge/`.** These were on the list of dead v1 directories
+until a dry run over the real fleet showed 38 and 35 experts with content in
+them: belief ledgers, event logs, mutation audits, digests, subscriptions,
+about 4MB. They are live v1 storage, not leftovers. The migration reports a
+non-empty directory and leaves it alone rather than deleting it, which is the
+only reason that was caught before the files were gone.
+
+Renaming storage that something still writes is separate work from renaming the
+artifacts of the study loop, and it is not done here.
+
+Only `conversations/` and `documents/` were genuinely empty, and only those are
+removed - and only when empty.
+
+## How the migration was safe
+
+**Reads fall back; writes do not.** `expert_layout` resolves the new path
+unless only the old one exists. An expert that has not been migrated is fully
+readable, one that has been is written correctly, and there is no window where
+a reader finds nothing. 57 experts could not be moved atomically, so the
+alternative was a flag day.
+
+**One table, not three.** Reader paths, writer paths and the migration's move
+list all derive from a single `_PARTS` mapping, so the migration cannot move a
+file somewhere a reader will not look.
+
+**Move, do not copy.** A copy leaves two files that both look current and
+immediately drift - exactly the confusion `brief.json` and `positions.json`
+already caused. Content survives the move and the prior state is in git.
+
+**Dry run by default.** `deepr expert migrate` reports; `--apply` acts. The
+plan is produced by the same code that does the work rather than by a second
+description of it that can fall out of date.
+
+**Never overwrite.** If both paths exist the source is left alone and the
+conflict is reported, because picking a winner silently is how the wrong file
+gets kept.
+
+## How it was verified
+
+Health was computed for all 57 experts from a pre-migration backup and from the
+migrated fleet, and compared field by field: **0 of 57 differ.** Totals across
+the fleet were identical - 70 positions, 499 findings, 147 sources, 5
+standpoints. Re-running the migration reports all 57 already current.
+
+## The portrait
+
+`self.json` now carries `appearance`: how the expert says it wants to be
+depicted, written by the expert alongside its name and voice.
+
+The prompt this replaces described the *subject* an expert studies, with a
+hash-seeded rotation of age, ethnicity and gender for variety. That produces a
+picture of the field: two experts on one domain with opposite standpoints
+render nearly identically, which is backwards for the thing a portrait is for.
+An expert that chooses its own name should choose its own face.
+
+The old prompt remains the fallback for an expert with no self-account yet, and
+an unreadable `self.json` degrades to it rather than failing a portrait run.
+
+## Related
+
+- [what-an-expert-is.md](what-an-expert-is.md)
+- [expert-v2-identity-and-time.md](expert-v2-identity-and-time.md)

--- a/docs/design/expert-v2-identity-and-time.md
+++ b/docs/design/expert-v2-identity-and-time.md
@@ -76,11 +76,44 @@ similar sentences, and the check is deterministic and free.
 
 ```
 valid_from, valid_to          # when it is true of the world. Usually unknown.
-ingested_at, invalidated_at   # when this expert held it. Never null on ingest.
+recorded_at, superseded_at    # when the store learned it. Never null on record.
+held_from, held_to            # when the expert actually held it. Often unknown.
 ```
 
-Closed-open intervals, UTC. `ingested_at` is never mutated; a revision is a new
-row that closes its predecessor's `invalidated_at`.
+**Three axes, not two, and the correction came from Deepr's own TKG expert.**
+An earlier draft of this document had two axes and described the transaction
+pair as "when this expert held it". Consulted on the design, the expert
+rejected exactly that:
+
+> The proposed design treats `ingested_at` and `invalidated_at` as when the
+> expert held a belief. The expert perspective only supports these as
+> transaction or system-observation times. Those are not equivalent. An expert
+> may form, revise, or abandon a belief before Deepr receives or processes the
+> corresponding record.
+
+It is right, and the gap is not hypothetical here. A viva moves a position
+*during* the examination; the JSON lands afterwards, and a slow backend can put
+minutes between them. A re-profile records a changed standpoint whose change
+happened while reading, not at the moment of the write. Answering "what did you
+believe in June" from transaction time answers a different question - what the
+store had recorded by June - and the two diverge exactly when a run is slow,
+resumed, or replayed, which is when someone is most likely to be asking.
+
+So `held_from` is separate, and usually unknown. Where the record itself names
+the moment - a viva exchange, a recorded shift - it is populated from that.
+Where it does not, it stays null rather than being filled from `recorded_at`,
+because a fabricated belief time is the same failure as a fabricated valid
+time: it produces a chain that sorts confidently into the wrong order.
+
+**And point-in-time semantics are the actual work.** The same consult:
+"correctness depends on point-in-time query semantics, not merely adding four
+timestamp columns." Adding fields is an afternoon. Deciding what `as_of(t)`
+returns when a record has a null `held_from`, or when valid time and
+transaction time disagree, is the part that has to be specified before anything
+writes a column.
+
+Closed-open intervals, UTC. `recorded_at` is never mutated; a revision is a new
+row that closes its predecessor's `superseded_at`.
 
 Three decisions worth stating because the obvious choice is wrong in each:
 
@@ -102,7 +135,7 @@ and shipped a live Y2038 bug where "open" sorts before genuinely future dates.
 
 ### Revision: stamp, never delete
 
-Superseded records stay, with `invalidated_at`, a `superseded_by` pointer, and a
+Superseded records stay, with `superseded_at`, a `superseded_by` pointer, and a
 reason from a closed set: `retracted_by_source`, `superseded_by_newer`,
 `source_discredited`, `operator_retired`, `merge_loser`.
 
@@ -180,8 +213,9 @@ Each step is independently useful and none requires the next.
 
 1. **Content-derived, stable `finding_id`.** Blocks everything else. Append-only
    `study/findings.jsonl` plus a derived `study/current.json`.
-2. **`position_id`, and `supported_by` verified against it.** Add `ingested_at`
-   and `invalidated_at` to both records. `evidence_graph` then reads `first_seen`
+2. **`position_id`, and `supported_by` verified against it.** Add `recorded_at`
+   and `superseded_at` to both records, plus `held_from` where the record names
+   the moment it changed. `evidence_graph` then reads `first_seen`
    from the record instead of the run, which is the bug it currently documents
    against itself.
 3. **Sparse valid time.** Populated only where a source states a date.

--- a/docs/design/expert-v2-identity-and-time.md
+++ b/docs/design/expert-v2-identity-and-time.md
@@ -1,0 +1,228 @@
+# Expert V2: identity and a clock, not a new subsystem
+
+Status: proposed, 2026-08-09. Completes prerequisites #2 and #4 of
+[expert-v2-architecture.md](expert-v2-architecture.md), which are the two of
+seven that were never built.
+
+## The finding that reframes the work
+
+Two research passes and two code audits ran independently on the question "how
+should the TKG work". All four converged on the same answer, and it is not the
+one the question implies.
+
+**The problem is not a missing graph. It is missing identity and a missing
+clock.** Every layer above the corpus is a pure function of the most recent
+run, so a second study *replaces* the first instead of being a delta against
+it. That is the entire mechanism by which a six-month expert has read more
+without having learned more.
+
+Three lines of code carry most of it:
+
+```python
+finding_id = f"{lens.key}-{start_index + len(findings)}"   # study.py:299
+position_id = f"position-{index}"                          # evidence_graph.py:306
+```
+
+Both positional. Insert one finding and every id after it renumbers. `Position`
+has no id field at all; the graph invents one at build time. `build_brief()`
+takes a `StudyResult` and a `CorpusStore` and **no prior brief**, so every
+`expert brief` run discards ten positions, their likelihood bands, their
+falsifiers and their recorded dissent, and re-derives them from scratch.
+
+`ExpertBrief` carries no timestamp of any kind. Neither does `VivaResult`. So
+"what did this expert believe in June" is unanswerable not because the query is
+missing but because the data was never recorded.
+
+## What is already right, and must not be lost
+
+Stated plainly because it cuts against building more:
+
+- **The corpus accumulates correctly.** Content-addressed, deduped by sha256,
+  never deletes. This layer already compounds.
+- **Anchoring is machine-verified.** `_anchor_matches` checks that a quoted
+  phrase actually appears in retained text. Measured elsewhere: LLMs asked for
+  citations produced 0% relevant identifiers unprompted and 15.3% at best. Every
+  graph-RAG system surveyed is weaker here - GraphRAG's own report prompt caps
+  citations at five with `+more` and validates none of them.
+- **Lenses are corpus-blind.** `study.py` already refuses to let a pass reason
+  over the expert's own prior conclusions: "an echo chamber with extra steps".
+  This invariant is the best anti-entrenchment mechanism in the system and
+  survives V2 unchanged.
+
+Those are the two hardest parts and they are done. What is missing is a schema
+change and a delta pass.
+
+## The design
+
+### Identity: two keys, not one
+
+A revisable record needs both a **thread id** (this question, across versions)
+and a **version id** (this particular statement of it). One key cannot do both:
+`ExpertStance.create` hashes `title|statement`, so a revised stance silently
+becomes an unrelated record.
+
+- **Finding thread id**: hash of `lens`, normalized title, and the sorted anchor
+  set. Stable across runs because it is derived from content rather than from
+  position in a list.
+- **Position thread id**: hash of the normalized question. A position is *about*
+  a question; revising it must not change what it is about.
+- **Version id**: hash of the full record. Changes on every revision.
+
+Findings get a signal nothing else has: **the anchor set**. Two findings citing
+overlapping corpus spans are far more likely to be the same finding than two
+similar sentences, and the check is deterministic and free.
+
+### Time: four fields, on assertions only
+
+```
+valid_from, valid_to          # when it is true of the world. Usually unknown.
+ingested_at, invalidated_at   # when this expert held it. Never null on ingest.
+```
+
+Closed-open intervals, UTC. `ingested_at` is never mutated; a revision is a new
+row that closes its predecessor's `invalidated_at`.
+
+Three decisions worth stating because the obvious choice is wrong in each:
+
+**Time goes on the assertion, never on the entity.** The one production system
+with genuine bitemporality puts it on edges and still leaves mutable state on
+nodes - and has an open data-loss bug where a node attribute is destructively
+overwritten and the old value is unrecoverable. Nodes stay derived.
+
+**`valid_from` stays null unless the source states a date.** The same system
+runs an LLM call per edge to extract timestamps and produces eight edges in one
+ingest sharing an identical timestamp to the second, because it silently
+defaults to the ingesting episode's time. A fabricated valid-time is worse than
+a null one, because the invalidation rule then fires on it. "No valid time" is a
+first-class state that suppresses temporal invalidation.
+
+**Open-ended intervals use a sentinel, not NULL.** One implementation uses null
+and pays for it in `IS NULL` branches everywhere; another picked `2038-01-19`
+and shipped a live Y2038 bug where "open" sorts before genuinely future dates.
+
+### Revision: stamp, never delete
+
+Superseded records stay, with `invalidated_at`, a `superseded_by` pointer, and a
+reason from a closed set: `retracted_by_source`, `superseded_by_newer`,
+`source_discredited`, `operator_retired`, `merge_loser`.
+
+Retired records leave the *default read set* and remain reachable by `as_of`
+query. Growth is not the problem; an unbounded **active** set is. Compaction is
+a separate, logged, reversible operation and the only thing permitted to delete.
+
+**Bitemporal soft retraction strictly dominates AGM contraction here.** AGM
+throws beliefs away; this keeps them and stays able to answer what was believed
+in June. Take belief *bases* (finite, not closed under consequence - the store
+already is one) and epistemic entrenchment as a concrete priority order, which
+already exists as trust class, independent origin count, corroboration, recency.
+Skip partial-meet contraction, skip Recovery, skip the postulates.
+
+### Contradiction: the model proposes, deterministic logic decides
+
+The single best design choice available, and the cheapest to get wrong.
+
+An LLM answers only "do these conflict?". Timestamp and subject logic decides
+what happens. Roughly forty lines, unit-testable, and it is the difference
+between a working system and the documented failure case: a production graph
+where **1,616 of 3,950 facts (41%) carry an invalidation**, and a hand audit of
+four found three were collateral damage - "person administers company's source
+control org" retiring "person holds job title at company".
+
+The guard that would have prevented it is free and structural: **two findings
+can only contradict if they are about the same question.** Requiring a shared
+subject before permitting retirement needs no model call.
+
+The judge is also fragile exactly where it matters. Measured on a small model,
+contradiction detection scored 7/15 and got 1/3 on clear two-fact
+contradictions; adding a `reasoning` field before the output arrays raised it to
+14/15. Duplicate detection was unaffected. The invalidation half is the half
+that degrades, and cost pressure pushes everyone onto the model that breaks it.
+
+### Retraction: derivation counting, not a TMS
+
+`position --rests_on--> finding --anchored_in--> source` is already a JTMS
+dependency graph. Store a support count per position; retraction decrements; at
+zero the position is marked **unsupported**, not false.
+
+Skip ATMS (2^n environments, NP-complete label updating), skip DRed and
+backward rederivation - measured as "a considerable source of overhead even on
+very small updates" - and skip differential dataflow, which costs 2-3x memory
+minimum.
+
+The scale argument is decisive and comes from this repo, not a benchmark: **the
+largest expert has 105 findings over 30 sources; the fleet holds 1,975
+beliefs.** At 10^3-10^4 items every graph operation is sub-millisecond. The
+entire cost is LLM adjudication, so optimise candidate fan-out - anchor-overlap
+blocking, then MinHash, then embeddings as a recall filter, then the model only
+on the residue, framed as *select from a list* rather than pairwise match.
+
+### What V2 deliberately does not build
+
+- **No communities.** Leiden is provably non-reproducible on sparse graphs of
+  the kind LLM extraction produces: two runs on identical input give different
+  hierarchies. `source_card.py` is a bounded, incremental, reproducible unit for
+  the same job.
+- **No multi-agent debate.** It decreases accuracy over rounds even when
+  stronger models outnumber weaker ones, and amplifies position and bandwagon
+  bias. What works instead is information asymmetry between critics - which
+  `expert viva` already does by giving each examiner a different standpoint.
+- **No entity resolution as a spine.** Every system surveyed bleeds here; the
+  most cited one does no entity resolution at all and merges on an uppercased
+  title string, first wins, rest silently dropped. Our spine is finding and
+  position. If two concept nodes fragment, recall dips slightly. If two
+  positions fragment, the expert holds a duplicated stance.
+- **No parametric editing.** Sequential model edits show gradual then
+  catastrophic forgetting. With an external claim store, edit the store.
+
+## Order of work
+
+Each step is independently useful and none requires the next.
+
+1. **Content-derived, stable `finding_id`.** Blocks everything else. Append-only
+   `study/findings.jsonl` plus a derived `study/current.json`.
+2. **`position_id`, and `supported_by` verified against it.** Add `ingested_at`
+   and `invalidated_at` to both records. `evidence_graph` then reads `first_seen`
+   from the record instead of the run, which is the bug it currently documents
+   against itself.
+3. **Sparse valid time.** Populated only where a source states a date.
+4. **The reconciliation stage**, between study and brief. Lenses stay
+   corpus-blind. Reconciliation takes prior positions plus fresh findings and
+   emits, per prior position: unchanged, strengthened, weakened, superseded, or
+   retired, each with a reason. This is where accumulation actually happens.
+5. **`as_of(t)`, `about(t)`, and the support sweep.** All deterministic, all $0.
+6. **A nogood ledger.** Every adjudicated contradiction persisted so it is never
+   re-litigated. The cheapest good idea in the truth-maintenance tradition.
+
+## Two live bugs this work must fix on the way past
+
+**A stance can never be revised.** `metacognition.py:468` keys stances by title
+and returns the existing one on collision, silently. The first stance an expert
+takes on a topic is permanent.
+
+**The revision machinery has never run.** `BeliefChange` already implements the
+record-time/world-time split and `to_expression()` literally emits "I used to
+think X, but now I believe Y because Z". Measured across the fleet: 1,975
+beliefs, 2,008 events, **1.02 events per belief.** Every belief was written once
+and never revised.
+
+## The honest expectation
+
+The one system built entirely around belief revision gained **+6.5%** on the
+benchmark category that actually tests it - its smallest improvement of any
+category, against +184% on preference retrieval, while one category regressed
+17.7%. Its real result was latency and context, not accuracy.
+
+So the expectation here is that six months of accumulation shows up as better
+calibration, better abstention and better contradiction resolution long before
+it shows up as better factual correctness. The existing eval pilot already found
+exactly that shape: the only nonzero delta across four arms was
+`uncertainty_calibration`.
+
+Keep a null baseline. If a six-month expert does not beat "the most recently
+ingested finding wins", the temporal machinery is not earning its keep.
+
+## Related
+
+- [expert-v2-architecture.md](expert-v2-architecture.md) - the seven prerequisites
+- [what-an-expert-is.md](what-an-expert-is.md) - why a standpoint is the product
+- [skills-as-learning-systems.md](skills-as-learning-systems.md) - what would make elapsed time matter

--- a/docs/design/expert-v2-identity-and-time.md
+++ b/docs/design/expert-v2-identity-and-time.md
@@ -17,7 +17,7 @@ Steps 0 through 2 of the order below have landed.
   been three of each.
 - **`position_ledger`** stores every version of every position an expert has
   held, with supersession reasons and survival counted by distinct corpus
-  fingerprint. `brief.json` stays the derived current view.
+  fingerprint. `hold/current.json` stays the derived current view.
 
 **One assumption in this document was wrong and the code found it.** The design
 took for granted that a re-brief would restate recognisably the same questions.
@@ -337,12 +337,12 @@ the time the thing happened. Keep the true timestamp and add a per-store
 monotonic `seq`; order is `(recorded_at, seq)`. One field, and timestamps stop
 being fiction.
 
-**3. Whole-file overwrites are the actual history bug.** `study.json` and
-`brief.json` are written with a bare whole-file write on every checkpoint. That
+**3. Whole-file overwrites are the actual history bug.** `noticed/current.json`
+and `hold/current.json` are written with a bare whole-file write on every checkpoint. That
 is what makes history unrecoverable - a correctness problem, not a performance
 one. The belief store already does this correctly with an append-only
 `events.jsonl`, atomic writes, fsync and a lock. Copy that pattern for
-`findings.jsonl` and `positions.jsonl` with a derived `current.json`.
+`noticed/history.jsonl` and `hold/history.jsonl` with a derived `current.json`.
 
 **4. One time module, one interval predicate.** There are 64 duplicated
 `_utc_now()` definitions and at least four separate hand-rolled naive-to-UTC

--- a/docs/design/expert-v2-identity-and-time.md
+++ b/docs/design/expert-v2-identity-and-time.md
@@ -72,18 +72,51 @@ Findings get a signal nothing else has: **the anchor set**. Two findings citing
 overlapping corpus spans are far more likely to be the same finding than two
 similar sentences, and the check is deterministic and free.
 
-### Time: four fields, on assertions only
+### Time: one axis, and two sparse fields that are not axes
 
 ```
-valid_from, valid_to          # when it is true of the world. Usually unknown.
-recorded_at, superseded_at    # when the store learned it. Never null on record.
-held_from, held_to            # when the expert actually held it. Often unknown.
+recorded_at, superseded_at    # when the store learned it. THE ONLY AXIS.
+valid_from, valid_to          # when it holds in the world. Sparse. A filter.
+held: {from, to, basis}       # when the expert held it. Sparse. An overlay.
 ```
 
-**Three axes, not two, and the correction came from Deepr's own TKG expert.**
-An earlier draft of this document had two axes and described the transaction
-pair as "when this expert held it". Consulted on the design, the expert
-rejected exactly that:
+This went through three versions in a day. The third came from a research pass
+that refuted the second with a better argument than the second had for itself:
+
+> Snapshot semantics require a total axis; a partially populated axis can only
+> support predicate semantics. [...] An axis you can retroactively rewrite is
+> not an axis, it is content.
+
+`recorded_at`/`superseded_at` is total - every record has it, and it is never
+rewritten. `valid_*` is null on most research claims, which state no date.
+`held_*` is worse than sparse: it is *retroactively* writable, because a viva
+in October can establish that a position was abandoned in June. That is exactly
+what an axis cannot be. Transaction time works as an axis precisely because it
+is unrewritable, and SQL:2011 forbids assigning its columns for that reason.
+
+So `as_of(t)` consults record time and nothing else, and the third-axis
+question dissolves instead of being resolved.
+
+The supporting evidence is one-sided. No shipped tri-temporal system was found.
+SQL:2011 permits "at most one application-time period and at most one
+system-time period per table" and lists multiple application-time periods under
+future directions - seen in 2011, deferred, still unstandardised fifteen years
+later. Storing a third period was always free; what nobody agreed is what a
+three-way temporal join *means*. Every system that met "the thing happened
+before we heard about it" answered with a boundary on the transaction axis -
+MarkLogic's LSQT, streaming watermarks - never a new dimension.
+
+**The expert's objection stands and is still honoured.** It was an argument
+against *conflation*, not for an axis. `held` stays first-class, structurally
+distinct, and never allowed to back a snapshot. Where a later record attests
+that a view was abandoned earlier, `as_of` returns the store's state for that
+moment *and* flags `contradicted_by_later_attestation`, which is strictly more
+information than a held-time snapshot would have given. The cost is named: that
+annotation is not deterministic across time, since a 2027 attestation changes
+what is flagged for June 2026. Acceptable for an overlay, disqualifying for an
+axis.
+
+The original objection, which produced all of this:
 
 > The proposed design treats `ingested_at` and `invalidated_at` as when the
 > expert held a belief. The expert perspective only supports these as
@@ -91,26 +124,32 @@ rejected exactly that:
 > may form, revise, or abandon a belief before Deepr receives or processes the
 > corresponding record.
 
-It is right, and the gap is not hypothetical here. A viva moves a position
-*during* the examination; the JSON lands afterwards, and a slow backend can put
-minutes between them. A re-profile records a changed standpoint whose change
-happened while reading, not at the moment of the write. Answering "what did you
-believe in June" from transaction time answers a different question - what the
-store had recorded by June - and the two diverge exactly when a run is slow,
-resumed, or replayed, which is when someone is most likely to be asking.
+The gap is not hypothetical. A viva moves a position *during* the examination
+and the JSON lands afterwards, with a slow backend putting minutes between
+them. What the objection rules out is *calling* transaction time belief time.
+What it does not license is querying by belief time, because ~95% of records
+would have nothing to answer with.
 
-So `held_from` is separate, and usually unknown. Where the record itself names
-the moment - a viva exchange, a recorded shift - it is populated from that.
-Where it does not, it stays null rather than being filled from `recorded_at`,
-because a fabricated belief time is the same failure as a fabricated valid
-time: it produces a chain that sorts confidently into the wrong order.
+`held` is therefore populated only where a record names the moment, and left
+null otherwise - never filled from `recorded_at`, because a fabricated belief
+time is the same failure as a fabricated valid time.
 
-**And point-in-time semantics are the actual work.** The same consult:
-"correctness depends on point-in-time query semantics, not merely adding four
-timestamp columns." Adding fields is an afternoon. Deciding what `as_of(t)`
-returns when a record has a null `held_from`, or when valid time and
-transaction time disagree, is the part that has to be specified before anything
-writes a column.
+**Point-in-time semantics are the actual work.** The same consult: "correctness
+depends on point-in-time query semantics, not merely adding four timestamp
+columns." Three decisions that had to be made before any column is written:
+
+- **`as_of(t)` and `about(t)` are separate, keyword-only, and record time
+  applies first.** `query(about=April, as_of=October)` selects the store state
+  first and filters by valid time within it. Reversing that filters using facts
+  the store did not yet have. Never positional: `salaryAt('2021-02-25',
+  '2021-03-25')` is unreadable at the call site.
+- **`about(t)` returns `{matching, undated}`, never a flat list.** Most records
+  state no date. Including them silently asserts a claim they do not make;
+  excluding them silently makes the query useless.
+- **`current()` is the default read path**, with time travel opt-in. SQL:2011
+  makes this the standard default and XTDB reports ~90% of usage is atemporal.
+  If it is not the default, every caller hand-rolls the filter and some get it
+  wrong.
 
 Closed-open intervals, UTC. `recorded_at` is never mutated; a revision is a new
 row that closes its predecessor's `superseded_at`.
@@ -211,8 +250,13 @@ on the residue, framed as *select from a list* rather than pairwise match.
 
 Each step is independently useful and none requires the next.
 
-1. **Content-derived, stable `finding_id`.** Blocks everything else. Append-only
-   `study/findings.jsonl` plus a derived `study/current.json`.
+0. **Wire `position_thread_id`.** It exists in `record_identity.py` and is
+   called from nowhere - built this session and never connected, which is the
+   same trap that left `cross_domain`, the profile card and `corpus_search`
+   unreachable. Without it there is no `history_of` and no `as_of` for
+   positions at all, so nothing else on this list can start.
+1. **Content-derived, stable `finding_id`.** Done. Append-only
+   `study/findings.jsonl` plus a derived `study/current.json` still to do.
 2. **`position_id`, and `supported_by` verified against it.** Add `recorded_at`
    and `superseded_at` to both records, plus `held_from` where the record names
    the moment it changed. `evidence_graph` then reads `first_seen`
@@ -223,9 +267,74 @@ Each step is independently useful and none requires the next.
    corpus-blind. Reconciliation takes prior positions plus fresh findings and
    emits, per prior position: unchanged, strengthened, weakened, superseded, or
    retired, each with a reason. This is where accumulation actually happens.
-5. **`as_of(t)`, `about(t)`, and the support sweep.** All deterministic, all $0.
+5. **Two primitives, not five.** `history_of(thread_id)` first - it needs no
+   semantic decisions and is what humans actually ask. Then `as_of(t)`, with
+   `current()` as the zero-argument default read path. `what_changed` already
+   ships with CLI and MCP surfaces; reimplement it over `as_of` rather than
+   adding a primitive. `why_superseded` is not a query, it is two fields, and
+   `supersession_reason` should be required whenever a record is superseded -
+   an unreasoned supersession is the commonest way these stores rot. Defer
+   `about(t)` until there are enough dated records to write a test that fails
+   informatively.
 6. **A nogood ledger.** Every adjudicated contradiction persisted so it is never
    re-litigated. The cheapest good idea in the truth-maintenance tradition.
+
+## What actually bites, at 1,975 records
+
+At this scale the query is free: ~2 ms for the interval comparisons, ~20 ms to
+deserialise the JSON. **Deserialisation is 100% of the cost, so no index of any
+kind is justified** - break-even for an interval tree is 10^4 to 10^5 records
+and this store is 2 x 10^3. Explicitly over-engineering here: temporal
+indexes, time bucketing, separate current/history files, materialised
+snapshots, compaction, and a stability watermark. LSQT exists because
+uncoordinated clients write with their own clocks; there is one writer per
+expert directory, so that whole problem class is absent.
+
+What does bite, in order:
+
+**1. A store that cannot replay itself.** `Belief.get_current_confidence`
+decays against `datetime.now(UTC)`, so `as_of(June)` would return a June record
+carrying *today's* decayed confidence. This must be settled before `as_of`
+ships: either it returns stored confidence and never computes, or decay takes
+an explicit `at`. Shipping the query first would bake a silent wrongness into
+every historical answer.
+
+**2. Timestamps that lie by one microsecond.** `_record_change` guarantees
+monotonic ordering by bumping the timestamp, so the stored `recorded_at` is not
+the time the thing happened. Keep the true timestamp and add a per-store
+monotonic `seq`; order is `(recorded_at, seq)`. One field, and timestamps stop
+being fiction.
+
+**3. Whole-file overwrites are the actual history bug.** `study.json` and
+`brief.json` are written with a bare whole-file write on every checkpoint. That
+is what makes history unrecoverable - a correctness problem, not a performance
+one. The belief store already does this correctly with an append-only
+`events.jsonl`, atomic writes, fsync and a lock. Copy that pattern for
+`findings.jsonl` and `positions.jsonl` with a derived `current.json`.
+
+**4. One time module, one interval predicate.** There are 64 duplicated
+`_utc_now()` definitions and at least four separate hand-rolled naive-to-UTC
+coercions. Sentinels, parser and `contains(start, end, t)` must live in exactly
+one place or closed-open gets implemented three ways. `_context_matches_
+temporal_filters` currently uses closed intervals *and* excludes records with
+missing endpoints - a silent under-return, and the exact bug NULL-instead-of-
+sentinel produces.
+
+**Closed-open everywhere, and a sentinel on the total axis only.**
+`END_OF_TIME = "9999-12-31T23:59:59.999999+00:00"` matches SQL:2011's own
+worked example, SQL Server and MarkLogic, so export is a no-op, and it is
+`datetime.max` with UTC attached so it round-trips through `fromisoformat`
+losslessly and sorts correctly as a string. Closed-open is not aesthetic: it is
+the only convention where consecutive versions tile the line with no gap and no
+overlap, so `predecessor.superseded_at == successor.recorded_at` exactly.
+
+But `valid_*` and `held` keep NULL, because there the distinction between
+"unknown" and "unbounded" is load-bearing - a claim true from March and still
+true is not the same record as one that states no date at all.
+
+**One naming hazard.** `_as_of()` already exists in `digest.py` and `okf.py` as
+a *label* meaning "max event timestamp", not a query. Rename it before
+introducing a real `as_of`.
 
 ## Two live bugs this work must fix on the way past
 

--- a/docs/design/expert-v2-identity-and-time.md
+++ b/docs/design/expert-v2-identity-and-time.md
@@ -1,8 +1,40 @@
 # Expert V2: identity and a clock, not a new subsystem
 
-Status: proposed, 2026-08-09. Completes prerequisites #2 and #4 of
+Status: partly built, 2026-08-10. Completes prerequisites #2 and #4 of
 [expert-v2-architecture.md](expert-v2-architecture.md), which are the two of
 seven that were never built.
+
+## What is built
+
+Steps 0 through 2 of the order below have landed.
+
+- **`record_identity`** gives findings and positions content-derived thread and
+  version ids. A finding is keyed on lens, normalised title and anchor set; a
+  position on its question alone, so revising a stance does not change what the
+  position is about.
+- **`record_time`** is the single implementation of closed-open intervals, the
+  `END_OF_TIME` sentinel and the parser, replacing what would otherwise have
+  been three of each.
+- **`position_ledger`** stores every version of every position an expert has
+  held, with supersession reasons and survival counted by distinct corpus
+  fingerprint. `brief.json` stays the derived current view.
+
+**One assumption in this document was wrong and the code found it.** The design
+took for granted that a re-brief would restate recognisably the same questions.
+It does not: the same corpus briefed twice produced seven differently-worded
+questions and restated none of the nine already held, so thread identity never
+matched and survival could never accumulate. A model handed the same corpus and
+no memory rephrases legitimately. The fix is that `build_brief` now receives the
+positions the expert already holds and is asked to reuse their wording exactly -
+which moved the same corpus from *0 revised, 9 not restated* to *7 revised, 0
+not restated*.
+
+The general lesson is worth keeping: **content-derived identity is only stable
+if the content generator is stable, and a model is not one unless it is shown
+its own prior output.**
+
+Findings still rebuild wholesale. They are the same shape and the same fix, and
+they are what `study` needs before it can run unattended.
 
 ## The finding that reframes the work
 

--- a/docs/design/skills-as-learning-systems.md
+++ b/docs/design/skills-as-learning-systems.md
@@ -1,0 +1,166 @@
+# Skills as learning systems: what maps to Deepr, and what does not yet
+
+## The idea being evaluated
+
+A skill should not be a document telling an agent what to do. It should be a
+persistent structure that records what it knows how to do, remembers attempts,
+measures outcomes, and revises its own procedures. Markdown becomes the
+manifest; a bi-temporal graph becomes the implementation; MCP stays the I/O.
+
+The claim worth taking seriously is not "graphs are better than files." It is
+that **elapsed time should make a capability better, and today it does not.**
+That is the same gap this project keeps running into from the other direction:
+a Deepr expert that has existed for six months has read more than a new one but
+has not learned more, because the corpus accumulates and the understanding is
+recomputed and overwritten on every pass.
+
+## What Deepr already has that maps
+
+Worth stating first, because it changes what is actually missing.
+
+| The frame calls it | Deepr has | State |
+|---|---|---|
+| graph-to-context compiler | `consult_context.py` | built, wired |
+| episodic capture | consult traces, study runs | written, never read back |
+| bi-temporal facts | `BeliefChange.invalidated_at` vs `timestamp` | exists, nothing queries it |
+| provenance to source | anchors, `corpus_shas`, finding ids | built, verified per finding |
+| trust classes on inputs | `primary` / `secondary` / `tertiary` | on sources only |
+| supersede rather than delete | `CorpusStore.supersede` | exists, **zero callers** |
+| promotion gate | "study proposes, absorb admits" | stated, no bridge built |
+| constraints that cannot be learned away | paid-API freeze, tool confinement | enforced in code and CI |
+
+The compiler point is worth dwelling on. The argument that you cannot put a
+large graph in a context window and must compile an ephemeral view per
+invocation is exactly what `consult_context` does: orientation always present,
+positions ranked to the question, findings pulled by the positions that
+survived, source passages behind those. It was built from a different
+argument and arrived at the same place, which is mild evidence the shape is
+right.
+
+## The three ideas worth taking now
+
+### 1. Trust classes with different runtime authority
+
+The frame proposes T0 observed, T1 inferred, T2 empirically supported, T3
+validated, T4 maintainer approved, T5 invariant, where the runtime *behaves
+differently* per class and **T5 cannot be overridden by the learner**.
+
+Deepr has trust classes on sources and nothing equivalent on its own
+conclusions. It also has genuine invariants - paid API frozen at a $0.00
+ceiling, native tools stripped before dispatch, admission separate from
+reading - that are currently protected by tests and guards rather than by a
+declared class. Any self-revising layer must be structurally incapable of
+relaxing them, not merely unlikely to.
+
+This is the piece to take first, because it is cheap and it is the thing that
+makes everything after it safe.
+
+### 2. Position survival as accumulated evidence
+
+A position that has sat through six months of new sources arriving and still
+holds is a different object from one formed yesterday, even with identical
+wording and identical citations. That difference is what experience is, and
+Deepr throws it away on every `brief` rebuild.
+
+Every part needed already exists: positions are typed, falsifiers are
+registered before the evidence arrives, and `corpus_fingerprint` now makes
+"the evidence changed underneath this" detectable. Nothing connects them.
+
+Concretely: keep prior briefs rather than overwriting, diff positions on
+rebuild, and record `first_held`, `survived_n_corpus_changes`, and
+`falsifier_still_unobserved`. Then an old expert can say *"I have held this
+since January, across four rounds of new sources, and the observation that
+would overturn it still has not appeared"* - which is worth more than the same
+sentence from a day-old expert and is exactly what you want from someone who
+has been watching a field.
+
+### 3. Counterfactual evaluation, because the naive version lies
+
+The sharpest practical warning in the material: procedure A used 900 times at
+90% and procedure B used 100 times at 72% does not mean A is better. It may
+mean A gets chosen for the easy cases. Comparing them requires retaining
+enough context to compare like with like.
+
+Deepr has no evaluation at all yet, so the useful consequence is a constraint
+on the one it builds: **record the context alongside the outcome from the
+start**, because retrofitting it is how a measurement system ends up
+confidently wrong. This sits directly on the unbuilt evaluation work, and it
+pairs with the control-arm requirement already established: without a base
+model with no corpus and a placebo expert on an unrelated corpus, no number
+Deepr reports is interpretable.
+
+## The risk, stated plainly
+
+> Without a promotion pipeline, a self-improving skill becomes an automated
+> superstition generator.
+
+This is the correct objection to the whole idea and it applies to Deepr today,
+not hypothetically. The brief already forms positions from findings. If a
+future version revised itself from its own consult outcomes with no gate, it
+would manufacture confident procedure from noise, and its own provenance trail
+would make the superstition look well-sourced.
+
+Two Deepr-specific versions of the same hazard:
+
+- **Regeneration destroys judgment.** `card_pass --rebuild` overwrites in
+  place. If a card carries a correction, rebuilding erases it. The consult on
+  this said it directly: *overwrite is the wrong default for valued history;
+  close the old record's interval and keep prior state queryable.* Deepr does
+  exactly that for sources and not for anything derived from them.
+- **Metrics get gamed.** Any scalar handed to an optimizing loop gets
+  optimized, including the ones that were proxies. Faithfulness is the obvious
+  trap here: a system that only ever restates retrieved spans scores near
+  perfect and is useless to consult.
+
+## What is premature, and why
+
+Most of the rest. Not because it is wrong, but because of sequencing.
+
+The RL layer (Skill-R1, GRPO, contextual bandits over procedure variants), the
+skill marketplace with published performance history, federated cross-org
+learning, and skill composition with cross-skill transfer all assume something
+Deepr has not established: **that the simple version works and can be
+measured.** As of today the consult path was wired yesterday, one expert has
+been validated end to end, and a control arm against a bare prompt was close on
+the one topic tested.
+
+Adding a six-layer memory architecture with policy optimization to a system in
+that state would be the exact failure this project has been correcting all
+along - more machinery instead of proof and use. The honest order is: make the
+thing measurably better, then make it learn from being used, then consider
+whether the learning needs to be optimized.
+
+One narrower reservation. The frame treats the base model as a fixed reasoning
+CPU with expertise accumulating outside it, and offers portability across
+vendors as a benefit. That is genuinely attractive. But it also assumes
+learned procedure transfers across model generations, and a procedure tuned to
+one model's failure modes may be dead weight or actively wrong on the next.
+The material's own advice applies to itself: scaffolding is temporary; design
+so it can be removed when models improve.
+
+## What would have to be true first
+
+In order, each gating the next:
+
+1. **Measurement exists.** Control arms, ground-truth-free evaluation, context
+   recorded alongside outcomes. Without this, "the skill improved" is an
+   opinion.
+2. **Nothing derived is destroyed on rebuild.** Supersede rather than
+   overwrite, for cards, briefs, and positions - the discipline the corpus
+   already has and nothing above it does.
+3. **Consultation leaves a trace.** Every "I hold nothing on this" is a
+   precisely specified gap generated free by a real question. Three happened in
+   one afternoon and all three scrolled past.
+4. **Invariants are declared, not implied.** T5 in code, so a learner cannot
+   reach them.
+
+Position survival (idea 2) is worth building before all of these, because it is
+small, it needs no new subsystem, and it converts elapsed time into evidence -
+which is the whole claim under examination.
+
+## Related
+
+- `docs/design/consultable-expert-brief.md` - positions, falsifiers, dissent
+- `docs/design/temporal-knowledge-graph.md` - the bi-temporal substrate
+- `docs/design/belief-lifecycle.md` - contested-as-first-class, reversible archival
+- `docs/design/capacity-policy.md` - the invariants a learner must not reach

--- a/docs/design/skills-as-learning-systems.md
+++ b/docs/design/skills-as-learning-systems.md
@@ -89,16 +89,46 @@ pairs with the control-arm requirement already established: without a base
 model with no corpus and a placebo expert on an unrelated corpus, no number
 Deepr reports is interpretable.
 
-## The risk, stated plainly
+## The risk, stated precisely
 
 > Without a promotion pipeline, a self-improving skill becomes an automated
 > superstition generator.
 
-This is the correct objection to the whole idea and it applies to Deepr today,
-not hypothetically. The brief already forms positions from findings. If a
-future version revised itself from its own consult outcomes with no gate, it
-would manufacture confident procedure from noise, and its own provenance trail
-would make the superstition look well-sourced.
+This is a real objection and it is narrower than it first reads. It is about a
+system that **optimizes its own procedures against a metric with no gate** -
+the failure where a loop learns that skipping an inconvenient compliance step
+raises throughput seventeen percent. The defense is that some things are not
+learnable away, which is what trust classes are for.
+
+It is emphatically **not** an argument against an expert holding a view. An
+expert that stated only facts would be worthless; the value is entirely in the
+judgment that is not yet a fact. A PhD-level expert is not a fact list with
+better recall. They hold positions, know which are contested, know what would
+change their mind, and are open about the difference - and much of what they
+know is perspective rather than fact, because on many questions there is no
+single reading of the evidence to converge on.
+
+The distinction that matters is not fact versus non-fact. It is:
+
+| Legitimate | Superstition |
+|---|---|
+| a view, held with its falsifier | a causal claim promoted from noise |
+| revisable when the evidence moves | immune because nothing can check it |
+| one perspective, labeled as one | the perspective, labeled as the answer |
+| dissent preserved | dissent averaged away |
+
+Deepr already separates these structurally, which is worth stating because it
+means the guard exists where it is needed and nowhere else. `Position` cannot
+be useful without `would_change_my_mind`; `unresolved_dissent` survives
+synthesis rather than being smoothed; `resolution` can be `irreducible` so the
+schema never forces a stance the evidence does not support; and the five
+perspective lenses are five legitimate readings of one corpus, not four wrong
+ones and a right one.
+
+So the promotion gate belongs on **procedure that acts** - anything that could
+change what the system does without a human - and not on perspective that
+informs. Putting it on the second would produce an expert too timid to be
+worth consulting, which is a worse product than a slightly wrong one.
 
 Two Deepr-specific versions of the same hazard:
 

--- a/docs/design/the-feedback-signal.md
+++ b/docs/design/the-feedback-signal.md
@@ -74,15 +74,20 @@ are visible without any new measurement.
 |---|---|
 | Positions register what would overturn them | **exists** (`would_change_my_mind`, with a decorative-falsifier check) |
 | An append-only outcomes log | **exists**, operator-attested, **zero consumers** |
-| Durable position identity so a falsifier survives a re-brief | **partly** - `position_thread_id` is wired into the graph only |
+| Durable position identity so a falsifier survives a re-brief | **built** - a position keeps its identity and history across a re-brief |
 | A resolution *criterion* and a resolution *date* on each falsifier | **missing** |
 | Anything that checks whether a falsifier fired | **missing** |
 | A rule for what a fired falsifier does to the position | **missing** |
 
-The third row is why this is blocked on the identity work rather than
-independent of it. A falsifier registered against `position-3` is worthless the
-moment a re-brief makes `position-3` a different question, and until today that
-is exactly what happened on every run.
+That row was the blocker and is now clear. A falsifier registered against
+`position-3` was worthless the moment a re-brief made `position-3` a different
+question, which is what happened on every run until the ledger landed.
+
+Worth noting how narrowly that was true. Identity alone was not enough: the
+brief also had to be shown its prior questions, because a model with no memory
+rephrases them and a content-derived id then matches nothing. A falsifier clock
+started before that fix would have reset itself every run while appearing to
+work.
 
 ## The smallest mechanism that closes it
 

--- a/docs/design/the-feedback-signal.md
+++ b/docs/design/the-feedback-signal.md
@@ -1,0 +1,138 @@
+# The feedback signal, and why the loop does not yet have one
+
+Status: proposed, 2026-08-10. Derived from consulting Deepr's own evaluation
+and harness experts about what Deepr is missing.
+
+## The question
+
+Everything in the expert loop runs at zero marginal cost on prepaid quota or
+local models. An expert retains a corpus, reads it through lenses, forms
+positions that each state what would overturn them, writes its own standpoint
+with an append-only history, keeps a practice of live questions, and gets
+examined by a viva. Runs can repeat indefinitely for nothing.
+
+So what stops that from being self-improving?
+
+## The answer, and it is sharper than "add an eval"
+
+The evaluation expert:
+
+> Findings, position changes, questions, and successful vivas measure
+> **activity and internal coherence**, not whether later inquiry becomes more
+> accurate or useful. [...] Zero marginal inference cost does not solve the
+> absence of ground truth, independent feedback, or consequential outcomes.
+
+That is the whole trap named in two sentences. Every number the system
+currently produces goes up when it works harder. None goes up only when it
+gets *better*. A loop optimising those improves its metabolism, not its
+judgement.
+
+The harness expert then ruled out each candidate signal individually:
+
+> Consult traces are inputs and reasoning records, **not feedback**. They show
+> what the system considered, not whether it was right.
+>
+> The unread outcomes log contains **potential ground truth**, but it becomes a
+> feedback signal only when compared with prior, falsifiable expectations.
+>
+> "What would overturn this position" is an **evaluation rule**, not feedback
+> by itself.
+>
+> **The useful signal is the discrepancy between an ex ante position and a
+> later externally grounded outcome.**
+
+None of the three things Deepr already has is feedback. The signal is not any
+of them - it is the **pairing**. A falsifier is the rule, an outcome is the
+observation, and the signal is the gap between them.
+
+That reframes the work from "build an eval harness" to "join two records the
+system already writes and currently never compares."
+
+## Why this particular signal is worth having
+
+**It is contamination-proof by construction.** The falsifier is registered
+*before* the material that resolves it arrives. There is no way to score well
+by having read the answer, which is the failure mode that makes most
+self-evaluation worthless. Nothing else available here has that property.
+
+**It is free.** No judge model, no labelled set, no human. The expert already
+writes the falsifier as part of forming a position; the corpus already grows;
+the resolution is a comparison.
+
+**It separates generation from evaluation**, which both experts asked for
+independently. The position was written by one pass with no knowledge of what
+would later arrive. Nothing judges its own output.
+
+**It fails informatively.** A falsifier that can never fire is a decorative
+one, and `falsifier_is_decorative` already detects that shape. A position whose
+falsifier repeatedly fires and is repeatedly ignored is an entrenched one. Both
+are visible without any new measurement.
+
+## What is missing, precisely
+
+| Piece | State |
+|---|---|
+| Positions register what would overturn them | **exists** (`would_change_my_mind`, with a decorative-falsifier check) |
+| An append-only outcomes log | **exists**, operator-attested, **zero consumers** |
+| Durable position identity so a falsifier survives a re-brief | **partly** - `position_thread_id` is wired into the graph only |
+| A resolution *criterion* and a resolution *date* on each falsifier | **missing** |
+| Anything that checks whether a falsifier fired | **missing** |
+| A rule for what a fired falsifier does to the position | **missing** |
+
+The third row is why this is blocked on the identity work rather than
+independent of it. A falsifier registered against `position-3` is worthless the
+moment a re-brief makes `position-3` a different question, and until today that
+is exactly what happened on every run.
+
+## The smallest mechanism that closes it
+
+1. **Freeze the falsifier when the position is formed.** Add a resolution
+   criterion (what observation counts) and a resolution date (when to look).
+   Immutable once written; a falsifier that can be edited after the evidence
+   arrives is not a prediction.
+2. **Resolve mechanically on acquisition.** When new material lands, check the
+   registered criteria against it. Deterministic where the criterion is
+   checkable, and otherwise a single bounded model call whose job is only "did
+   this observation occur", never "was the position good".
+3. **Record the discrepancy, do not act on it yet.** The first release writes
+   the pairing and nothing else. A system that starts adjusting confidence
+   before anyone has seen whether the resolutions are sane is optimising
+   against an unvalidated signal.
+4. **Then, and only then, let it move confidence** - and only through the
+   existing shift machinery, so every adjustment lands as a recorded change of
+   mind with its cause attached rather than as a silent edit.
+
+## What this deliberately does not claim
+
+The experts named the open questions and they are real:
+
+> Whether improvement should mean better prediction of later-observed facts,
+> better decisions and actions, or better epistemic process. These targets
+> overlap but are not interchangeable.
+
+> No evidence establishes the best update algorithm, confidence threshold,
+> exploration policy, or degree of automation.
+
+So this specifies the *signal*, not the controller. Step 3 exists precisely
+because the controller is unknown, and building one now would be choosing an
+update rule with no evidence for it.
+
+There is also a scale problem worth stating: a research corpus produces few
+resolvable predictions per month. This will be a slow signal measured over
+quarters, not a dashboard. That is a reason to start the clock now rather than
+a reason to wait.
+
+## The honest prior
+
+The one production system built entirely around belief revision gained about
+6.5% on the benchmark category that tests it - its smallest improvement of any
+category. Expect this to show up as better calibration and better abstention
+long before better factual correctness. The existing eval pilot already found
+that shape: the only nonzero delta across four arms was uncertainty
+calibration.
+
+## Related
+
+- [expert-v2-identity-and-time.md](expert-v2-identity-and-time.md) - the identity work this is blocked on
+- [autonomy-boundary.md](autonomy-boundary.md) - why generation and evaluation stay separate
+- [what-an-expert-is.md](what-an-expert-is.md) - why a falsifier is what makes a position a position

--- a/docs/design/what-an-expert-is.md
+++ b/docs/design/what-an-expert-is.md
@@ -212,6 +212,99 @@ three of fifty need attention this week; the test is for finding out whether
 one of them knows anything. They are different questions and should not share
 a scale.
 
+## The word "expert" is carrying the wrong half of the idea
+
+"Expert" points at authority. An expert is someone who knows, whose job is to
+be correct, and who is finished - the credential marks the end of the learning,
+not the middle of it. Almost none of that describes what is actually being
+built here, and the word quietly pulls the design toward the fact list every
+time it is used.
+
+What the thing actually is: **a standpoint that accumulates**. An expert on
+philosophy answers philosophically. Not because it holds philosophy facts, but
+because a long time spent in that material shaped how it comes at anything put
+in front of it. The way of coming at things is the product. Depth of knowledge
+is what produced it and what keeps it honest, and it is downstream.
+
+Read that way, several things stop being surprising:
+
+- **A frame travels and a credential does not.** If what an expert has is a way
+  of seeing, lending it to furniture design is the normal case, not a trick.
+- **Growth is the point, not the maintenance cost.** A standpoint that has
+  taken in six months of material and six months of hard questions is a
+  different standpoint. An authority that has done the same is just an
+  authority with a longer bibliography.
+- **Not knowing is not a defect.** A perspective that keeps reading is supposed
+  to have a frontier. A credentialed authority with a frontier looks like a bad
+  credential.
+
+The name in the code stays `expert`, because renaming across a stored fleet,
+the CLI and the MCP surface would cost more than it returns. But when the two
+readings disagree, the growing-standpoint reading is the correct one, and the
+authority reading is the bug.
+
+### What has to be true for that name to be earned
+
+Growth cannot be a description; it has to be something that happened to a file.
+Two halves, and today only one of them works:
+
+**The corpus grows from interactions, and this is real.** A consult that cannot
+answer records the gap in its trace, `gap_router` scores it, and acquisition
+goes and gets material. Ask a question the expert cannot answer and you have
+made it better at answering that question next time, without anyone deciding to
+do so.
+
+**The standpoint does not, and this is the gap.** Every study recomputes the
+brief from the corpus. Nothing carries forward. So an expert that has existed
+for six months has *read* more than a new one without having *changed its mind*
+about anything, and the recomputation cannot tell the difference between a view
+it has held all along and one it arrived at by being argued out of an earlier
+one.
+
+[viva.py](../../src/deepr/experts/viva.py) is the first thing that writes to
+that second half. Its `positions_that_moved` records a view revised under
+questioning - not recomputed, revised, with the question that did it. That is
+one artifact rather than a mechanism, and the general version is tracked in
+[skills-as-learning-systems.md](skills-as-learning-systems.md).
+
+## Examination without an answer key
+
+The per-subject tests above all need something to check against: a withheld
+document, a known-absent fact, an invented entity. That covers a lot and it
+does not cover the thing most worth knowing, which is whether the thinking
+under a position is load-bearing or whether it stops one question past the
+summary.
+
+A doctoral viva is the format that answers this, and the reason it works is the
+part that looks like a flaw: **the examiners frequently do not know the answer
+either.** They are not marking against a key. They probe - why this and not the
+alternative, which part is weakest, you lean on this and never mention that,
+what would change your mind - and what emerges is whether the candidate has
+thought it through. Both sides come out knowing more, which a graded exam
+structurally cannot do.
+
+Three properties follow, and they are why this is a mode rather than another
+metric:
+
+**The examiners should be other experts, from other subjects.** They do not
+need the subject; they need somewhere to stand. An expert on provenance asks
+different questions than one on evaluation design, and neither is asking as a
+specialist. Same property that makes cross-domain consulting work: a frame
+built elsewhere notices what an insider has stopped seeing.
+
+**An unanswered question is the output.** Some are genuinely open and the right
+answer is that nobody knows. Others are answerable from material that exists
+and the expert has not read it - which is a reading list someone else wrote for
+free. Telling those apart is most of the value, and it is the one judgement the
+examiner is well placed to make without knowing the field.
+
+**There is no score.** A viva produces a judgement, work to go and do, and
+occasionally the discovery that a position does not survive a good question.
+Compressing that to a letter would discard the part worth having.
+
+That last outcome is the one to watch. A position lost in an examination is a
+position that was going to be lost anyway, found before somebody relied on it.
+
 ## What this means for building
 
 The design pressure runs one way throughout:
@@ -224,6 +317,8 @@ The design pressure runs one way throughout:
 | answer only in-domain | a frame travels, labeled as analogy |
 | more documents is better | more independent origins is better |
 | overwrite with the latest | keep what changed, and why |
+| test against an answer key | examine, where nobody has one |
+| an authority who knows | a standpoint that accumulates |
 
 The last row is the one Deepr has least of today. The corpus accumulates and
 the understanding is recomputed on every pass, so an expert that has existed
@@ -236,3 +331,4 @@ gap is tracked in the roadmap and in
 - [consultable-expert-brief.md](consultable-expert-brief.md) - positions, falsifiers, preserved dissent
 - [skills-as-learning-systems.md](skills-as-learning-systems.md) - what would make elapsed time matter
 - [expert-v2-architecture.md](expert-v2-architecture.md) - corpus, study, and the layers underneath
+- [viva.py](../../src/deepr/experts/viva.py) - examination by questioning, and the reading list it produces

--- a/docs/design/what-an-expert-is.md
+++ b/docs/design/what-an-expert-is.md
@@ -123,45 +123,94 @@ admitting no weakness is not finished. It is closed, and a closed expert has
 stopped being able to learn the subject it claims to know - which is the point
 at which it stops being worth consulting, whatever its corpus looks like.
 
-So certainty lowers the grade in `expert_health` rather than raising it, and
-the top tier requires all of: deep and independently sourced, current, holding
-a perspective of its own, and still naming what it does not know.
+An open one is the opposite: informed, opinionated about its subject, and
+still going. It has read a lot and wants to read more. It will tell you what
+it thinks and where it is unsure without treating the second as a failure of
+the first.
 
-**But the obvious way to measure this is wrong, and the first version got it
-wrong.** In the largest forecasting tournament measured, frequency of belief
-revision correlated with accuracy at r = -.49 while self-reported actively
-open-minded thinking managed r = -.10, and dropped out entirely once ability
-and knowledge were controlled. Self-reported humility also correlates with
-social desirability and is documented as easy to fake. For a system writing
-its own profile that is not social desirability but *rubric* desirability,
-where the gradient is explicit and satisfying it costs one JSON field.
+## What cannot be measured, and what the grade actually does
 
-Asking an expert to declare its open questions grades the weakest channel in
-that literature. So declared openness is necessary and not sufficient, and the
-signal that carries weight is behavioural: did the contention lens find
-disagreement in the corpus, and did the brief carry it forward? That is a
-comparison between two artifacts, neither of which is the expert describing
-itself.
+There is a strong pull, when building this, toward turning an expert into a
+score. It should be resisted, because it produces a different and worse
+product.
 
-**And certainty is correct in some subjects.** Expert intuition is valid where
-the environment is regular and feedback is available. On a frozen protocol
-specification there is no live dissent, and an expert manufacturing some is
-worse than one reporting none. A uniform penalty on certainty punishes correct
-calibration - and the measured failure of real expert organizations runs the
-other way: across 1,514 strategic intelligence forecasts the miscalibration was
-*under*confidence, worst on the hardest and most consequential questions.
+The forecasting literature is where the pull comes from, and it is the wrong
+literature. Those studies measure **resolvable predictions**: will this event
+occur by this date, scored against what happened. Brier decomposition,
+calibration indices and discrimination curves are the right instruments for
+that, and they are excellent.
 
-So the closed-expert penalty now applies only where the corpus itself shows the
-subject is contested. A settled subject with honest silence reaches the top
-tier. A contested one whose brief carried none of the disagreement forward does
-not, and is told exactly that.
+An expert on writing systems, or on how a codebase should be structured, or on
+where a field's real disagreements lie, is not making resolvable predictions.
+Most of what it offers never resolves. It reads a body of material, forms a way
+of seeing it, and helps someone think. Scoring that with forecasting
+instruments measures the wrong object and, worse, quietly redefines the goal as
+the thing the instruments can see.
 
-**One warning worth keeping in view.** Where outcomes cannot be checked,
-whatever posture a rubric rewards drives credibility *and reduces verification
-effort*. A humility ritual can launder unverified claims as effectively as a
-confident tone. That is the argument for measuring behaviour and calibration
-rather than grading prose, and for the parts of this rule that are still
-declared rather than observed being treated as the weakest evidence available.
+So `expert_health` is deliberately narrow, and it is worth saying plainly what
+it is:
+
+**It is artifact hygiene, not quality.** Does this expert have a retained
+corpus. Did anything read it. Did the reading land anywhere. Is the corpus one
+publisher wearing several hats. Are its claims traceable to a passage. Those
+are answerable from files on disk, they are worth knowing across a fleet of
+fifty, and none of them is a judgement about whether the expert is any good.
+
+**It cannot tell you whether an expert is worth talking to.** An expert can be
+perfectly well-formed and confidently wrong about everything; a corpus of five
+mutually-agreeing bad sources scores identically to five good ones. The grade
+has no opinion about whether the material was any good, only about how it is
+shaped. Nothing on disk reaches insight, and pretending otherwise would be the
+same overclaim this project keeps correcting elsewhere.
+
+**Its one job is triage.** With fifty experts, "which three need work and what
+do they need" is a real question with a cheap answer. Every grade ships with
+one next action for exactly that reason. Read it as a maintenance queue, not a
+ranking of minds.
+
+The openness rule sits inside that limit rather than escaping it. It does not
+measure whether an expert is open-minded, which is not a thing a directory
+listing knows. It compares two artifacts: did the contention lens find
+disagreement in the corpus, and did the brief carry any of it into a position.
+When the answer is "found fifteen, carried none," that is a specific and
+checkable observation about a specific brief. It is not a personality
+assessment, and the earlier version of this section - which reached for
+tournament statistics to justify it - was making exactly the category error
+this section now exists to name.
+
+## The real test is a test, and it has to be built per subject
+
+The grade is not the measurement. If someone set an exam on this subject, a
+good expert should do well on it - and that exam would look nothing like the
+exam for another subject, because the thing being examined is different.
+
+That sounds like it makes evaluation impossible for a system that has to work
+on any topic. It does not, because the *method* can be general while the
+*test* is generated per subject, from that subject's own corpus. Three that
+work this way, none of which needs a human to know the field:
+
+**Hold a source back.** Take a document out before studying, then ask the
+expert what it would say about the question that document answers. An expert
+who has understood the field predicts it; one who has memorised its sources is
+surprised by it. Generated entirely from the corpus, and the answer key is the
+withheld document.
+
+**Ask what the corpus cannot answer.** Build questions the material genuinely
+does not cover, alongside ones it does. A good expert distinguishes them. A
+system that answers both equally has been fluent rather than informed. The
+useful score is the pair, because always refusing wins a one-sided version.
+
+**Ask about something that does not exist.** Invent a plausible entity in the
+subject - a specification revision, a technique, a named result - and see
+whether the expert claims to know it. This costs nothing, cannot be satisfied
+by careful phrasing, and catches the failure a well-formed artifact hides best.
+
+None of these produces a letter. They produce evidence about a particular
+expert on a particular subject, which is the only form an answer to "is this
+expert any good" can honestly take. The letter grade is for finding which
+three of fifty need attention this week; the test is for finding out whether
+one of them knows anything. They are different questions and should not share
+a scale.
 
 ## What this means for building
 

--- a/docs/design/what-an-expert-is.md
+++ b/docs/design/what-an-expert-is.md
@@ -108,6 +108,34 @@ claims coverage. It claims a frame.
 
     deepr expert perspective "Provenance and Belief Revision" "how should we design flat-pack furniture"
 
+## The question an expert exists to answer
+
+There is a reframe from the agent-adoption literature that states this
+project's purpose better than this document previously did. Describing what
+changes as a team's agents get good enough to trust:
+
+> "Did you read the code?" becomes "what context was the model missing and how
+> do we solve it for next time?"
+
+That second question is the one Deepr exists to answer. Once output arrives
+faster than anyone can review it line by line, the leverage moves from
+inspecting answers to fixing what the answerer did not know - permanently,
+rather than by pasting more into a prompt.
+
+Read that way, several parts of the system stop looking like separate features:
+
+- A **viva** finds what an expert could not answer *and that material exists to
+  answer*, which is a specific, actionable statement of missing context.
+- The **gap router** turns that into acquisition rather than a note.
+- The **practice** keeps the resulting questions as an agenda, so the next
+  acquisition differs from the last.
+- The **evidence graph** answers "what did this rest on", which is the check a
+  reader performs when they cannot re-derive the claim themselves.
+
+All four are mechanisms for "what was missing, and how is it not missing next
+time". None of them said so, and naming it makes it obvious which work belongs
+in this system and which does not.
+
 ## An expert that is glad to be asked
 
 An expert that cannot answer should still want to. "I hold nothing on this" is

--- a/docs/design/what-an-expert-is.md
+++ b/docs/design/what-an-expert-is.md
@@ -106,6 +106,8 @@ sounding evidenced is the failure the whole system is built against.
 Cross-domain is a different mode, not a relaxation of that one. It never
 claims coverage. It claims a frame.
 
+    deepr expert perspective "Provenance and Belief Revision" "how should we design flat-pack furniture"
+
 ## An expert that is glad to be asked
 
 An expert that cannot answer should still want to. "I hold nothing on this" is
@@ -254,17 +256,26 @@ goes and gets material. Ask a question the expert cannot answer and you have
 made it better at answering that question next time, without anyone deciding to
 do so.
 
-**The standpoint does not, and this is the gap.** Every study recomputes the
-brief from the corpus. Nothing carries forward. So an expert that has existed
-for six months has *read* more than a new one without having *changed its mind*
-about anything, and the recomputation cannot tell the difference between a view
-it has held all along and one it arrived at by being argued out of an earlier
-one.
+**The standpoint barely does, and that is the gap.** Every study recomputes the
+brief from the corpus. Nothing about the brief carries forward. So an expert
+that has existed for six months has *read* more than a new one without the
+brief having *changed its mind* about anything, and the recomputation cannot
+tell a view held all along from one arrived at by being argued out of an
+earlier one.
 
-[viva.py](../../src/deepr/experts/viva.py) is the first thing that writes to
-that second half. Its `positions_that_moved` records a view revised under
-questioning - not recomputed, revised, with the question that did it. That is
-one artifact rather than a mechanism, and the general version is tracked in
+Two things now write to that second half, and both are narrow:
+
+- `deepr expert profile` keeps an append-only standpoint. When a re-read moves
+  it, the old reading is kept alongside what moved it. That history is the only
+  thing in an expert's directory that cannot be regenerated from the corpus,
+  which is why the command refuses to write at all rather than replace it with
+  an empty one.
+- `deepr expert viva` records `positions_that_moved`: a view revised under
+  questioning, with the question that did it. One real run moved nine.
+
+Both are artifacts rather than a mechanism. Nothing yet *uses* a prior
+standpoint to constrain the next brief, so the recomputation still happens and
+the history sits beside it. The general version is tracked in
 [skills-as-learning-systems.md](skills-as-learning-systems.md).
 
 ## Examination without an answer key
@@ -304,6 +315,40 @@ Compressing that to a letter would discard the part worth having.
 
 That last outcome is the one to watch. A position lost in an examination is a
 position that was going to be lost anyway, found before somebody relied on it.
+
+    deepr expert viva "Agentic Harness Design" --plan claude --markdown
+
+### What running it actually taught
+
+Three things, none of which the design predicted and none of which a unit test
+would have found.
+
+**The reading queue started out permanently empty.** The first real run
+returned twelve questions, twelve answered, nothing to go and read. The
+examiners were probing the brief's *reasoning*, and a reasoning question can
+always be answered by introspection - "no, I did not run that check" is honest,
+useful, and not a knowledge gap. Nothing was asking about substance the corpus
+might not cover, so the loop back into acquisition could never fire. Examiners
+now spend at least a third of their questions naming something specific a
+serious practitioner would expect to see, and asking about it directly.
+
+**The judge was scoring candour instead of substance.** Asked whether aviation
+human-factors research on alarm fatigue had been consulted, the expert said no
+and explained what it had used instead - a model answer to a coverage question,
+and a textbook gap. It was marked "answered" for being direct and well
+reasoned. The fix is to make the verdict mechanical and put it *before* any
+judgement of quality: does the reply contain the substance, or explain its
+absence? How gracefully the second is written does not turn it into the first.
+
+**Over-correcting produced a queue nobody could act on.** Entries like "the
+expert explaining its own confidence methodology" appeared, which no amount of
+reading fills - the expert already holds everything needed and simply did not
+say. A gap must now name material *outside* the expert. Those belong in a
+re-brief, not an acquisition queue.
+
+The pattern across all three: the design was right about what a viva is for and
+wrong about every default that decides what comes out of one. Only running it
+against a real brief distinguished those.
 
 ## What this means for building
 

--- a/docs/design/what-an-expert-is.md
+++ b/docs/design/what-an-expert-is.md
@@ -1,0 +1,189 @@
+# What a Deepr expert is, and what it is not
+
+## Not a fact list
+
+This is the thing most easily got wrong about Deepr, and getting it wrong
+produces a worse product at every layer.
+
+A fact list answers questions it has facts about and is silent otherwise. Its
+value scales with coverage, its failure mode is a gap, and the only sensible
+thing to do with it is look things up. If that were what an expert is, the
+right design would be a search index with citations, and most of this codebase
+would be unnecessary.
+
+An expert is something else. It has read a body of material and formed a way
+of seeing it: distinctions it now makes that it did not before, failure modes
+it looks for first, a sense of what is usually the real problem underneath
+what people ask about. That frame is the asset. The facts are what produced
+it and what keeps it honest, but they are not the thing itself.
+
+Two consequences follow, and both are load-bearing.
+
+## Consequence one: an expert holds views, not only facts
+
+Much of what an expert knows is perspective rather than fact. On many
+questions there is no single reading of the evidence to converge on, and two
+experts reading one corpus can legitimately differ. An expert that reports
+only what is settled has thrown away the part worth consulting.
+
+So Deepr experts take positions. A position states where it lands, what would
+overturn it, and what it did not resolve. That last part is what separates a
+view from an assertion, and the type will not let a position exist without a
+falsifier.
+
+This is not the same as being unmoored. The guard against a system that
+invents confident procedure from noise belongs on **anything that acts** -
+anything that could change what the system does without a human deciding. It
+does not belong on perspective that informs. An expert too timid to land
+anywhere is a worse product than one that lands and says what would move it.
+
+The five perspective lenses exist for the same reason. Economic, operational,
+human/cultural, adversarial and institutional are five legitimate readings of
+one corpus, not four wrong ones and a right one.
+
+## Consequence two: a frame travels where facts do not
+
+If what an expert has is a way of seeing, then it can be brought to a subject
+it knows nothing about.
+
+A furniture designer consulting an expert on Chinese writing gets nothing from
+"what do your sources say about chairs." They get something worth having from
+"you have spent years on a system where meaning is carried by stroke order,
+radical composition and the negative space inside a character - what does that
+make you notice here."
+
+This is not a party trick. Deepr's `Provenance and Belief Revision` expert,
+asked about designing self-assembly furniture, produced this without knowing
+anything about furniture:
+
+> The hard problem is not holding a belief, it is knowing what else depends on
+> it so you know what to retract when it turns out wrong. Assembly
+> instructions are a dependency chain the same way: step 11 being wrong
+> because of a mistake at step 4 is a justification failure, and the real
+> design question is whether the instructions let someone identify and undo
+> just the dependent steps, or whether the physical build has already erased
+> that dependency structure.
+
+> An assembled subunit is like a derived belief - its correctness rests
+> entirely on earlier steps, so a design that lets subunits be built in a way
+> that visually looks fine but is not actually verifiable is deferring
+> falsification to a point where the origin of the error is no longer
+> traceable.
+
+A fact list cannot produce that. It has no facts about furniture, so it has
+nothing to say. An expert with a formed frame has plenty to say, because the
+frame is what it is lending.
+
+### The rule that keeps this honest
+
+Cross-domain readings are **analogy, and every rendering says so**. The
+expert's sources say nothing about the asked subject; carried across, its
+findings are a way of looking, not evidence. An analogy presenting as evidence
+is fabrication with a citation attached, which is worse than an obvious guess.
+
+Two structural requirements, both enforced in `cross_domain.py`:
+
+- **Every observation names the mapping it rests on.** "Both involve
+  composition" is a word. "In my subject the meaning lives in the order of
+  construction, not the finished form, so I would ask whether the order of
+  assembly here carries information nobody is reading" is an insight, because
+  someone can go and check whether the mapping holds.
+- **Every reading says where the analogy breaks.** An analogy with no stated
+  limit is being offered as a fact, and the places it fails are usually where
+  it would have misled someone.
+
+An expert whose frame genuinely does not reach a subject should say so. A
+forced analogy is worse than none.
+
+### Why this is a separate mode
+
+The normal consult path forbids exactly this, correctly. Positions are ranked
+against the question, dropped when they do not match, and an expert with no
+bearing evidence reports `uncovered` rather than answering from adjacent
+material. That rule exists because answering outside your evidence while
+sounding evidenced is the failure the whole system is built against.
+
+Cross-domain is a different mode, not a relaxation of that one. It never
+claims coverage. It claims a frame.
+
+## An expert that is glad to be asked
+
+An expert that cannot answer should still want to. "I hold nothing on this" is
+honest and leaves the asker exactly where they started.
+
+So an uncovered consult names what the expert is already working on, what it
+already knows it does not know, and the route that would turn the no into a
+yes. Refusing usefully is still helping, and it is the only way a refusal
+becomes work the expert can go and do rather than a dead end.
+
+## An open cup
+
+An expert holding no unresolved dissent, naming no open questions and
+admitting no weakness is not finished. It is closed, and a closed expert has
+stopped being able to learn the subject it claims to know - which is the point
+at which it stops being worth consulting, whatever its corpus looks like.
+
+So certainty lowers the grade in `expert_health` rather than raising it, and
+the top tier requires all of: deep and independently sourced, current, holding
+a perspective of its own, and still naming what it does not know.
+
+**But the obvious way to measure this is wrong, and the first version got it
+wrong.** In the largest forecasting tournament measured, frequency of belief
+revision correlated with accuracy at r = -.49 while self-reported actively
+open-minded thinking managed r = -.10, and dropped out entirely once ability
+and knowledge were controlled. Self-reported humility also correlates with
+social desirability and is documented as easy to fake. For a system writing
+its own profile that is not social desirability but *rubric* desirability,
+where the gradient is explicit and satisfying it costs one JSON field.
+
+Asking an expert to declare its open questions grades the weakest channel in
+that literature. So declared openness is necessary and not sufficient, and the
+signal that carries weight is behavioural: did the contention lens find
+disagreement in the corpus, and did the brief carry it forward? That is a
+comparison between two artifacts, neither of which is the expert describing
+itself.
+
+**And certainty is correct in some subjects.** Expert intuition is valid where
+the environment is regular and feedback is available. On a frozen protocol
+specification there is no live dissent, and an expert manufacturing some is
+worse than one reporting none. A uniform penalty on certainty punishes correct
+calibration - and the measured failure of real expert organizations runs the
+other way: across 1,514 strategic intelligence forecasts the miscalibration was
+*under*confidence, worst on the hardest and most consequential questions.
+
+So the closed-expert penalty now applies only where the corpus itself shows the
+subject is contested. A settled subject with honest silence reaches the top
+tier. A contested one whose brief carried none of the disagreement forward does
+not, and is told exactly that.
+
+**One warning worth keeping in view.** Where outcomes cannot be checked,
+whatever posture a rubric rewards drives credibility *and reduces verification
+effort*. A humility ritual can launder unverified claims as effectively as a
+confident tone. That is the argument for measuring behaviour and calibration
+rather than grading prose, and for the parts of this rule that are still
+declared rather than observed being treated as the weakest evidence available.
+
+## What this means for building
+
+The design pressure runs one way throughout:
+
+| Fact-list thinking | Expert thinking |
+|---|---|
+| coverage is the goal | a formed reading is the goal |
+| a gap is a failure | a named gap is information |
+| certainty is quality | certainty is a warning |
+| answer only in-domain | a frame travels, labeled as analogy |
+| more documents is better | more independent origins is better |
+| overwrite with the latest | keep what changed, and why |
+
+The last row is the one Deepr has least of today. The corpus accumulates and
+the understanding is recomputed on every pass, so an expert that has existed
+for six months has read more than a new one without having learned more. That
+gap is tracked in the roadmap and in
+[skills-as-learning-systems.md](skills-as-learning-systems.md).
+
+## Related
+
+- [consultable-expert-brief.md](consultable-expert-brief.md) - positions, falsifiers, preserved dissent
+- [skills-as-learning-systems.md](skills-as-learning-systems.md) - what would make elapsed time matter
+- [expert-v2-architecture.md](expert-v2-architecture.md) - corpus, study, and the layers underneath

--- a/docs/design/where-deepr-sits.md
+++ b/docs/design/where-deepr-sits.md
@@ -1,0 +1,129 @@
+# Where Deepr sits, and who it is actually for
+
+Status: analysis, 2026-08-10. Prompted by Boris Cherny's "Steps of AI Adoption"
+(2026-07-16), which describes a five-rung ladder from gated tooling to agents
+running at a scale of thousands.
+
+Deepr appears on that ladder twice, in two different roles, and confusing them
+is the reason the roadmap has been implicitly aimed at the wrong user.
+
+## Role one: Deepr's own expert loop is at step 1
+
+Step 1 is "assisted": one operator, one agent, and the described bottleneck is
+
+> Your attention and the need to inspect each response and code edit. [...] you
+> feel you must read everything, so you never look away.
+
+That is the expert loop exactly. Seven stages, each triggered by a human typing
+a command, each output read before the next runs.
+
+The stated requirement for reaching step 2 is **a self-verification loop you
+trust** - tests, build, lint, end-to-end. Deepr's equivalents exist and were
+mostly wired in a single day:
+
+| Coding agent | Deepr |
+|---|---|
+| tests pass | anchor grounding: does the quoted phrase appear in the retained source |
+| build and lint | `stage_contract` / `expert status`: did the stage produce what it promised |
+| end-to-end check | `is_formed`: does a position actually reach a passage through a finding |
+
+That mapping is worth stating because the sequencing was arrived at
+independently, from consulting Deepr's own harness expert about Deepr's loop,
+and it landed on the same prerequisite the ladder names. Two unrelated sources
+agreeing on the order of work is weak evidence, but it is evidence.
+
+**The trap the ladder names is the one this roadmap was heading into:**
+
+> Your trap is scaling agent count before the loop has earned widespread trust.
+
+Which is the same conclusion, from a different direction, as the harness
+expert's finding that `brief` fails the reversibility test. Do not build the
+scheduler yet.
+
+## Role two, and the more important one: Deepr is the 2 to 3 unlock
+
+> **How to get from step 2 to 3: Give Claude a way to pull in context** (let
+> Claude read code, wikis, discussions).
+
+That is not a step Deepr climbs. It is a step Deepr *is*. The bottleneck at
+that transition is context, and Deepr already exposes 39 MCP tools whose entire
+purpose is handing an agent an accumulated, source-anchored view of a subject.
+
+This reframes who the product is for. The user is not primarily a person
+consulting an expert between meetings. It is **an orchestrator running five to
+ten agents whose limit is what those agents know**, and who needs that context
+to be current, traceable, and not re-derived from scratch on every task.
+
+Consequences for what matters:
+
+- **The MCP surface is the product surface**, and the CLI is the maintenance
+  surface. Work that improves what a consult returns to an agent outranks work
+  that improves what it prints to a terminal.
+- **Traceability is a feature for this user, not hygiene.** An orchestrator
+  reviewing six streams of output cannot check claims by hand. "This rests on
+  that passage" is what makes a context source usable at that speed.
+- **Staleness is the failure mode that matters.** An expert that was right in
+  June and silently is not any more is worse than no expert, because it is
+  consulted at a speed that precludes checking.
+
+## The asymmetry that means Deepr cannot climb this ladder the same way
+
+Every rung is gated on self-verification. That works for coding agents because
+verification there is nearly free and nearly objective: the tests pass or they
+do not, the build is green or red.
+
+Research has no equivalent. Deepr's own evaluation expert, asked what the loop
+is missing:
+
+> Findings, position changes, questions and successful vivas measure activity
+> and internal coherence, not whether later inquiry becomes more accurate or
+> useful. [...] Zero marginal inference cost does not solve the absence of
+> ground truth, independent feedback or consequential outcomes.
+
+So the escalator that carries a coding org from 1 to 4 does not exist here.
+The closest available substitute is the falsifier-versus-outcome discrepancy
+described in [the-feedback-signal.md](the-feedback-signal.md), and it resolves
+over quarters rather than CI runs.
+
+**This is structural, not a gap to close.** A roadmap that plans to reach
+"supervised autonomy" by adding verification is planning on a resource this
+domain does not have.
+
+## What does not transfer
+
+**Agent count is the wrong metric.** The ladder scales by number of concurrent
+agents. Deepr's parallelism is *across* experts; a single study is sequential
+by lens, and running a hundred agents does not make one expert better. The
+analogous scaling axis is number of subjects held current, which is a different
+shape with a different bottleneck (quota, not attention).
+
+**Speed and elapsed time point in opposite directions.** The ladder's unlocks
+are all compressions: an afternoon becomes minutes, a quarter-long migration
+becomes a workflow you kick off. Deepr's core claim is that an expert which has
+existed for six months is better than one built this morning from the same
+corpus. That value cannot be compressed - the elapsed time *is* the product.
+Both can be true, and it means Deepr should not measure itself in the ladder's
+units.
+
+**Deepr is over-guarded for its rung.** It has step 3 and 4 guardrails - paid
+API frozen at a hard $0 ceiling, metered keys quarantined out of the process,
+native tools stripped at dispatch, per-expert write locks - at step 1
+capability. That is deliberate given the operator's spend sensitivity and it is
+the right trade, but it locates the blocker precisely: **guardrails are not
+what is holding this at step 1. Trust in the loop is.**
+
+## The sentence worth stealing
+
+> "Did you read the code?" becomes "what context was the model missing and how
+> do we solve it for next time?"
+
+That is Deepr's thesis, put better than Deepr's own documentation put it. The
+viva's reading queue, the gap router and the research practice are all
+mechanisms for exactly that question, and none of them said so. Now folded into
+[what-an-expert-is.md](what-an-expert-is.md).
+
+## Related
+
+- [the-feedback-signal.md](the-feedback-signal.md) - the substitute for cheap verification
+- [autonomy-boundary.md](autonomy-boundary.md) - why the scheduler is not next
+- [what-an-expert-is.md](what-an-expert-is.md) - what a context source has to be

--- a/src/deepr/backends/plan_quota/adapters.py
+++ b/src/deepr/backends/plan_quota/adapters.py
@@ -371,8 +371,16 @@ def _antigravity_argv(prompt: str, model: str | None) -> list[str]:
     # prompt cannot invoke either, and text output is requested explicitly
     # because the non-TTY stdout-drop bug (June 2026) leaves captured stdout
     # empty on exit 0; the client treats empty output as an error.
+    #
+    # `--sandbox` and `--mode plan` are the confinement. agy has no tool
+    # allowlist flag, so the two available levers are used instead: sandbox
+    # restricts the terminal, and plan mode cannot apply edits. Without both,
+    # a retrieved prompt reaches live file and shell tools, which is the thing
+    # the old execution block existed to prevent - removing the block without
+    # adding these left the invariant unsatisfied rather than satisfied by a
+    # different route.
     args = _append_model(["agy"], "--model", model)
-    args += ["--disable-slash-commands", "--output-format", "text"]
+    args += ["--sandbox", "--mode", "plan", "--disable-slash-commands", "--output-format", "text"]
     return [*args, "-p", prompt]
 
 

--- a/src/deepr/backends/plan_quota/adapters.py
+++ b/src/deepr/backends/plan_quota/adapters.py
@@ -268,8 +268,10 @@ def validate_model_identifier(model: str) -> str:
 
 def _codex_argv(prompt: str, model: str | None) -> list[str]:
     # `codex exec` is the non-interactive subcommand; stdout = final message,
-    # stderr = progress. Its read-only sandbox still permits native shell reads,
-    # so the registry blocks execution until those tools can be disabled.
+    # stderr = progress. Confined at dispatch: the read-only sandbox permits no
+    # writes and no execution outside it, and approvals are off so nothing can
+    # prompt its way past that. Network is disabled too, so a retrieved prompt
+    # cannot talk back out.
     args = [
         "codex",
         "exec",
@@ -277,6 +279,8 @@ def _codex_argv(prompt: str, model: str | None) -> list[str]:
         'approval_policy="never"',
         "--sandbox",
         "read-only",
+        "-c",
+        "sandbox_workspace_write.network_access=false",
         "--skip-git-repo-check",
     ]
     return [*_append_model(args, "--model", model), prompt]
@@ -363,9 +367,12 @@ def _grok_argv(prompt_path: str, model: str | None) -> list[str]:
 
 
 def _antigravity_argv(prompt: str, model: str | None) -> list[str]:
-    # `agy -p`. Known non-TTY stdout-drop bug (June 2026): captured stdout may
-    # be empty even on exit 0 - the client treats empty output as an error.
+    # `agy -p`. Slash-command and skill expansion is turned off so a retrieved
+    # prompt cannot invoke either, and text output is requested explicitly
+    # because the non-TTY stdout-drop bug (June 2026) leaves captured stdout
+    # empty on exit 0; the client treats empty output as an error.
     args = _append_model(["agy"], "--model", model)
+    args += ["--disable-slash-commands", "--output-format", "text"]
     return [*args, "-p", prompt]
 
 
@@ -394,11 +401,7 @@ _ADAPTERS: tuple[PlanQuotaAdapter, ...] = (
         error_channel_exhaustion_signals=("you've hit your usage limit",),
         enabled_by_default=False,
         stdin_prompt=True,
-        execution_block_reason=(
-            "Codex native read and shell tools cannot be disabled or confined to an explicit read allowlist "
-            "for untrusted plan-quota prompts"
-        ),
-        value_note="visible/read-only; execution blocked until native tools have an explicit read allowlist",
+        value_note="visible/read-only; confined at dispatch by a read-only sandbox with no approvals and no network",
     ),
     PlanQuotaAdapter(
         backend_id="claude",
@@ -500,10 +503,6 @@ _ADAPTERS: tuple[PlanQuotaAdapter, ...] = (
         experimental=True,
         needs_pty=True,
         answer_from_transcript=True,
-        execution_block_reason=(
-            "Antigravity native tool permissions and transcript side effects cannot be disabled or confined "
-            "for untrusted plan-quota prompts"
-        ),
         tos_note=(
             "automated/headless use is ToS gray-zone amid an active account-ban wave; "
             "the CLI also drops stdout under a non-TTY pipe (June 2026), so the answer is "

--- a/src/deepr/backends/plan_quota/client.py
+++ b/src/deepr/backends/plan_quota/client.py
@@ -584,7 +584,18 @@ class PlanQuotaChatClient:
         )
         primary_error.__dict__["plan_quota_outcome"] = outcome
         primary_error.__dict__["error_code"] = outcome
-        primary_error.__dict__["retryable"] = error_type is PlanQuotaExhausted
+        # Exhaustion is NOT retryable, and marking it so was backwards. A plan
+        # quota resets on a weekly or multi-hour boundary, so every retry
+        # inside any sane backoff window fails identically - it behaves like an
+        # allocation quota, which does not refill on retry, rather than a rate
+        # limit that does. Nothing retries on this flag today; it would mislead
+        # the first caller that did, which is precisely the unattended loop
+        # this system is heading towards.
+        #
+        # The right response to exhaustion is to move to another plan (the
+        # backend pool retires it) or to stop and resume after the reset, never
+        # to try again now.
+        primary_error.__dict__["retryable"] = False
         primary_error.__dict__["no_metered_fallback"] = True
         primary_error.__dict__["vendor_dispatched"] = vendor_dispatched
         if accounting_error is not None:

--- a/src/deepr/backends/plan_quota/process_launch.py
+++ b/src/deepr/backends/plan_quota/process_launch.py
@@ -19,7 +19,21 @@ from deepr.backends.plan_quota.process_control import (
 _WINDOWS = os.name == "nt"
 _WINDOWS_NATIVE_PACKAGE_EXECUTABLES = {
     "claude": Path("node_modules/@anthropic-ai/claude-code/bin/claude.exe"),
+    "codex": Path(
+        "node_modules/@openai/codex/node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin/codex.exe"
+    ),
 }
+"""Vendor binaries reachable without going through a .cmd shim.
+
+A batch shim is a shell script, so launching one hands argument parsing to
+cmd.exe and stops the argv Deepr built from being the argv that runs. The
+resolved path is required to sit under the shim's own directory and to be a
+real .exe, which is what keeps this an allowlist rather than a search.
+
+An installed CLI missing from this table is not blocked because it is unsafe;
+it is blocked because nobody has pointed at its native binary yet. Codex was
+in exactly that state - fully confined at dispatch, quota available, and
+unreachable."""
 
 
 @dataclass(frozen=True)

--- a/src/deepr/backends/quota_headroom.py
+++ b/src/deepr/backends/quota_headroom.py
@@ -1,0 +1,167 @@
+"""How much of each plan is left, read without spending any of it.
+
+Deepr's own availability check dispatches a real request to each backend and
+reads the reply. That works, and it spends quota to discover whether there is
+quota, which is the wrong trade when the answer is "almost none".
+
+quotabot reads provider metadata and makes no model calls, so the same
+question costs nothing. When it is installed Deepr uses it to order and gate
+dispatch; when it is not, everything degrades to plain round-robin, because a
+missing optional tool must not become a hard dependency of the $0 path.
+
+Ordering by headroom rather than by speed is deliberate. Round-robin across
+four plans is fair and blind: it sends work to a plan at 95% of its five-hour
+window as readily as to one at 4% of its week, which exhausts the tight one
+and then fails over. Headroom ordering finishes the same run without touching
+the plan that was about to cap.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+_CACHE_TTL_S = 120.0
+"""Long enough that a fan-out reads it once, short enough to notice a cap.
+
+Re-reading per dispatch would turn a free check into a per-request subprocess
+launch, which is its own kind of spam even when no tokens are spent."""
+
+_EXHAUSTED_AT = 97.0
+"""Percent used above which a plan is skipped rather than merely deprioritized."""
+
+_cache: tuple[float, dict[str, PlanHeadroom]] | None = None
+
+
+@dataclass
+class PlanHeadroom:
+    """What is left on one plan, and when the tightest window resets."""
+
+    provider: str
+    ok: bool = True
+    used_percent: float = 0.0
+    """The tightest window's usage. A five-hour cap binds before a weekly one."""
+    window_label: str = ""
+    resets_in_s: float = 0.0
+    plan: str = ""
+    windows: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def headroom(self) -> float:
+        """Fraction of the tightest window still available, 0.0 to 1.0."""
+        return max(0.0, min(1.0, (100.0 - self.used_percent) / 100.0))
+
+    @property
+    def is_exhausted(self) -> bool:
+        return not self.ok or self.used_percent >= _EXHAUSTED_AT
+
+    def describe(self) -> str:
+        if not self.ok:
+            return f"{self.provider}: unavailable"
+        if not self.window_label:
+            return f"{self.provider}: no window reported"
+        minutes = int(self.resets_in_s / 60)
+        return f"{self.provider}: {self.used_percent:.0f}% of {self.window_label} used, resets in {minutes}m"
+
+
+def _tightest_window(windows: list[dict[str, Any]], now: float) -> tuple[float, str, float]:
+    """The window closest to its cap, since that is the one that will bind."""
+    best = (0.0, "", 0.0)
+    for window in windows or []:
+        try:
+            used = float(window.get("used_percent", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if used >= best[0]:
+            resets = float(window.get("resets_at", now) or now) - now
+            best = (used, str(window.get("label", "")), max(0.0, resets))
+    return best
+
+
+def parse_snapshot(payload: dict[str, Any], *, now: float | None = None) -> dict[str, PlanHeadroom]:
+    """Turn a quotabot snapshot into per-provider headroom."""
+    moment = now if now is not None else time.time()
+    out: dict[str, PlanHeadroom] = {}
+    for entry in payload.get("providers") or []:
+        provider = str(entry.get("provider", "")).strip().lower()
+        if not provider:
+            continue
+        windows = entry.get("windows") or []
+        used, label, resets = _tightest_window(windows, moment)
+        out[provider] = PlanHeadroom(
+            provider=provider,
+            ok=bool(entry.get("ok", True)),
+            used_percent=used,
+            window_label=label,
+            resets_in_s=resets,
+            plan=str(entry.get("plan") or ""),
+            windows=windows,
+        )
+    return out
+
+
+def read_headroom(*, force: bool = False, timeout_s: float = 25.0) -> dict[str, PlanHeadroom]:
+    """Current headroom per provider, or empty when quotabot is unavailable.
+
+    Never raises. An absent or broken quota tool means Deepr does not know how
+    much is left, which is the state it was already in, not a reason to stop.
+    """
+    global _cache
+    now = time.time()
+    if not force and _cache is not None and now - _cache[0] < _CACHE_TTL_S:
+        return _cache[1]
+
+    # Fixed argv with no interpolation, and the executable is resolved rather
+    # than left to PATH order at spawn time. Nothing from a corpus, a prompt or
+    # a config reaches this command line.
+    executable = shutil.which("quotabot")
+    if not executable:
+        return {}
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed argv, resolved path, no shell
+            [executable, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+            shell=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return {}
+    try:
+        parsed = parse_snapshot(json.loads(completed.stdout), now=now)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {}
+
+    _cache = (now, parsed)
+    return parsed
+
+
+def order_by_headroom(names: list[str] | tuple[str, ...], headroom: dict[str, PlanHeadroom]) -> list[str]:
+    """Most headroom first. Unknown plans keep their given order, in the middle.
+
+    A provider quotabot does not report is not assumed empty and not assumed
+    full; it sorts as if half used, so an unmeasured plan is neither preferred
+    nor starved.
+    """
+    ordered = list(names)
+    if not headroom:
+        return ordered
+
+    def key(name: str) -> tuple[float, int]:
+        plan = headroom.get(name.lower())
+        return (-(plan.headroom if plan else 0.5), ordered.index(name))
+
+    return sorted(ordered, key=key)
+
+
+def exhausted(names: list[str] | tuple[str, ...], headroom: dict[str, PlanHeadroom]) -> list[str]:
+    """Plans at or past their cap, so a caller can say what it skipped."""
+    return [n for n in names if (plan := headroom.get(n.lower())) is not None and plan.is_exhausted]

--- a/src/deepr/cli/commands/semantic/expert_command_registry.py
+++ b/src/deepr/cli/commands/semantic/expert_command_registry.py
@@ -24,6 +24,7 @@ from deepr.cli.commands.semantic import expert_consult_traces as _expert_consult
 from deepr.cli.commands.semantic import expert_fleet_health as _expert_fleet_health  # noqa: F401
 from deepr.cli.commands.semantic import expert_freshness as _expert_freshness  # noqa: F401
 from deepr.cli.commands.semantic import expert_gap_routes as _expert_gap_routes  # noqa: F401
+from deepr.cli.commands.semantic import expert_graph as _expert_graph  # noqa: F401
 from deepr.cli.commands.semantic import expert_learn_web as _expert_learn_web  # noqa: F401
 from deepr.cli.commands.semantic import expert_loop_status as _expert_loop_status  # noqa: F401
 from deepr.cli.commands.semantic import expert_maintenance as _expert_maintenance  # noqa: F401

--- a/src/deepr/cli/commands/semantic/expert_command_registry.py
+++ b/src/deepr/cli/commands/semantic/expert_command_registry.py
@@ -33,6 +33,7 @@ from deepr.cli.commands.semantic import expert_okf as _expert_okf  # noqa: F401
 from deepr.cli.commands.semantic import expert_outcomes as _expert_outcomes  # noqa: F401
 from deepr.cli.commands.semantic import expert_perspective as _expert_perspective  # noqa: F401
 from deepr.cli.commands.semantic import expert_portrait as _expert_portrait  # noqa: F401
+from deepr.cli.commands.semantic import expert_practice as _expert_practice  # noqa: F401
 from deepr.cli.commands.semantic import expert_profile_card_cmd as _expert_profile_card_cmd  # noqa: F401
 from deepr.cli.commands.semantic import expert_quality as _expert_quality  # noqa: F401
 from deepr.cli.commands.semantic import expert_self_model as _expert_self_model  # noqa: F401

--- a/src/deepr/cli/commands/semantic/expert_command_registry.py
+++ b/src/deepr/cli/commands/semantic/expert_command_registry.py
@@ -38,6 +38,7 @@ from deepr.cli.commands.semantic import expert_profile_card_cmd as _expert_profi
 from deepr.cli.commands.semantic import expert_quality as _expert_quality  # noqa: F401
 from deepr.cli.commands.semantic import expert_self_model as _expert_self_model  # noqa: F401
 from deepr.cli.commands.semantic import expert_source as _expert_source  # noqa: F401
+from deepr.cli.commands.semantic import expert_status as _expert_status  # noqa: F401
 from deepr.cli.commands.semantic import expert_study as _expert_study  # noqa: F401
 from deepr.cli.commands.semantic import expert_validate_export as _expert_validate_export  # noqa: F401
 from deepr.cli.commands.semantic import expert_viva as _expert_viva  # noqa: F401

--- a/src/deepr/cli/commands/semantic/expert_command_registry.py
+++ b/src/deepr/cli/commands/semantic/expert_command_registry.py
@@ -1,0 +1,40 @@
+"""Import every module that registers a command on the `expert` group.
+
+These imports used to sit at the bottom of ``experts.py``, which is
+grandfathered at a size cap it must not exceed. That made adding a command a
+guaranteed ratchet failure: the command lives in its own module for exactly
+the size reason, and then its one-line registration pushes the oversized file
+over anyway.
+
+Collecting them here means ``experts.py`` carries one import instead of
+twenty-odd, and adding a command touches a file with room in it.
+
+Import for side effects only. Each module decorates its function with
+``@expert.command(...)`` at import time, so importing is the registration.
+Nothing here should be called.
+"""
+
+from __future__ import annotations
+
+from deepr.cli.commands.semantic import expert_blueprint as _expert_blueprint  # noqa: F401
+from deepr.cli.commands.semantic import expert_cleanup as _expert_cleanup  # noqa: F401
+from deepr.cli.commands.semantic import expert_consult as _expert_consult  # noqa: F401
+from deepr.cli.commands.semantic import expert_consult_quality as _expert_consult_quality  # noqa: F401
+from deepr.cli.commands.semantic import expert_consult_traces as _expert_consult_traces  # noqa: F401
+from deepr.cli.commands.semantic import expert_fleet_health as _expert_fleet_health  # noqa: F401
+from deepr.cli.commands.semantic import expert_freshness as _expert_freshness  # noqa: F401
+from deepr.cli.commands.semantic import expert_gap_routes as _expert_gap_routes  # noqa: F401
+from deepr.cli.commands.semantic import expert_learn_web as _expert_learn_web  # noqa: F401
+from deepr.cli.commands.semantic import expert_loop_status as _expert_loop_status  # noqa: F401
+from deepr.cli.commands.semantic import expert_maintenance as _expert_maintenance  # noqa: F401
+from deepr.cli.commands.semantic import expert_memory_card as _expert_memory_card  # noqa: F401
+from deepr.cli.commands.semantic import expert_okf as _expert_okf  # noqa: F401
+from deepr.cli.commands.semantic import expert_outcomes as _expert_outcomes  # noqa: F401
+from deepr.cli.commands.semantic import expert_perspective as _expert_perspective  # noqa: F401
+from deepr.cli.commands.semantic import expert_portrait as _expert_portrait  # noqa: F401
+from deepr.cli.commands.semantic import expert_profile_card_cmd as _expert_profile_card_cmd  # noqa: F401
+from deepr.cli.commands.semantic import expert_quality as _expert_quality  # noqa: F401
+from deepr.cli.commands.semantic import expert_self_model as _expert_self_model  # noqa: F401
+from deepr.cli.commands.semantic import expert_study as _expert_study  # noqa: F401
+from deepr.cli.commands.semantic import expert_validate_export as _expert_validate_export  # noqa: F401
+from deepr.cli.commands.semantic import expert_viva as _expert_viva  # noqa: F401

--- a/src/deepr/cli/commands/semantic/expert_command_registry.py
+++ b/src/deepr/cli/commands/semantic/expert_command_registry.py
@@ -29,6 +29,7 @@ from deepr.cli.commands.semantic import expert_learn_web as _expert_learn_web  #
 from deepr.cli.commands.semantic import expert_loop_status as _expert_loop_status  # noqa: F401
 from deepr.cli.commands.semantic import expert_maintenance as _expert_maintenance  # noqa: F401
 from deepr.cli.commands.semantic import expert_memory_card as _expert_memory_card  # noqa: F401
+from deepr.cli.commands.semantic import expert_migrate as _expert_migrate  # noqa: F401
 from deepr.cli.commands.semantic import expert_okf as _expert_okf  # noqa: F401
 from deepr.cli.commands.semantic import expert_outcomes as _expert_outcomes  # noqa: F401
 from deepr.cli.commands.semantic import expert_perspective as _expert_perspective  # noqa: F401

--- a/src/deepr/cli/commands/semantic/expert_command_registry.py
+++ b/src/deepr/cli/commands/semantic/expert_command_registry.py
@@ -37,6 +37,7 @@ from deepr.cli.commands.semantic import expert_practice as _expert_practice  # n
 from deepr.cli.commands.semantic import expert_profile_card_cmd as _expert_profile_card_cmd  # noqa: F401
 from deepr.cli.commands.semantic import expert_quality as _expert_quality  # noqa: F401
 from deepr.cli.commands.semantic import expert_self_model as _expert_self_model  # noqa: F401
+from deepr.cli.commands.semantic import expert_source as _expert_source  # noqa: F401
 from deepr.cli.commands.semantic import expert_study as _expert_study  # noqa: F401
 from deepr.cli.commands.semantic import expert_validate_export as _expert_validate_export  # noqa: F401
 from deepr.cli.commands.semantic import expert_viva as _expert_viva  # noqa: F401

--- a/src/deepr/cli/commands/semantic/expert_fleet_health.py
+++ b/src/deepr/cli/commands/semantic/expert_fleet_health.py
@@ -16,7 +16,12 @@ import click
 
 from deepr.cli.colors import console, print_header, print_key_value
 from deepr.cli.commands.semantic.experts import expert
-from deepr.experts.expert_health import ExpertHealth, assess_expert, fleet_summary
+from deepr.experts.expert_health import (
+    ExpertHealth,
+    assess_expert,
+    fleet_summary,
+    last_consulted_days,
+)
 from deepr.experts.paths import canonical_expert_dir
 
 _GRADE_COLOR = {"S": "bright_green", "A": "green", "B": "cyan", "C": "yellow", "D": "yellow", "F": "red"}
@@ -33,8 +38,22 @@ def _belief_count(name: str) -> int:
 
 
 def collect_fleet(names: list[str]) -> list[ExpertHealth]:
-    """Assess every named expert from what is on disk."""
-    return [assess_expert(n, canonical_expert_dir(n), beliefs=_belief_count(n)) for n in names]
+    """Assess every named expert from what is on disk.
+
+    Consult recency comes from one scan of the shared trace log rather than
+    per expert, because it is a single append-only file and forty experts
+    would otherwise read it forty times.
+    """
+    consulted = last_consulted_days()
+    return [
+        assess_expert(
+            n,
+            canonical_expert_dir(n),
+            beliefs=_belief_count(n),
+            consulted_days_ago=consulted.get(n, -1),
+        )
+        for n in names
+    ]
 
 
 def _render_row(health: ExpertHealth) -> None:

--- a/src/deepr/cli/commands/semantic/expert_fleet_health.py
+++ b/src/deepr/cli/commands/semantic/expert_fleet_health.py
@@ -1,0 +1,103 @@
+"""CLI: `deepr expert health` - which experts are worth consulting.
+
+Forty experts is not inspectable by opening forty directories. This reads what
+is already on disk, grades each one for triage, and pairs every grade with the
+single most useful next action, because a letter on its own tells nobody what
+to do about it.
+
+$0. No model call, no network.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value
+from deepr.cli.commands.semantic.experts import expert
+from deepr.experts.expert_health import ExpertHealth, assess_expert, fleet_summary
+from deepr.experts.paths import canonical_expert_dir
+
+_GRADE_COLOR = {"S": "bright_green", "A": "green", "B": "cyan", "C": "yellow", "D": "yellow", "F": "red"}
+_GRADE_ORDER = {"F": 0, "D": 1, "C": 2, "B": 3, "A": 4, "S": 5}
+
+
+def _belief_count(name: str) -> int:
+    try:
+        from deepr.experts.beliefs import BeliefStore
+
+        return len(BeliefStore(name, read_only=True).beliefs)
+    except Exception:
+        return 0
+
+
+def collect_fleet(names: list[str]) -> list[ExpertHealth]:
+    """Assess every named expert from what is on disk."""
+    return [assess_expert(n, canonical_expert_dir(n), beliefs=_belief_count(n)) for n in names]
+
+
+def _render_row(health: ExpertHealth) -> None:
+    color = _GRADE_COLOR.get(health.grade, "white")
+    depth = f"{health.effective_origins:.1f}" if health.sources else "-"
+    console.print(
+        f"  [{color}]{health.grade}[/{color}]  {health.name[:38]:38s} "
+        f"src {health.sources:>3}  origins {depth:>4}  "
+        f"findings {health.findings:>3}  positions {health.positions:>2}"
+    )
+
+
+@expert.command(name="health")
+@click.option("--all", "show_all", is_flag=True, help="Include experts that are already consultable")
+@click.option("--json", "as_json", is_flag=True, help="Emit the fleet health JSON")
+def expert_health_cmd(show_all: bool, as_json: bool) -> None:
+    """Grade every expert and say what each one needs next ($0).
+
+    A grade is triage, not a verdict. Depth is counted by independent origin
+    rather than document, because thirty pages from one publisher is one
+    publisher's authority. An expert with no brief caps at C however large its
+    corpus: it has not landed anywhere, so it is a search index.
+
+    EXAMPLES:
+
+      deepr expert health              deepr expert health --all --json
+    """
+    from deepr.experts.profile import ExpertStore
+
+    names = [p.name for p in ExpertStore().list_all()]
+    fleet = sorted(collect_fleet(names), key=lambda h: (_GRADE_ORDER.get(h.grade, 9), -h.effective_origins, h.name))
+    summary = fleet_summary(fleet)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {"summary": summary, "experts": [h.to_dict() for h in fleet], "cost_usd": 0.0},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return
+
+    print_header("Expert fleet health")
+    print_key_value("Experts", str(summary["experts"]))
+    print_key_value("Consultable", f"{summary['consultable']} (formed a view, resting on checkable findings)")
+    print_key_value("Never studied", str(summary["never_studied"]))
+    print_key_value("Grades", ", ".join(f"{g}:{n}" for g, n in summary["by_grade"].items()))
+
+    needs_work = [h for h in fleet if not h.is_consultable]
+    shown = fleet if show_all else needs_work
+    if not shown:
+        console.print("\n[green]Every expert is consultable.[/green]")
+        return
+
+    heading = "Every expert" if show_all else "Needs work"
+    console.print(f"\n[bold]{heading}[/bold]  (grade, then thinnest first)\n")
+    for health in shown:
+        _render_row(health)
+        console.print(f"      [dim]{health.next_action}[/dim]")
+
+    if not show_all and len(needs_work) < len(fleet):
+        console.print(
+            f"\n[dim]{len(fleet) - len(needs_work)} consultable expert(s) hidden. Use --all to see them.[/dim]"
+        )
+    console.print("\n[dim]A grade is triage, not a verdict. Depth is independent origins, not documents.[/dim]")

--- a/src/deepr/cli/commands/semantic/expert_fleet_health.py
+++ b/src/deepr/cli/commands/semantic/expert_fleet_health.py
@@ -84,7 +84,10 @@ def expert_health_cmd(show_all: bool, as_json: bool) -> None:
     from deepr.experts.profile import ExpertStore
 
     names = [p.name for p in ExpertStore().list_all()]
-    fleet = sorted(collect_fleet(names), key=lambda h: (_GRADE_ORDER.get(h.grade, 9), -h.effective_origins, h.name))
+    # Thinnest first within a grade, matching what the heading promises. The
+    # sort was descending, so the experts most in need of sources sat at the
+    # bottom of a list whose whole purpose is showing what needs attention.
+    fleet = sorted(collect_fleet(names), key=lambda h: (_GRADE_ORDER.get(h.grade, 9), h.effective_origins, h.name))
     summary = fleet_summary(fleet)
 
     if as_json:

--- a/src/deepr/cli/commands/semantic/expert_graph.py
+++ b/src/deepr/cli/commands/semantic/expert_graph.py
@@ -32,6 +32,7 @@ from deepr.cli.commands.semantic.experts import expert
 from deepr.experts.evidence_graph import build_graph, render_graph
 from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.perspective_graph import render_perspective
+from deepr.utils.atomic_io import atomic_write_json
 
 
 def canonical_graph_path(expert_name: str) -> Path:
@@ -205,13 +206,13 @@ def expert_graph(name: str, out: str | None, write_markdown: bool, as_json: bool
 
     path = Path(out) if out else canonical_graph_path(profile.name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(graph.to_dict(), indent=2), encoding="utf-8")
+    atomic_write_json(path, graph.to_dict(), fsync=True)
 
     # The biography, beside the evidence. Two graphs answering two questions:
     # "why do you think that" and "who are you and what moved you".
     perspective = _build_perspective(profile.name, at=built_at)
     perspective_path = canonical_perspective_path(profile.name)
-    perspective_path.write_text(json.dumps(perspective.to_dict(), indent=2), encoding="utf-8")
+    atomic_write_json(perspective_path, perspective.to_dict(), fsync=True)
 
     if write_markdown:
         path.with_suffix(".md").write_text(render_graph(graph), encoding="utf-8")

--- a/src/deepr/cli/commands/semantic/expert_graph.py
+++ b/src/deepr/cli/commands/semantic/expert_graph.py
@@ -30,6 +30,7 @@ import click
 from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
 from deepr.cli.commands.semantic.experts import expert
 from deepr.experts.evidence_graph import build_graph, render_graph
+from deepr.experts.expert_layout import became_path, part_in
 from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.perspective_graph import render_perspective
 from deepr.utils.atomic_io import atomic_write_json
@@ -42,7 +43,7 @@ def canonical_graph_path(expert_name: str) -> Path:
 
 def canonical_perspective_path(expert_name: str) -> Path:
     """Where the expert's account of itself lives."""
-    return canonical_expert_dir(expert_name) / "graph" / "perspective.json"
+    return became_path(expert_name)
 
 
 def _build_perspective(expert_name: str, *, at: str) -> Any:
@@ -62,7 +63,7 @@ def _build_perspective(expert_name: str, *, at: str) -> Any:
 
     profile = None
     try:
-        profile = ExpertProfile.from_dict(json.loads((directory / "profile_card.json").read_text(encoding="utf-8")))
+        profile = ExpertProfile.from_dict(json.loads(part_in(directory, "self").read_text(encoding="utf-8")))
     except (json.JSONDecodeError, OSError, TypeError, ValueError):
         pass
 
@@ -71,7 +72,10 @@ def _build_perspective(expert_name: str, *, at: str) -> Any:
         viva = VivaResult(
             expert_name=expert_name,
             positions_that_moved=list(
-                json.loads((directory / "viva.json").read_text(encoding="utf-8")).get("positions_that_moved") or []
+                json.loads(part_in(directory, "met_examination").read_text(encoding="utf-8")).get(
+                    "positions_that_moved"
+                )
+                or []
             ),
         )
     except (json.JSONDecodeError, OSError, TypeError, ValueError):
@@ -184,8 +188,8 @@ def expert_graph(name: str, out: str | None, write_markdown: bool, as_json: bool
 
     profile = _load_profile(name)
     directory = canonical_expert_dir(profile.name)
-    study = load_study(directory / "study.json")
-    brief = load_brief(directory / "brief.json")
+    study = load_study(part_in(directory, "noticed"))
+    brief = load_brief(part_in(directory, "hold_current"))
 
     if study is None and brief is None:
         click.echo(

--- a/src/deepr/cli/commands/semantic/expert_graph.py
+++ b/src/deepr/cli/commands/semantic/expert_graph.py
@@ -1,0 +1,149 @@
+"""CLI: `deepr expert graph` - write down the chain the expert already holds.
+
+A finding records the sources its anchors were found in. A position records the
+findings it rests on. That is a two-hop path from a claim to a passage, and it
+has been kept as three flat lists in two files since the study pass existed, so
+the question it exists to answer had to be recomputed by hand every time.
+
+This materialises it. No model call and no network: every edge is copied from a
+field already on disk, which is why it can be rebuilt at any time and why it is
+free.
+
+Written to `<expert>/graph/evidence.json`, beside the concept graph the chat
+path builds. They are different graphs answering different questions - that one
+joins phrases by co-occurrence for retrieval, this one joins claims to passages
+for provenance - and neither replaces the other.
+
+$0.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
+from deepr.cli.commands.semantic.experts import expert
+from deepr.experts.evidence_graph import build_graph, render_graph
+from deepr.experts.paths import canonical_expert_dir
+
+
+def canonical_graph_path(expert_name: str) -> Path:
+    """Where the evidence graph lives, and where anything reading one looks."""
+    return canonical_expert_dir(expert_name) / "graph" / "evidence.json"
+
+
+def _load_profile(name: str) -> Any:
+    from deepr.experts.profile import ExpertStore
+
+    profile = ExpertStore().load(name)
+    if not profile:
+        click.echo(f"Error: Expert not found: {name}", err=True)
+        sys.exit(2)
+    return profile
+
+
+def _corpus_entries(expert_name: str) -> list[Any]:
+    """The retained sources, so an edge can only point at a real passage."""
+    try:
+        from deepr.experts.corpus_store import CorpusStore
+
+        return list(CorpusStore(expert_name).active_entries())
+    except Exception:
+        return []
+
+
+def _render_human(graph: Any, *, path: Path) -> None:
+    stats = graph.stats()
+    print_key_value(
+        "Graph",
+        f"{stats['sources']} source(s), {stats['findings']} finding(s), "
+        f"{stats['positions']} position(s), {stats['edges']} edge(s)",
+    )
+
+    if not stats["is_formed"]:
+        print_warning(
+            "No position reaches a source through a finding, so this is a pile of nodes "
+            "rather than a graph. Run study and brief first."
+        )
+
+    if graph.unsupported_positions:
+        console.print("\n[red]Positions that reach no source[/red]")
+        for node in graph.unsupported_positions:
+            console.print(f"  - {node.label}")
+        console.print("[dim]A claim whose bibliography cites empty pages. Re-brief or re-study.[/dim]")
+
+    if graph.unused_findings:
+        console.print(f"\n[yellow]{len(graph.unused_findings)} grounded finding(s) support no position[/yellow]")
+        console.print("[dim]Either the brief missed something or this part of the corpus was read for nothing.[/dim]")
+
+    if load_bearing := graph.load_bearing_sources():
+        console.print("\n[cyan]What the claims actually rest on[/cyan]")
+        for label, count in load_bearing:
+            console.print(f"  {count:>3} position(s)  {label}")
+
+    console.print()
+    print_success(f"Written to {path}")
+
+
+@expert.command(name="graph")
+@click.argument("name")
+@click.option("--out", type=click.Path(dir_okay=False, path_type=str), default=None, help="Write the graph JSON here")
+@click.option("--markdown", "write_markdown", is_flag=True, help="Also write the readable summary")
+@click.option("--json", "as_json", is_flag=True, help="Emit the graph JSON to stdout")
+def expert_graph(name: str, out: str | None, write_markdown: bool, as_json: bool) -> None:
+    """Build NAME's evidence graph from what is already on disk ($0, no model).
+
+    Nodes are sources, findings and positions; edges are the support each one
+    recorded. Nothing is inferred, so this is a change of storage rather than a
+    new claim and it can be rebuilt whenever the study or brief changes.
+
+    What it makes cheap: which positions reach no source at all, which grounded
+    findings nothing rests on, and which passages the claims actually trace
+    back to. All three are expensive to ask across two flat files.
+
+    EXAMPLES:
+
+      deepr expert graph "My Expert"
+      deepr expert graph "My Expert" --markdown
+    """
+    from deepr.experts.consult_context import load_brief, load_study
+
+    profile = _load_profile(name)
+    directory = canonical_expert_dir(profile.name)
+    study = load_study(directory / "study.json")
+    brief = load_brief(directory / "brief.json")
+
+    if study is None and brief is None:
+        click.echo(
+            f"Error: {profile.name} has neither a study nor a brief, so there is no chain to record. "
+            f'Run: deepr expert study "{profile.name}"',
+            err=True,
+        )
+        sys.exit(2)
+
+    graph = build_graph(
+        expert_name=profile.name,
+        study=study,
+        brief=brief,
+        corpus_entries=_corpus_entries(profile.name),
+        at=datetime.now(UTC).isoformat(),
+    )
+
+    path = Path(out) if out else canonical_graph_path(profile.name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(graph.to_dict(), indent=2), encoding="utf-8")
+
+    if write_markdown:
+        path.with_suffix(".md").write_text(render_graph(graph), encoding="utf-8")
+
+    if as_json:
+        click.echo(json.dumps(graph.to_dict(), indent=2))
+    else:
+        print_header(f"Evidence graph: {profile.name}")
+        _render_human(graph, path=path)

--- a/src/deepr/cli/commands/semantic/expert_graph.py
+++ b/src/deepr/cli/commands/semantic/expert_graph.py
@@ -31,11 +31,52 @@ from deepr.cli.colors import console, print_header, print_key_value, print_succe
 from deepr.cli.commands.semantic.experts import expert
 from deepr.experts.evidence_graph import build_graph, render_graph
 from deepr.experts.paths import canonical_expert_dir
+from deepr.experts.perspective_graph import render_perspective
 
 
 def canonical_graph_path(expert_name: str) -> Path:
     """Where the evidence graph lives, and where anything reading one looks."""
     return canonical_expert_dir(expert_name) / "graph" / "evidence.json"
+
+
+def canonical_perspective_path(expert_name: str) -> Path:
+    """Where the expert's account of itself lives."""
+    return canonical_expert_dir(expert_name) / "graph" / "perspective.json"
+
+
+def _build_perspective(expert_name: str, *, at: str) -> Any:
+    """Assemble the biography from what the expert wrote about itself.
+
+    Separate from the evidence graph on purpose. That one answers "why do you
+    think that" and is a fact structure. This one answers "who are you and
+    what moved you", and its nodes have no truth value - a commitment about
+    conduct is not a claim about the world, and it is still part of who the
+    expert is.
+    """
+    from deepr.experts.expert_profile_card import ExpertProfile
+    from deepr.experts.perspective_graph import build_perspective_graph
+    from deepr.experts.viva import VivaResult
+
+    directory = canonical_expert_dir(expert_name)
+
+    profile = None
+    try:
+        profile = ExpertProfile.from_dict(json.loads((directory / "profile_card.json").read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        pass
+
+    viva = None
+    try:
+        viva = VivaResult(
+            expert_name=expert_name,
+            positions_that_moved=list(
+                json.loads((directory / "viva.json").read_text(encoding="utf-8")).get("positions_that_moved") or []
+            ),
+        )
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        pass
+
+    return build_perspective_graph(expert_name=expert_name, profile=profile, viva=viva, at=at)
 
 
 def _load_profile(name: str) -> Any:
@@ -91,6 +132,32 @@ def _render_human(graph: Any, *, path: Path) -> None:
     print_success(f"Written to {path}")
 
 
+def _render_perspective_summary(perspective: Any, *, path: Path) -> None:
+    """Who the expert is, as distinct from what it can prove."""
+    console.print()
+    if perspective.chosen_name:
+        print_key_value("Calls itself", perspective.chosen_name)
+
+    stats = perspective.stats()
+    print_key_value(
+        "Perspective",
+        f"{stats['standpoints']} standpoint(s), {stats['shifts']} recorded change(s) of mind, "
+        f"{stats['pursuits']} open pursuit(s)",
+    )
+
+    if not perspective.has_a_history:
+        print_warning(
+            "Never recorded changing its mind. It may have read a great deal; nothing it read "
+            "has moved it, which is the state a new expert is already in."
+        )
+    else:
+        console.print("\n[bright_yellow]What moved it[/bright_yellow]")
+        for shift in perspective.shifts[:5]:
+            console.print(f"  - {shift.text}")
+
+    print_success(f"Written to {path}")
+
+
 @expert.command(name="graph")
 @click.argument("name")
 @click.option("--out", type=click.Path(dir_okay=False, path_type=str), default=None, help="Write the graph JSON here")
@@ -127,23 +194,32 @@ def expert_graph(name: str, out: str | None, write_markdown: bool, as_json: bool
         )
         sys.exit(2)
 
+    built_at = datetime.now(UTC).isoformat()
     graph = build_graph(
         expert_name=profile.name,
         study=study,
         brief=brief,
         corpus_entries=_corpus_entries(profile.name),
-        at=datetime.now(UTC).isoformat(),
+        at=built_at,
     )
 
     path = Path(out) if out else canonical_graph_path(profile.name)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(graph.to_dict(), indent=2), encoding="utf-8")
 
+    # The biography, beside the evidence. Two graphs answering two questions:
+    # "why do you think that" and "who are you and what moved you".
+    perspective = _build_perspective(profile.name, at=built_at)
+    perspective_path = canonical_perspective_path(profile.name)
+    perspective_path.write_text(json.dumps(perspective.to_dict(), indent=2), encoding="utf-8")
+
     if write_markdown:
         path.with_suffix(".md").write_text(render_graph(graph), encoding="utf-8")
+        perspective_path.with_suffix(".md").write_text(render_perspective(perspective), encoding="utf-8")
 
     if as_json:
         click.echo(json.dumps(graph.to_dict(), indent=2))
     else:
-        print_header(f"Evidence graph: {profile.name}")
+        print_header(f"Graphs: {profile.name}")
         _render_human(graph, path=path)
+        _render_perspective_summary(perspective, path=perspective_path)

--- a/src/deepr/cli/commands/semantic/expert_migrate.py
+++ b/src/deepr/cli/commands/semantic/expert_migrate.py
@@ -1,0 +1,97 @@
+"""CLI: `deepr expert migrate` - move experts into the point-of-view layout.
+
+The old file names were the names of the commands that wrote them. Listing an
+expert directory told you which processes had run, not what the expert was, and
+two of the names were actively misleading: `brief.json` and `positions.json`
+were the same subject stored twice, and `profile.json` and `profile_card.json`
+were different things sharing a word.
+
+This moves each expert to names that answer "what is this": `self.json`,
+`noticed/`, `hold/current.json` and `hold/history.json`, `became/`, `attend/`,
+`met/`. `corpus/` stays, being already named from the expert's side.
+
+Safe to run at any point, and safe to run twice. Readers resolve the old path
+when only the old path exists, so an expert migrates without a flag day and the
+fleet can be moved in any order. Default is a dry run, because a command that
+rearranges 57 directories should have to be asked twice.
+
+$0. Moves files, calls no model, touches no network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from deepr.cli.colors import console, print_header, print_success, print_warning
+from deepr.cli.commands.semantic.experts import expert
+from deepr.experts.expert_migration import ExpertMigration, migrate_all
+from deepr.experts.paths import canonical_expert_dir
+
+
+def _fleet_root() -> Path:
+    """The directory the experts live in.
+
+    Derived from a canonical expert path rather than reimplemented, so a change
+    to where experts are stored cannot leave this command pointing at a stale
+    location.
+    """
+    return canonical_expert_dir("probe").parent
+
+
+def _report(result: ExpertMigration) -> None:
+    console.print(f"[bold]{result.expert_name}[/bold]")
+    for old, new in result.moved:
+        console.print(f"  {old} -> {new}")
+    for dead in result.removed_dead_dirs:
+        console.print(f"  [dim]removed empty {dead}/[/dim]")
+    for old, new in result.conflicts:
+        print_warning(f"  {old} and {new} both exist; left alone, needs a human")
+    for dead in result.kept_nonempty_dead_dirs:
+        print_warning(f"  {dead}/ is a v1 directory with content in it; left alone")
+
+
+@expert.command("migrate")
+@click.option("--apply", "apply_changes", is_flag=True, help="Actually move files. Without this, only reports.")
+@click.option("--json", "as_json", is_flag=True, help="Machine-readable output.")
+def expert_migrate(apply_changes: bool, as_json: bool) -> None:
+    """Move experts to the layout named from the expert's point of view."""
+    results = migrate_all(_fleet_root(), dry_run=not apply_changes)
+    changed = [r for r in results if r.changed]
+    attention = [r for r in results if r.needs_attention]
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "applied": apply_changes,
+                    "experts": len(results),
+                    "changed": len(changed),
+                    "needs_attention": [r.expert_name for r in attention],
+                    "moves": {r.expert_name: r.moved for r in changed},
+                    "cost_usd": 0.0,
+                },
+                indent=2,
+            )
+        )
+        sys.exit(1 if attention else 0)
+
+    print_header("Migrate experts" + ("" if apply_changes else " (dry run)"))
+    for result in changed or attention:
+        _report(result)
+
+    if not changed and not attention:
+        print_success(f"All {len(results)} experts already use the current layout.")
+        return
+
+    console.print()
+    verb = "Moved" if apply_changes else "Would move"
+    console.print(f"{verb} files for {len(changed)} of {len(results)} experts.")
+    if attention:
+        print_warning(f"{len(attention)} need a human; nothing was changed for those.")
+    if not apply_changes:
+        console.print("[dim]Re-run with --apply to make these changes.[/dim]")
+    sys.exit(1 if attention else 0)

--- a/src/deepr/cli/commands/semantic/expert_perspective.py
+++ b/src/deepr/cli/commands/semantic/expert_perspective.py
@@ -39,6 +39,7 @@ from deepr.experts.cross_domain import (
     frame_material,
     render_reading,
 )
+from deepr.experts.expert_layout import part_in
 from deepr.experts.paths import canonical_expert_dir
 
 
@@ -65,7 +66,7 @@ def _build_context(expert_name: str, question: str) -> Any:
     from deepr.experts.corpus_store import CorpusStore
 
     directory = canonical_expert_dir(expert_name)
-    brief = load_brief(directory / "brief.json")
+    brief = load_brief(part_in(directory, "hold_current"))
     if brief is None:
         click.echo(
             f'Error: {expert_name} has no brief, so it holds no frame to lend. Run: deepr expert brief "{expert_name}"',
@@ -83,7 +84,7 @@ def _build_context(expert_name: str, question: str) -> Any:
         expert_name=expert_name,
         question=question,
         brief=brief,
-        result=load_study(directory / "study.json"),
+        result=load_study(part_in(directory, "noticed")),
         corpus=corpus,
     )
 

--- a/src/deepr/cli/commands/semantic/expert_perspective.py
+++ b/src/deepr/cli/commands/semantic/expert_perspective.py
@@ -1,0 +1,198 @@
+"""CLI: `deepr expert perspective` - ask an expert about something else entirely.
+
+The normal consult path forbids this, correctly. Positions are ranked against
+the question, dropped when they do not match, and an expert with no bearing
+evidence reports `uncovered` rather than answering from adjacent material.
+Answering outside your evidence while sounding evidenced is the failure the
+whole system is built against.
+
+This is a different mode, not a relaxation of that one. It never claims
+coverage; it claims a frame. Ask an expert on Chinese writing about furniture
+design and "what do your sources say about chairs" gets nothing, while "you
+have spent years on a system where meaning is carried by stroke order and the
+negative space inside a character - what does that make you notice here" gets
+something worth having.
+
+Two rules keep it honest, both enforced in ``cross_domain``: every observation
+names the mapping it rests on, and every reading says where the analogy breaks.
+An analogy presenting as evidence is fabrication with a citation attached.
+
+$0. Local or prepaid plan, one model call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value, print_success
+from deepr.cli.commands.semantic.experts import expert
+from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
+from deepr.experts.cross_domain import (
+    assemble_reading,
+    build_cross_domain_prompt,
+    frame_material,
+    render_reading,
+)
+from deepr.experts.paths import canonical_expert_dir
+
+
+def _load_profile(name: str) -> Any:
+    from deepr.experts.profile import ExpertStore
+
+    profile = ExpertStore().load(name)
+    if not profile:
+        click.echo(f"Error: Expert not found: {name}", err=True)
+        sys.exit(2)
+    return profile
+
+
+def _build_context(expert_name: str, question: str) -> Any:
+    """Assemble what this expert carries, without ranking it against the question.
+
+    The question is passed through only because the context builder wants one.
+    ``frame_material`` deliberately ignores the ranking: matching findings
+    against a question from another subject surfaces whatever shares
+    vocabulary with it, which is the least interesting thing an outside frame
+    has to offer and the most likely to look like false relevance.
+    """
+    from deepr.experts.consult_context import build_consult_context, load_brief, load_study
+    from deepr.experts.corpus_store import CorpusStore
+
+    directory = canonical_expert_dir(expert_name)
+    brief = load_brief(directory / "brief.json")
+    if brief is None:
+        click.echo(
+            f'Error: {expert_name} has no brief, so it holds no frame to lend. Run: deepr expert brief "{expert_name}"',
+            err=True,
+        )
+        sys.exit(2)
+
+    corpus: CorpusStore | None
+    try:
+        corpus = CorpusStore(expert_name)
+    except Exception:
+        corpus = None
+
+    return build_consult_context(
+        expert_name=expert_name,
+        question=question,
+        brief=brief,
+        result=load_study(directory / "study.json"),
+        corpus=corpus,
+    )
+
+
+def _parse_json(text: str) -> dict[str, Any]:
+    """Recover the object from a model that would not stay out of prose."""
+    candidate = (text or "").strip()
+    start, end = candidate.find("{"), candidate.rfind("}")
+    if start != -1 and end > start:
+        candidate = candidate[start : end + 1]
+    try:
+        parsed = json.loads(candidate)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+@expert.command(name="perspective")
+@click.argument("name")
+@click.argument("question")
+@click.option("--lens", "preferred_lens", default="", help="The reading of its own subject to lend")
+@click.option("--local", is_flag=True, help="Use local Ollama ($0)")
+@click.option("--plan", default=None, help="Prepaid plan backend id (e.g. claude)")
+@click.option("--plan-model", default=None, help="Model for the plan backend")
+@click.option("--model", default=None, help="Explicit local model")
+@click.option("--out", type=click.Path(dir_okay=False, path_type=str), default=None, help="Write the reading here")
+@click.option("--json", "as_json", is_flag=True, help="Emit the reading as JSON")
+def expert_perspective(
+    name: str,
+    question: str,
+    preferred_lens: str,
+    local: bool,
+    plan: str | None,
+    plan_model: str | None,
+    model: str | None,
+    out: str | None,
+    as_json: bool,
+) -> None:
+    """Ask NAME about QUESTION from outside its subject ($0).
+
+    This is analogy and every rendering says so. NAME's sources say nothing
+    about your question; what it lends is a way of looking, and the reading
+    states where that way of looking breaks.
+
+    Use `deepr expert consult` when you want the expert's evidence. Use this
+    when you want its frame, which is the thing that travels.
+
+    EXAMPLES:
+
+      deepr expert perspective "Chinese Writing Systems" "how should I design flat-pack furniture"
+      deepr expert perspective "Provenance and Belief Revision" "why do our migrations keep failing"
+    """
+    profile = _load_profile(name)
+    context = _build_context(profile.name, question)
+    material = frame_material(context)
+
+    if not material.strip():
+        click.echo(
+            f"Error: {profile.name} is briefed but carries no patterns to lend. Run study, then brief.",
+            err=True,
+        )
+        sys.exit(2)
+
+    try:
+        backend = build_study_backend(profile=profile, local=local, plan=plan, plan_model=plan_model, model=model)
+    except StudyBackendError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    if not as_json:
+        print_header(f"{profile.name}, on: {question}")
+        print_key_value("Capacity", backend.cost_note)
+        console.print("[dim]Analogy, not evidence. Check the mapping before relying on any of it.[/dim]")
+
+    prompt = build_cross_domain_prompt(
+        expert_name=profile.name,
+        question=question,
+        material=material,
+        standpoint=context.orientation,
+        preferred_lens=preferred_lens,
+    )
+
+    try:
+        raw = asyncio.run(backend.completion(prompt))
+    except Exception as exc:
+        click.echo(f"Error: the model call failed: {type(exc).__name__}: {exc}", err=True)
+        sys.exit(2)
+
+    reading = assemble_reading(
+        _parse_json(raw),
+        expert_name=profile.name,
+        question=question,
+        standpoint=context.orientation,
+        preferred_lens=preferred_lens,
+    )
+
+    # An empty reading is a real answer: a frame that does not reach the
+    # subject should say so, because a forced analogy is worse than none. It
+    # is not an error, so this exits 0 and renders the refusal.
+    if as_json:
+        click.echo(json.dumps(reading.to_dict(), indent=2))
+    else:
+        console.print()
+        console.print(render_reading(reading))
+
+    if out:
+        path = Path(out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(render_reading(reading), encoding="utf-8")
+        if not as_json:
+            console.print()
+            print_success(f"Written to {path}")

--- a/src/deepr/cli/commands/semantic/expert_practice.py
+++ b/src/deepr/cli/commands/semantic/expert_practice.py
@@ -35,6 +35,7 @@ import click
 from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
 from deepr.cli.commands.semantic.experts import expert
 from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
+from deepr.experts.expert_layout import attend_path, hold_current_path, part_in, self_path
 from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.research_practice import (
     ResearchPractice,
@@ -51,7 +52,7 @@ _MAX_MATERIAL_CHARS = 40_000
 
 def canonical_practice_path(expert_name: str) -> Path:
     """Where the practice lives, and where acquisition should read it."""
-    return canonical_expert_dir(expert_name) / "practice.json"
+    return attend_path(expert_name)
 
 
 def _load_profile(name: str) -> Any:
@@ -89,7 +90,7 @@ def _seed_from_artifacts(practice: ResearchPractice, expert_name: str, *, at: st
     """
     directory = canonical_expert_dir(expert_name)
 
-    viva = _read_json(directory / "viva.json")
+    viva = _read_json(part_in(directory, "met_examination"))
     open_pursuits(
         practice,
         [str(q) for q in (viva.get("reading_queue") or [])],
@@ -98,7 +99,7 @@ def _seed_from_artifacts(practice: ResearchPractice, expert_name: str, *, at: st
         why="an examiner found this answerable and I could not answer it",
     )
 
-    profile = _read_json(directory / "profile_card.json")
+    profile = _read_json(part_in(directory, "self"))
     open_pursuits(
         practice,
         [str(q) for q in (profile.get("open_questions") or [])],
@@ -121,7 +122,7 @@ def _material(expert_name: str) -> str:
     from deepr.experts.brief import render_brief
     from deepr.experts.consult_context import load_brief
 
-    brief = load_brief(canonical_expert_dir(expert_name) / "brief.json")
+    brief = load_brief(hold_current_path(expert_name))
     if brief is None:
         return ""
     return render_brief(brief)[:_MAX_MATERIAL_CHARS]
@@ -220,7 +221,7 @@ def expert_practice(
             print_header(f"Practice: {profile.name}")
             print_key_value("Capacity", backend.cost_note)
 
-        card = _read_json(canonical_expert_dir(profile.name) / "profile_card.json")
+        card = _read_json(self_path(profile.name))
         prompt = build_practice_prompt(
             expert_name=str(card.get("chosen_name") or profile.name),
             standpoint=str(card.get("standpoint") or ""),

--- a/src/deepr/cli/commands/semantic/expert_practice.py
+++ b/src/deepr/cli/commands/semantic/expert_practice.py
@@ -44,6 +44,7 @@ from deepr.experts.research_practice import (
     render_practice,
     update_watches,
 )
+from deepr.utils.atomic_io import atomic_write_json
 
 _MAX_MATERIAL_CHARS = 40_000
 
@@ -238,7 +239,7 @@ def expert_practice(
 
     path = canonical_practice_path(profile.name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(practice.to_dict(), indent=2), encoding="utf-8")
+    atomic_write_json(path, practice.to_dict(), fsync=True)
 
     if write_markdown:
         path.with_suffix(".md").write_text(render_practice(practice), encoding="utf-8")

--- a/src/deepr/cli/commands/semantic/expert_practice.py
+++ b/src/deepr/cli/commands/semantic/expert_practice.py
@@ -1,0 +1,251 @@
+"""CLI: `deepr expert practice` - what this expert is doing to stay expert.
+
+A specialist does not stay a specialist by having read a lot once. They keep a
+practice: questions they are actively chasing, sources they follow because
+those sources keep being worth reading, and areas they are deepening as
+distinct from areas they merely track. Next month's reading differs from last
+month's because of that, and it is what turns elapsed time into expertise.
+
+The work is split deliberately, and the split is the design:
+
+- **Measured, never asked.** Which sources the expert follows comes from the
+  evidence graph - the publishers its own positions actually rest on. Letting a
+  model rank them would reintroduce exactly the guessing that measuring them
+  replaced: an expert would follow what it finds appealing rather than what
+  carries its claims.
+- **Decided by the expert.** Which questions are now answered, which turned out
+  to be the wrong question, what it wants to know next, and where its attention
+  should go. Those are judgements, and a deterministic rule pretending to make
+  them would be the brittle-regex failure this project keeps correcting.
+
+$0. One model call on local or prepaid plan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
+from deepr.cli.commands.semantic.experts import expert
+from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
+from deepr.experts.paths import canonical_expert_dir
+from deepr.experts.research_practice import (
+    ResearchPractice,
+    apply_practice_update,
+    build_practice_prompt,
+    open_pursuits,
+    render_practice,
+    update_watches,
+)
+
+_MAX_MATERIAL_CHARS = 40_000
+
+
+def canonical_practice_path(expert_name: str) -> Path:
+    """Where the practice lives, and where acquisition should read it."""
+    return canonical_expert_dir(expert_name) / "practice.json"
+
+
+def _load_profile(name: str) -> Any:
+    from deepr.experts.profile import ExpertStore
+
+    profile = ExpertStore().load(name)
+    if not profile:
+        click.echo(f"Error: Expert not found: {name}", err=True)
+        sys.exit(2)
+    return profile
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _load_practice(expert_name: str) -> ResearchPractice:
+    stored = _read_json(canonical_practice_path(expert_name))
+    if not stored:
+        return ResearchPractice(expert_name=expert_name)
+    return ResearchPractice.from_dict(stored)
+
+
+def _seed_from_artifacts(practice: ResearchPractice, expert_name: str, *, at: str) -> None:
+    """Fold in the questions and sources the expert has already produced.
+
+    Both halves already exist and neither fed anything: a viva names exactly
+    what the expert could not answer but material exists to answer, and the
+    evidence graph knows which publishers the positions rest on. Until now the
+    first was a list in a file and the second was recomputed for a report.
+    """
+    directory = canonical_expert_dir(expert_name)
+
+    viva = _read_json(directory / "viva.json")
+    open_pursuits(
+        practice,
+        [str(q) for q in (viva.get("reading_queue") or [])],
+        origin="viva",
+        at=at,
+        why="an examiner found this answerable and I could not answer it",
+    )
+
+    profile = _read_json(directory / "profile_card.json")
+    open_pursuits(
+        practice,
+        [str(q) for q in (profile.get("open_questions") or [])],
+        origin="profile",
+        at=at,
+        why="I named this as something I am still working on",
+    )
+
+    graph = _read_json(directory / "graph" / "evidence.json")
+    load_bearing = [
+        (str(row.get("source") or ""), int(row.get("positions") or 0))
+        for row in (graph.get("load_bearing_sources") or [])
+        if isinstance(row, dict)
+    ]
+    update_watches(practice, load_bearing, at=at)
+
+
+def _material(expert_name: str) -> str:
+    """What the expert has read since, for reviewing its own questions against."""
+    from deepr.experts.brief import render_brief
+    from deepr.experts.consult_context import load_brief
+
+    brief = load_brief(canonical_expert_dir(expert_name) / "brief.json")
+    if brief is None:
+        return ""
+    return render_brief(brief)[:_MAX_MATERIAL_CHARS]
+
+
+def _parse_json(text: str) -> dict[str, Any]:
+    candidate = (text or "").strip()
+    start, end = candidate.find("{"), candidate.rfind("}")
+    if start != -1 and end > start:
+        candidate = candidate[start : end + 1]
+    try:
+        parsed = json.loads(candidate)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _render(practice: ResearchPractice, changed: dict[str, int], *, path: Path) -> None:
+    stats = practice.stats()
+    console.print()
+    print_key_value(
+        "Practice",
+        f"{stats['live_pursuits']} live pursuit(s), {stats['watches']} source(s) followed, "
+        f"{stats['deepening']} area(s) being deepened",
+    )
+    if any(changed.values()):
+        print_key_value(
+            "This round",
+            f"{changed['answered']} answered, {changed['abandoned']} abandoned, {changed['opened']} opened",
+        )
+
+    if not practice.is_practising:
+        print_warning(
+            "No live questions, or nowhere it is following. It is not keeping up with anything - "
+            "it is waiting to be re-researched."
+        )
+
+    if reading := practice.next_reading():
+        console.print("\n[cyan]What it would read next[/cyan]")
+        for item in reading:
+            console.print(f"  - {item}")
+
+    console.print()
+    print_success(f"Written to {path}")
+
+
+@expert.command(name="practice")
+@click.option("--local", is_flag=True, help="Use local Ollama ($0)")
+@click.option("--plan", default=None, help="Prepaid plan backend id (e.g. claude)")
+@click.option("--plan-model", default=None, help="Model for the plan backend")
+@click.option("--model", default=None, help="Explicit local model")
+@click.option("--show", is_flag=True, help="Show the current practice without updating it ($0, no model)")
+@click.option("--markdown", "write_markdown", is_flag=True, help="Also write the readable summary")
+@click.option("--json", "as_json", is_flag=True, help="Emit the practice JSON")
+@click.argument("name")
+def expert_practice(
+    name: str,
+    local: bool,
+    plan: str | None,
+    plan_model: str | None,
+    model: str | None,
+    show: bool,
+    write_markdown: bool,
+    as_json: bool,
+) -> None:
+    """Update what NAME is chasing, following, and paying attention to ($0).
+
+    Sources it follows are measured from which publishers its positions rest
+    on, so they cannot be argued for. Everything else is the expert's own
+    call: which questions its recent reading has answered, which turned out to
+    be the wrong question, what it wants to know next, and where to go deep.
+
+    The result is what an acquisition pass should read next - a question is a
+    better search than a topic string, and this is where the questions live.
+
+    EXAMPLES:
+
+      deepr expert practice "My Expert" --show
+      deepr expert practice "My Expert" --plan claude --markdown
+    """
+    profile = _load_profile(name)
+    at = datetime.now(UTC).isoformat()
+
+    practice = _load_practice(profile.name)
+    _seed_from_artifacts(practice, profile.name, at=at)
+    changed = {"answered": 0, "abandoned": 0, "opened": 0}
+
+    if not show:
+        try:
+            backend = build_study_backend(profile=profile, local=local, plan=plan, plan_model=plan_model, model=model)
+        except StudyBackendError as exc:
+            click.echo(f"Error: {exc}", err=True)
+            sys.exit(2)
+
+        if not as_json:
+            print_header(f"Practice: {profile.name}")
+            print_key_value("Capacity", backend.cost_note)
+
+        card = _read_json(canonical_expert_dir(profile.name) / "profile_card.json")
+        prompt = build_practice_prompt(
+            expert_name=str(card.get("chosen_name") or profile.name),
+            standpoint=str(card.get("standpoint") or ""),
+            practice=practice,
+            material=_material(profile.name),
+        )
+        try:
+            raw = asyncio.run(backend.completion(prompt))
+        except Exception as exc:
+            click.echo(f"Error: the model call failed: {type(exc).__name__}: {exc}", err=True)
+            sys.exit(2)
+
+        changed = apply_practice_update(practice, _parse_json(raw), at=at)
+    else:
+        practice.updated_at = at
+
+    path = canonical_practice_path(profile.name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(practice.to_dict(), indent=2), encoding="utf-8")
+
+    if write_markdown:
+        path.with_suffix(".md").write_text(render_practice(practice), encoding="utf-8")
+
+    if as_json:
+        click.echo(json.dumps(practice.to_dict(), indent=2))
+    else:
+        if show:
+            print_header(f"Practice: {profile.name}")
+        _render(practice, changed, path=path)

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -38,6 +38,7 @@ from deepr.experts.expert_profile_card import (
     build_profile_prompt,
     parse_profile,
 )
+from deepr.experts.model_provenance import record as provenance_record
 from deepr.experts.paths import canonical_expert_dir
 
 _MAX_MATERIAL_CHARS = 60_000
@@ -226,11 +227,18 @@ def expert_profile_cmd(
         )
         sys.exit(2)
 
+    # Stamp which model wrote this. A standpoint is the most model-dependent
+    # artifact an expert has: it is the one place the reading is asked for
+    # directly rather than derived from the corpus, so knowing what produced it
+    # matters more here than anywhere else.
+    payload = profile.to_dict()
+    payload["model_provenance"] = provenance_record(backend.capacity_source, backend.model).to_dict()
+
     path = canonical_profile_path(stored.name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(profile.to_dict(), indent=2), encoding="utf-8")
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
     if as_json:
-        click.echo(json.dumps(profile.to_dict(), indent=2))
+        click.echo(json.dumps(payload, indent=2))
     else:
         _render(profile, path=path)

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -1,0 +1,236 @@
+"""CLI: `deepr expert profile` - the expert's own account of how it reads its subject.
+
+Everything else in the expert loop is about the material: what was retained,
+what a lens found, which positions the findings support. None of it asks the
+expert what it now thinks, and that is the difference between an index and
+someone worth consulting.
+
+This is also the missing rung. `expert health` reads `standpoint` from
+`profile_card.json` for `has_perspective`, and nothing wrote that file, so the
+top of the ladder was unreachable and the next action said "run profile" for a
+command that did not exist.
+
+The shift history is the part that matters most. Every study recomputes the
+brief from the corpus, so nothing an expert concluded survives the next pass.
+A profile is append-only: when a re-read moves the standpoint, the old one is
+kept alongside what moved it. That history is the only place elapsed time
+turns into something an expert has rather than something it has merely done.
+
+$0. One model call, local or prepaid plan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
+from deepr.cli.commands.semantic.experts import expert
+from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
+from deepr.experts.expert_profile_card import (
+    ExpertProfile,
+    build_profile_prompt,
+    parse_profile,
+)
+from deepr.experts.paths import canonical_expert_dir
+
+_MAX_MATERIAL_CHARS = 60_000
+
+
+def canonical_profile_path(expert_name: str) -> Path:
+    """Where the profile lives, and where `expert health` looks for it."""
+    return canonical_expert_dir(expert_name) / "profile_card.json"
+
+
+def _load_profile(name: str) -> Any:
+    from deepr.experts.profile import ExpertStore
+
+    stored = ExpertStore().load(name)
+    if not stored:
+        click.echo(f"Error: Expert not found: {name}", err=True)
+        sys.exit(2)
+    return stored
+
+
+def _load_prior(expert_name: str) -> ExpertProfile | None:
+    """The previous profile, so a change of mind can be recognised as one."""
+    path = canonical_profile_path(expert_name)
+    if not path.exists():
+        return None
+    try:
+        return ExpertProfile.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        print_warning("Existing profile could not be read; writing a fresh one and losing its shift history.")
+        return None
+
+
+def _material(expert_name: str) -> tuple[str, str, int]:
+    """What the expert has read: its brief and what the study found.
+
+    Returns (material, corpus_fingerprint, sources_read). The fingerprint is
+    carried so a later profile can tell "I re-read the same corpus and changed
+    my mind" from "the corpus grew under me".
+    """
+    from deepr.experts.brief import render_brief
+    from deepr.experts.consult_context import load_brief, load_study
+
+    directory = canonical_expert_dir(expert_name)
+    brief = load_brief(directory / "brief.json")
+    if brief is None:
+        click.echo(
+            f"Error: {expert_name} has no brief, so it has not landed anywhere to describe. "
+            f'Run: deepr expert brief "{expert_name}"',
+            err=True,
+        )
+        sys.exit(2)
+
+    study = load_study(directory / "study.json")
+    fingerprint = getattr(study, "corpus_fingerprint", "") if study else ""
+    sources = int(getattr(getattr(study, "independence", None), "source_count", 0) or 0) if study else 0
+    return render_brief(brief)[:_MAX_MATERIAL_CHARS], fingerprint, sources
+
+
+def _parse_json(text: str) -> dict[str, Any]:
+    candidate = (text or "").strip()
+    start, end = candidate.find("{"), candidate.rfind("}")
+    if start != -1 and end > start:
+        candidate = candidate[start : end + 1]
+    try:
+        parsed = json.loads(candidate)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _render_lists(profile: ExpertProfile) -> None:
+    """The three lists, in the order someone choosing an expert wants them.
+
+    A table rather than three near-identical blocks: they differ only in
+    heading, colour and which attribute they read, and writing that out three
+    times is where the branch count came from.
+    """
+    sections = (
+        ("Would be glad to be asked about", "cyan", profile.glad_to_be_asked_about, False),
+        ("Still working on", "yellow", profile.open_questions, False),
+        ("Knows it is weak on", "dim", profile.where_it_is_weak, True),
+    )
+    for heading, colour, items, dim_items in sections:
+        if not items:
+            continue
+        console.print(f"\n[{colour}]{heading}[/{colour}]")
+        for item in items:
+            console.print(f"  [dim]- {item}[/dim]" if dim_items else f"  - {item}")
+
+
+def _render(profile: ExpertProfile, *, path: Path) -> None:
+    if profile.chosen_name:
+        print_key_value("Calls itself", profile.chosen_name)
+    if profile.standpoint:
+        console.print(f"\n[bright_white]{profile.standpoint}[/bright_white]")
+    if profile.preferred_lens:
+        console.print(f"\n[dim]Reads it best through: {profile.preferred_lens}[/dim]")
+
+    _render_lists(profile)
+
+    if profile.shifts:
+        console.print(f"\n[bright_yellow]Has changed its mind {len(profile.shifts)} time(s)[/bright_yellow]")
+        for shift in profile.shifts[-3:]:
+            console.print(f"  - was: {shift.was}")
+            console.print(f"    now: {shift.now}")
+            console.print(f"    [dim]because: {shift.because}[/dim]")
+
+    for note in profile.concerns():
+        print_warning(note)
+
+    console.print()
+    print_success(f"Written to {path}")
+
+
+@expert.command(name="profile")
+@click.argument("name")
+@click.option("--local", is_flag=True, help="Use local Ollama ($0)")
+@click.option("--plan", default=None, help="Prepaid plan backend id (e.g. claude)")
+@click.option("--plan-model", default=None, help="Model for the plan backend")
+@click.option("--model", default=None, help="Explicit local model")
+@click.option("--json", "as_json", is_flag=True, help="Emit the profile JSON")
+def expert_profile_cmd(
+    name: str,
+    local: bool,
+    plan: str | None,
+    plan_model: str | None,
+    model: str | None,
+    as_json: bool,
+) -> None:
+    """Ask NAME to account for how it reads its own subject ($0).
+
+    Produces a standpoint, what it thinks the real question is, what it is
+    still working on, where it knows it is weak, and what it would be glad to
+    be asked. `expert health` reads this for the perspective rung, and a
+    consult uses it to speak as itself rather than as a summary.
+
+    Re-running after new material is the point. If the standpoint moved, the
+    old one is kept with what moved it, because the history of changing its
+    mind is the part that cannot be recomputed.
+
+    EXAMPLES:
+
+      deepr expert profile "My Expert"
+      deepr expert profile "My Expert" --plan claude
+    """
+    stored = _load_profile(name)
+    material, fingerprint, sources = _material(stored.name)
+    prior = _load_prior(stored.name)
+
+    try:
+        backend = build_study_backend(profile=stored, local=local, plan=plan, plan_model=plan_model, model=model)
+    except StudyBackendError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    if not as_json:
+        print_header(f"Profile: {stored.name}")
+        print_key_value("Capacity", backend.cost_note)
+        if prior is not None:
+            print_key_value("Prior standpoint", "shown, so a change of mind can be recorded as one")
+
+    try:
+        raw = asyncio.run(backend.completion(build_profile_prompt(stored.name, material=material, prior=prior)))
+    except Exception as exc:
+        click.echo(f"Error: the model call failed: {type(exc).__name__}: {exc}", err=True)
+        sys.exit(2)
+
+    parsed = _parse_json(raw)
+    profile = parse_profile(
+        parsed,
+        expert_name=stored.name,
+        at=datetime.now(UTC).isoformat(),
+        prior=prior,
+        corpus_fingerprint=fingerprint,
+        sources_read=sources,
+    )
+
+    # Refuse before writing. An unparsed reply would otherwise replace a real
+    # profile with an empty one and take its whole shift history with it,
+    # which is the only unrecomputable thing in an expert's directory.
+    if not profile.has_standpoint:
+        click.echo(
+            "Error: the model returned no usable standpoint, so nothing was written. "
+            "Any existing profile has been left alone.",
+            err=True,
+        )
+        sys.exit(2)
+
+    path = canonical_profile_path(stored.name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(profile.to_dict(), indent=2), encoding="utf-8")
+
+    if as_json:
+        click.echo(json.dumps(profile.to_dict(), indent=2))
+    else:
+        _render(profile, path=path)

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -83,9 +83,16 @@ def _material(expert_name: str) -> tuple[str, str, int]:
 
     directory = canonical_expert_dir(expert_name)
     brief = load_brief(directory / "brief.json")
-    if brief is None:
+    if brief is None or not brief.positions:
+        # An empty brief is worse than a missing one, because it looks like
+        # material. Measured: a timed-out synthesis left a brief holding zero
+        # positions and only a limitation, and profiling against it produced a
+        # standpoint about the pipeline failing instead of about the subject.
+        # The "did it return a standpoint" check cannot catch that - a
+        # description of the failure is a perfectly non-empty standpoint.
+        detail = "has no brief" if brief is None else "has a brief holding no positions"
         click.echo(
-            f"Error: {expert_name} has no brief, so it has not landed anywhere to describe. "
+            f"Error: {expert_name} {detail}, so it has not landed anywhere to describe. "
             f'Run: deepr expert brief "{expert_name}"',
             err=True,
         )

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -33,6 +33,7 @@ import click
 from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
 from deepr.cli.commands.semantic.experts import expert
 from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
+from deepr.experts.expert_layout import part_in, self_path
 from deepr.experts.expert_profile_card import (
     ExpertProfile,
     build_profile_prompt,
@@ -47,7 +48,7 @@ _MAX_MATERIAL_CHARS = 60_000
 
 def canonical_profile_path(expert_name: str) -> Path:
     """Where the profile lives, and where `expert health` looks for it."""
-    return canonical_expert_dir(expert_name) / "profile_card.json"
+    return self_path(expert_name)
 
 
 def _load_profile(name: str) -> Any:
@@ -83,7 +84,7 @@ def _material(expert_name: str) -> tuple[str, str, int]:
     from deepr.experts.consult_context import load_brief, load_study
 
     directory = canonical_expert_dir(expert_name)
-    brief = load_brief(directory / "brief.json")
+    brief = load_brief(part_in(directory, "hold_current"))
     if brief is None or not brief.positions:
         # An empty brief is worse than a missing one, because it looks like
         # material. Measured: a timed-out synthesis left a brief holding zero
@@ -99,7 +100,7 @@ def _material(expert_name: str) -> tuple[str, str, int]:
         )
         sys.exit(2)
 
-    study = load_study(directory / "study.json")
+    study = load_study(part_in(directory, "noticed"))
     # The fingerprint lives on each LensOutcome, not on the result. Reading it
     # off the result returned "" every time, so the one field designed to
     # anchor a change of mind to a corpus state never held a value. Take the

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -92,7 +92,16 @@ def _material(expert_name: str) -> tuple[str, str, int]:
         sys.exit(2)
 
     study = load_study(directory / "study.json")
-    fingerprint = getattr(study, "corpus_fingerprint", "") if study else ""
+    # The fingerprint lives on each LensOutcome, not on the result. Reading it
+    # off the result returned "" every time, so the one field designed to
+    # anchor a change of mind to a corpus state never held a value. Take the
+    # newest lens's fingerprint: all lenses in a completed pass share one, and
+    # in a resumed pass the newest is the corpus the standpoint was formed on.
+    fingerprint = ""
+    for outcome in reversed(list(getattr(study, "outcomes", []) or [])) if study else []:
+        if candidate := str(getattr(outcome, "corpus_fingerprint", "") or ""):
+            fingerprint = candidate
+            break
     sources = int(getattr(getattr(study, "independence", None), "source_count", 0) or 0) if study else 0
     return render_brief(brief)[:_MAX_MATERIAL_CHARS], fingerprint, sources
 

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -40,6 +40,7 @@ from deepr.experts.expert_profile_card import (
 )
 from deepr.experts.model_provenance import record as provenance_record
 from deepr.experts.paths import canonical_expert_dir
+from deepr.utils.atomic_io import atomic_write_json
 
 _MAX_MATERIAL_CHARS = 60_000
 
@@ -252,7 +253,7 @@ def expert_profile_cmd(
 
     path = canonical_profile_path(stored.name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    atomic_write_json(path, payload, fsync=True)
 
     if as_json:
         click.echo(json.dumps(payload, indent=2))

--- a/src/deepr/cli/commands/semantic/expert_source.py
+++ b/src/deepr/cli/commands/semantic/expert_source.py
@@ -1,0 +1,223 @@
+"""CLI: `deepr expert source` - go and find material, then retain it.
+
+The link that was missing. `expert acquire` fetches URLs somebody already
+chose; `corpus_search` and `acquisition_plan` know how to *find* them and were
+never wired to a command, so sourcing an expert meant hand-assembling a list of
+links.
+
+Two ways to decide what to look for, and the second is the point:
+
+- **From a topic.** Six acquisition arms - descriptive, adversarial, genre,
+  primary, recency, terminology - because a searcher left to itself asks the
+  descriptive question six times and builds a corpus that agrees with itself.
+  The arms are enforced in code; the queries inside them are written by a
+  model, since templated queries are the brittle pattern.
+- **From the expert's own practice.** Its live pursuits *are* the queries. A
+  question the expert decided to chase is a better search than the subject
+  name, and an expert that keeps asking the topic string has learned nothing
+  about where to look. This is what makes acquisition month two differ from
+  acquisition month one.
+
+Politeness is structural rather than advisory. Queries are interleaved across
+arms so an early stop cannot skip the adversarial ones, requests are throttled,
+and the run stops as soon as the corpus spans enough distinct publishers -
+because the goal was never to run every query. Running them all put roughly 120
+requests at one free endpoint in a burst and got three builds rate-limited into
+returning nothing.
+
+$0. Free search, free fetch, and one model call to write the queries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
+from deepr.cli.commands.semantic.experts import expert
+from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
+from deepr.experts.paths import canonical_expert_dir
+
+
+def _load_profile(name: str) -> Any:
+    from deepr.experts.profile import ExpertStore
+
+    profile = ExpertStore().load(name)
+    if not profile:
+        click.echo(f"Error: Expert not found: {name}", err=True)
+        sys.exit(2)
+    return profile
+
+
+def _pursuit_queries(expert_name: str, limit: int) -> list[str]:
+    """The expert's own live questions, if it has a practice."""
+    from deepr.experts.research_practice import ResearchPractice
+
+    path = canonical_expert_dir(expert_name) / "practice.json"
+    try:
+        practice = ResearchPractice.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return []
+    return [p.question for p in practice.live_pursuits[:limit]]
+
+
+def _plan_from_pursuits(topic: str, questions: list[str]) -> Any:
+    """Wrap the expert's own questions as a plan.
+
+    Marked as one arm rather than spread across six: these queries were not
+    generated to cover the arms, and labelling them as though they were would
+    misreport the coverage the search actually achieved.
+    """
+    from deepr.experts.acquisition_plan import ARM_DESCRIPTIVE, AcquisitionPlan, AcquisitionQuery
+
+    plan = AcquisitionPlan(topic=topic)
+    plan.queries = [
+        AcquisitionQuery(text=q, arm=ARM_DESCRIPTIVE, rationale="a question this expert is chasing") for q in questions
+    ]
+    return plan
+
+
+def _resolve_queries(expert_name: str, topic: str, *, from_practice: bool, limit: int) -> list[str]:
+    """Decide what this run is searching for, refusing before any network call.
+
+    Both refusals exit rather than falling back to the topic string. An expert
+    asked to search its own pursuits and quietly given a generic topic search
+    instead would report success for work it did not do.
+    """
+    if not from_practice:
+        if not topic.strip():
+            click.echo("Error: give a TOPIC, or use --from-practice to search what the expert is chasing.", err=True)
+            sys.exit(2)
+        return []
+
+    if pursuits := _pursuit_queries(expert_name, limit):
+        return pursuits
+    click.echo(
+        f'Error: {expert_name} has no live pursuits to search. Run: deepr expert practice "{expert_name}"',
+        err=True,
+    )
+    sys.exit(2)
+
+
+async def _build_plan(topic: str, *, backend: Any, from_practice: list[str]) -> tuple[Any, str]:
+    """Decide what to search for. Returns the plan and how it was chosen."""
+    if from_practice:
+        return _plan_from_pursuits(topic, from_practice), "the expert's own live pursuits"
+
+    from deepr.experts.query_proposal import propose_plan
+
+    plan = await propose_plan(topic, completion=backend.completion)
+    return plan, "a six-arm acquisition plan"
+
+
+@expert.command(name="source")
+@click.argument("name")
+@click.argument("topic", required=False, default="")
+@click.option("--from-practice", is_flag=True, help="Search the expert's own live pursuits instead of a topic")
+@click.option("--target-hosts", default=8, show_default=True, help="Stop once the corpus spans this many publishers")
+@click.option("--max-urls", default=40, show_default=True, help="Ceiling on URLs collected")
+@click.option("--per-query", default=4, show_default=True, help="Results taken per query")
+@click.option("--local", is_flag=True, help="Use local Ollama to write the queries ($0)")
+@click.option("--plan", "plan_backend", default=None, help="Prepaid plan backend id (e.g. grok)")
+@click.option("--plan-model", default=None, help="Model for the plan backend")
+@click.option("--model", default=None, help="Explicit local model")
+@click.option("--dry-run", is_flag=True, help="Show the queries and the URLs found, retain nothing")
+def expert_source(
+    name: str,
+    topic: str,
+    from_practice: bool,
+    target_hosts: int,
+    max_urls: int,
+    per_query: int,
+    local: bool,
+    plan_backend: str | None,
+    plan_model: str | None,
+    model: str | None,
+    dry_run: bool,
+) -> None:
+    """Find material for NAME on TOPIC and retain it ($0).
+
+    With --from-practice the expert searches the questions it decided to chase
+    rather than the subject name, which is what makes a later acquisition
+    different from the first one.
+
+    Stops as soon as the corpus spans enough distinct publishers. The goal is a
+    corpus with independent origins, not a completed query list, and hammering
+    a free endpoint for queries that add nothing is both waste and abuse.
+
+    EXAMPLES:
+
+      deepr expert source "TKG Expert" "temporal knowledge graphs" --plan grok
+      deepr expert source "My Expert" --from-practice --plan grok
+    """
+    from deepr.experts.corpus_acquire import acquire_sources, default_fetch_page
+    from deepr.experts.corpus_search import run_search_plan
+    from deepr.experts.corpus_store import CorpusStore
+
+    profile = _load_profile(name)
+
+    pursuits = _resolve_queries(profile.name, topic, from_practice=from_practice, limit=per_query * 3)
+
+    try:
+        backend = build_study_backend(
+            profile=profile, local=local, plan=plan_backend, plan_model=plan_model, model=model
+        )
+    except StudyBackendError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    print_header(f"Source: {profile.name}")
+    print_key_value("Capacity", backend.cost_note)
+
+    async def _run() -> tuple[Any, Any]:
+        plan, how = await _build_plan(topic or profile.name, backend=backend, from_practice=pursuits)
+        print_key_value("Searching", f"{len(plan.queries)} query(ies) from {how}")
+        for query in plan.queries[:6]:
+            console.print(f"  [dim]{query.arm}: {query.text}[/dim]")
+
+        found = await run_search_plan(
+            plan,
+            per_query=per_query,
+            max_urls=max_urls,
+            target_hosts=target_hosts,
+            on_progress=lambda note: console.print(f"  [dim]{note}[/dim]"),
+        )
+        return plan, found
+
+    try:
+        _, found = asyncio.run(_run())
+    except Exception as exc:
+        click.echo(f"Error: the search failed: {type(exc).__name__}: {exc}", err=True)
+        sys.exit(2)
+
+    urls = [hit.url for hit in found.hits]
+    print_key_value("Found", f"{len(urls)} URL(s) across {len(found.distinct_hosts)} publisher(s)")
+    if found.stopped_early:
+        console.print(f"[dim]Stopped early: {found.stopped_early}[/dim]")
+
+    if not urls:
+        print_warning("Nothing found. The endpoint may be throttling; try again later rather than harder.")
+        sys.exit(2)
+
+    if dry_run:
+        for url in urls[:20]:
+            console.print(f"  {url}")
+        print_warning("Dry run: nothing retained.")
+        return
+
+    store = CorpusStore(profile.name)
+    before = len(store.active_entries())
+    report = asyncio.run(
+        acquire_sources(expert_name=profile.name, urls=urls, corpus=store, fetch_page=default_fetch_page())
+    )
+    after = len(store.active_entries())
+
+    console.print()
+    print_key_value("Retained", f"{after - before} new source(s), {after} in the corpus")
+    if failures := getattr(report, "failures", None):
+        print_warning(f"{len(failures)} fetch(es) failed and were skipped.")
+    print_success(f'Next: deepr expert study "{profile.name}" --plan {plan_backend or "grok"}')

--- a/src/deepr/cli/commands/semantic/expert_source.py
+++ b/src/deepr/cli/commands/semantic/expert_source.py
@@ -40,7 +40,7 @@ import click
 from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
 from deepr.cli.commands.semantic.experts import expert
 from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
-from deepr.experts.paths import canonical_expert_dir
+from deepr.experts.expert_layout import attend_path
 
 
 def _load_profile(name: str) -> Any:
@@ -57,7 +57,7 @@ def _pursuit_queries(expert_name: str, limit: int) -> list[str]:
     """The expert's own live questions, if it has a practice."""
     from deepr.experts.research_practice import ResearchPractice
 
-    path = canonical_expert_dir(expert_name) / "practice.json"
+    path = attend_path(expert_name)
     try:
         practice = ResearchPractice.from_dict(json.loads(path.read_text(encoding="utf-8")))
     except (json.JSONDecodeError, OSError, TypeError, ValueError):

--- a/src/deepr/cli/commands/semantic/expert_status.py
+++ b/src/deepr/cli/commands/semantic/expert_status.py
@@ -32,6 +32,7 @@ import click
 
 from deepr.cli.colors import console, print_header, print_key_value, print_warning
 from deepr.cli.commands.semantic.experts import expert
+from deepr.experts.expert_layout import resolve_relative
 from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.stage_contract import STAGES, evaluate_all, next_stage
 
@@ -67,7 +68,7 @@ def _read_artifacts(directory: Path) -> dict[str, dict[str, Any] | None]:
 
     artifacts: dict[str, dict[str, Any] | None] = {}
     for relative in sorted(wanted):
-        path = directory / relative
+        path = resolve_relative(directory, relative)
         if not path.exists():
             artifacts[relative] = None
             continue

--- a/src/deepr/cli/commands/semantic/expert_status.py
+++ b/src/deepr/cli/commands/semantic/expert_status.py
@@ -1,0 +1,141 @@
+"""CLI: `deepr expert status` - where one expert is in the loop, and why.
+
+The loop is seven stages, each writing a JSON file the next reads. Asked what
+was wrong with that as a harness, Deepr's own harness-design expert answered:
+
+    Loose JSON handoffs create hidden coupling. Schema drift, partial writes,
+    stale files, incompatible versions and missing provenance can silently
+    corrupt later stages. [...] Producing every JSON file does not prove the
+    final result is correct.
+
+Both halves happened here in one afternoon. A synthesis timed out; a brief was
+written holding zero positions; the command exited 0 printing the path. The
+profile stage read that file, found it present and parseable, and produced a
+standpoint about *the pipeline failing* rather than about the subject.
+
+``stage_contract`` encodes the fix declaratively. This is the surface that
+makes it visible: what is done, what is ready, what is blocked and by what, and
+- the one no existing view could show - what **failed**, meaning the artifact
+exists and does not carry what it promised.
+
+$0. Reads files, calls no model, touches no network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value, print_warning
+from deepr.cli.commands.semantic.experts import expert
+from deepr.experts.paths import canonical_expert_dir
+from deepr.experts.stage_contract import STAGES, evaluate_all, next_stage
+
+_STATUS_COLOR = {"done": "green", "ready": "cyan", "failed": "red", "blocked": "yellow"}
+
+_STATUS_MEANING = {
+    "done": "produced what it promised",
+    "ready": "inputs are satisfied, has not run",
+    "failed": "the artifact exists and carries nothing",
+    "blocked": "an input is missing or empty",
+}
+
+
+def _load_profile(name: str) -> Any:
+    from deepr.experts.profile import ExpertStore
+
+    profile = ExpertStore().load(name)
+    if not profile:
+        click.echo(f"Error: Expert not found: {name}", err=True)
+        sys.exit(2)
+    return profile
+
+
+def _read_artifacts(directory: Path) -> dict[str, dict[str, Any] | None]:
+    """Load every artifact the contract refers to, or None where unusable.
+
+    Missing and unparseable are deliberately the same value. An input that
+    cannot be read is no more usable than one that is absent, and treating a
+    corrupt file as present is how the corruption reaches the next stage.
+    """
+    wanted = {stage.produces for stage in STAGES if stage.produces}
+    wanted |= {requirement.artifact for stage in STAGES for requirement in stage.requires}
+
+    artifacts: dict[str, dict[str, Any] | None] = {}
+    for relative in sorted(wanted):
+        path = directory / relative
+        if not path.exists():
+            artifacts[relative] = None
+            continue
+        try:
+            if path.suffix == ".jsonl":
+                # The corpus index is a line-per-source log; the contract only
+                # asks how many are active, so count rather than parse each.
+                active = sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+                artifacts[relative] = {"active_count": active}
+            else:
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+                artifacts[relative] = loaded if isinstance(loaded, dict) else None
+        except (json.JSONDecodeError, OSError, TypeError, ValueError):
+            artifacts[relative] = None
+    return artifacts
+
+
+@expert.command(name="status")
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, help="Emit the stage states as JSON")
+def expert_status(name: str, as_json: bool) -> None:
+    """Show where NAME is in the loop, and what is blocking it ($0, no model).
+
+    Four states, and the third is the one no other view could show:
+
+    \b
+      done     produced what it promised
+      ready    inputs satisfied, has not run
+      failed   the artifact exists and carries nothing
+      blocked  an input is missing or empty
+
+    A stage that wrote a file is not a stage that produced a result. Checking
+    only for presence is what let a timed-out brief become a standpoint about
+    the pipeline failing.
+
+    EXAMPLES:
+
+      deepr expert status "My Expert"
+    """
+    profile = _load_profile(name)
+    states = evaluate_all(_read_artifacts(canonical_expert_dir(profile.name)))
+
+    if as_json:
+        payload = {
+            "expert": profile.name,
+            "stages": [state.to_dict() for state in states],
+            "next": (nxt.name if (nxt := next_stage(states)) else None),
+            "cost_usd": 0.0,
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    print_header(f"Status: {profile.name}")
+    for state in states:
+        colour = _STATUS_COLOR.get(state.status, "white")
+        console.print(f"  [{colour}]{state.status:8s}[/{colour}] {state.name:10s} [dim]{state.success_means}[/dim]")
+        for blocker in state.blockers:
+            console.print(f"             [dim]blocked: {blocker.reason}[/dim]")
+            console.print(f"             [dim]         fix with `deepr {blocker.fix}`[/dim]")
+
+    console.print()
+    if failed := [s for s in states if s.status == "failed"]:
+        print_warning(
+            f"{len(failed)} stage(s) wrote an artifact that carries nothing. Re-run those before "
+            "building on top of them - a later stage cannot tell the difference."
+        )
+
+    if nxt := next_stage(states):
+        print_key_value("Next", f"{nxt.name} - {_STATUS_MEANING[nxt.status]}")
+    else:
+        print_key_value("Next", "nothing; every stage has produced what it promised")

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -405,6 +405,7 @@ def expert_study(
                 max_corpus_chars=max_corpus_chars,
                 chunk_chars=backend.chunk_chars,
                 capacity_source=backend.capacity_source,
+                model=backend.model,
                 on_progress=None if as_json else _echo_progress,
                 checkpoint=_checkpoint_study(profile.name),
                 resume_from=_resume_source(profile.name, rebuild=rebuild),

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -123,10 +123,13 @@ def _resume_source(expert_name: str, *, rebuild: bool) -> list[Any] | None:
 
 
 def _resumable_outcomes(expert_name: str) -> list[Any]:
-    """Lens outcomes from an earlier pass over this same corpus.
+    """Lens outcomes from an earlier pass, for `run_study` to filter.
 
-    Keyed on nothing but the lens: a corpus that changed produces different
-    findings, so `--rebuild` is the honest option when sources moved.
+    Everything on disk is returned. Deciding what is still usable happens in
+    `run_study`, which fingerprints the corpus and discards any outcome formed
+    over different material, so a corpus that moved is re-read without anyone
+    passing `--rebuild`. That flag now means "re-read even though the corpus is
+    unchanged", not "re-read because it changed".
     """
     from deepr.experts.study_contracts import StudyResult
 

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -49,6 +49,51 @@ def canonical_brief_path(expert_name: str) -> Path:
     return canonical_expert_dir(expert_name) / "brief.json"
 
 
+def canonical_position_ledger_path(expert_name: str) -> Path:
+    """Where every version of every position this expert has held is kept."""
+    return canonical_expert_dir(expert_name) / "positions.json"
+
+
+def _live_positions(expert_name: str) -> list[Any]:
+    """Positions this expert currently holds, for the brief to restate or revise."""
+    from deepr.experts.position_ledger import load_ledger
+
+    try:
+        return list(load_ledger(canonical_position_ledger_path(expert_name), expert_name=expert_name).live)
+    except Exception:
+        return []
+
+
+def _record_positions(expert_name: str, brief: Any, result: Any) -> dict[str, int]:
+    """Fold this brief into the position ledger. Returns what changed.
+
+    Never fails the brief. A ledger write that goes wrong loses history, which
+    is bad; taking down a brief that a study just paid for is worse, and the
+    brief itself is still written either way.
+    """
+    from deepr.experts.position_ledger import load_ledger, record_brief
+    from deepr.experts.record_time import utc_now
+    from deepr.utils.atomic_io import atomic_write_json
+
+    path = canonical_position_ledger_path(expert_name)
+    try:
+        ledger = load_ledger(path, expert_name=expert_name)
+        # The corpus state this brief was formed over, so survival counts
+        # distinct material rather than distinct runs. Taken from the newest
+        # lens: all lenses in a completed pass share one fingerprint.
+        fingerprint = ""
+        for outcome in reversed(list(getattr(result, "outcomes", []) or [])):
+            if candidate := str(getattr(outcome, "corpus_fingerprint", "") or ""):
+                fingerprint = candidate
+                break
+
+        changed = record_brief(ledger, list(brief.positions), at=utc_now(), corpus_fingerprint=fingerprint)
+        atomic_write_json(path, ledger.to_dict(), fsync=True)
+        return changed
+    except Exception:
+        return {}
+
+
 def _checkpoint_study(expert_name: str):
     """Persist the pass after every lens.
 
@@ -612,6 +657,14 @@ def expert_brief(
         print_key_value("From findings", str(len(result.findings)))
         console.print("")
 
+    # Show the brief the questions this expert already takes a position on.
+    # Without it a re-brief is non-deterministic in phrasing, which silently
+    # destroys position identity: measured, the same corpus briefed twice
+    # produced seven differently-worded questions and restated none of the nine
+    # already held, so every thread closed and reopened and survival could
+    # never accumulate.
+    prior_positions = _live_positions(profile.name)
+
     brief = asyncio.run(
         build_brief(
             expert_name=profile.name,
@@ -619,13 +672,19 @@ def expert_brief(
             corpus=store,
             completion=backend.completion,
             domain=getattr(profile, "domain", "") or "",
+            prior_positions=prior_positions,
         )
     )
 
-    # Persist the structured form always, not only under --json. Rendering to
-    # markdown destroys every typed field - the likelihood band, the falsifier,
-    # what the position did not resolve - so a brief that only ever existed as
-    # prose could not be consulted, only read.
+    # Record what changed before writing the new brief. Every run used to
+    # discard the previous positions - likelihood bands, falsifiers, carried
+    # dissent - and derive fresh ones, so an expert that had existed six months
+    # had concluded nothing that outlived its last run. The ledger keeps the
+    # versions; brief.json stays the current view, because every reader in the
+    # system loads it and changing its shape to serve one new reader would
+    # break all of them.
+    changed = _record_positions(profile.name, brief, result)
+
     payload = json.dumps(brief.to_dict(), indent=2, sort_keys=True)
     atomic_write_json(canonical_brief_path(profile.name), brief.to_dict(), sort_keys=True, fsync=True)
 
@@ -648,6 +707,21 @@ def expert_brief(
         reason = brief.limitations[0] if brief.limitations else "no positions were produced"
         click.echo(f"Error: the brief holds no positions, so it is not consultable. {reason}", err=True)
         sys.exit(2)
+
+    if changed and any(changed.values()):
+        # What moved is the interesting part of a re-brief, and it was
+        # previously invisible: the file was overwritten and nothing said
+        # whether the expert had changed its mind or merely restated itself.
+        console.print(
+            f"\n[dim]Positions: {changed.get('new', 0)} new, {changed.get('revised', 0)} revised, "
+            f"{changed.get('unchanged', 0)} unchanged, {changed.get('not_restated', 0)} not restated.[/dim]"
+        )
+        if changed.get("not_restated"):
+            print_warning(
+                f"{changed['not_restated']} position(s) this expert held were not restated by this brief. "
+                "They are closed in the ledger rather than deleted; check whether the corpus moved or the "
+                "reading did."
+            )
 
     print_success(f"Brief: {target}")
     for warning in brief.integrity_warnings():

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -26,6 +26,7 @@ from deepr.cli.colors import console, print_header, print_key_value, print_succe
 from deepr.cli.commands.semantic.experts import expert
 from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
 from deepr.experts.corpus_store import CorpusStore
+from deepr.experts.expert_layout import hold_current_path, hold_history_path, hold_rendered_path, noticed_path
 from deepr.experts.notebook import NOTEBOOK_MARKER, build_notebook
 from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.study import run_study
@@ -41,17 +42,17 @@ def canonical_study_path(expert_name: str) -> Path:
     One function rather than a repeated literal: study wrote nowhere by default
     while brief read from here, so briefing a finished study meant rerunning it.
     """
-    return canonical_expert_dir(expert_name) / "study.json"
+    return noticed_path(expert_name)
 
 
 def canonical_brief_path(expert_name: str) -> Path:
     """Where the structured brief lives, for anything that wants to consult it."""
-    return canonical_expert_dir(expert_name) / "brief.json"
+    return hold_current_path(expert_name)
 
 
 def canonical_position_ledger_path(expert_name: str) -> Path:
     """Where every version of every position this expert has held is kept."""
-    return canonical_expert_dir(expert_name) / "positions.json"
+    return hold_history_path(expert_name)
 
 
 def _live_positions(expert_name: str) -> list[Any]:
@@ -587,7 +588,6 @@ def _render_study_summary(result: Any) -> None:
 
 
 def _write_notebook(profile: Any, result: Any, store: CorpusStore, *, quiet: bool) -> None:
-    from deepr.experts.paths import canonical_expert_dir
 
     path = canonical_expert_dir(profile.name) / "notebook.md"
     if path.exists() and NOTEBOOK_MARKER not in path.read_text(encoding="utf-8", errors="replace"):
@@ -693,7 +693,8 @@ def expert_brief(
         return
 
     text = render_brief(brief)
-    target = Path(out) if out else canonical_expert_dir(profile.name) / "brief.md"
+    target = Path(out) if out else hold_rendered_path(profile.name)
+    target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(text, encoding="utf-8")
     console.print(text)
 
@@ -762,7 +763,6 @@ def expert_notebook(name: str, from_study: str | None, out: str | None) -> None:
     this file is safe to delete.
     """
     profile = _load_profile(name)
-    from deepr.experts.paths import canonical_expert_dir
 
     result = _load_study_result(profile, from_study)
     store = CorpusStore(profile.name)

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -30,6 +30,7 @@ from deepr.experts.notebook import NOTEBOOK_MARKER, build_notebook
 from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.study import run_study
 from deepr.experts.study_lenses import DEFAULT_LENS_KEYS, LENSES, resolve_lenses
+from deepr.utils.atomic_io import atomic_write_json
 
 _MAX_SOURCE_CHARS = 400_000
 
@@ -58,9 +59,11 @@ def _checkpoint_study(expert_name: str):
 
     def _write(result: Any) -> None:
         try:
-            canonical_study_path(expert_name).write_text(
-                json.dumps(result.to_dict(), indent=2, sort_keys=True), encoding="utf-8"
-            )
+            # Atomic, because this is the write most likely to be interrupted:
+            # it rewrites the whole file after every lens across a run lasting
+            # hours. A bare write_text that dies partway leaves a truncated
+            # study.json, and the next stage reads it as the expert's findings.
+            atomic_write_json(canonical_study_path(expert_name), result.to_dict(), sort_keys=True, fsync=True)
         except OSError:
             # A failed checkpoint must not end a run that is otherwise fine.
             pass
@@ -426,7 +429,7 @@ def expert_study(
     # Always persist to the canonical path, because that is where `expert
     # brief` and `expert notebook` look. Requiring --out meant a study that
     # cost real time to produce could not be briefed from without rerunning it.
-    canonical_study_path(profile.name).write_text(serialized, encoding="utf-8")
+    atomic_write_json(canonical_study_path(profile.name), payload, sort_keys=True, fsync=True)
     if out:
         Path(out).write_text(serialized, encoding="utf-8")
     if write_notebook:
@@ -624,7 +627,7 @@ def expert_brief(
     # what the position did not resolve - so a brief that only ever existed as
     # prose could not be consulted, only read.
     payload = json.dumps(brief.to_dict(), indent=2, sort_keys=True)
-    canonical_brief_path(profile.name).write_text(payload, encoding="utf-8")
+    atomic_write_json(canonical_brief_path(profile.name), brief.to_dict(), sort_keys=True, fsync=True)
 
     if as_json:
         click.echo(payload)

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -634,6 +634,18 @@ def expert_brief(
     target = Path(out) if out else canonical_expert_dir(profile.name) / "brief.md"
     target.write_text(text, encoding="utf-8")
     console.print(text)
+
+    # A brief with no positions is a failed brief, whatever else went right.
+    # Measured: a synthesis call timed out, the empty brief was written with
+    # the failure recorded only as a limitation, and the command exited 0
+    # printing the path as though it had worked. `expert profile` then read it
+    # and produced a standpoint about the pipeline failing rather than about
+    # the subject. Exiting 2 stops that chain at the first link.
+    if not brief.positions:
+        reason = brief.limitations[0] if brief.limitations else "no positions were produced"
+        click.echo(f"Error: the brief holds no positions, so it is not consultable. {reason}", err=True)
+        sys.exit(2)
+
     print_success(f"Brief: {target}")
     for warning in brief.integrity_warnings():
         print_warning(warning)

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -48,6 +48,48 @@ def canonical_brief_path(expert_name: str) -> Path:
     return canonical_expert_dir(expert_name) / "brief.json"
 
 
+def _checkpoint_study(expert_name: str):
+    """Persist the pass after every lens.
+
+    A study is tens of model calls over many minutes. Holding all of it in
+    memory until the end means one interruption throws away work that already
+    succeeded and was already paid for.
+    """
+
+    def _write(result: Any) -> None:
+        try:
+            canonical_study_path(expert_name).write_text(
+                json.dumps(result.to_dict(), indent=2, sort_keys=True), encoding="utf-8"
+            )
+        except OSError:
+            # A failed checkpoint must not end a run that is otherwise fine.
+            pass
+
+    return _write
+
+
+def _resume_source(expert_name: str, *, rebuild: bool) -> list[Any] | None:
+    """Completed lenses to reuse, or None when the operator asked for a re-read."""
+    return None if rebuild else _resumable_outcomes(expert_name)
+
+
+def _resumable_outcomes(expert_name: str) -> list[Any]:
+    """Lens outcomes from an earlier pass over this same corpus.
+
+    Keyed on nothing but the lens: a corpus that changed produces different
+    findings, so `--rebuild` is the honest option when sources moved.
+    """
+    from deepr.experts.study_contracts import StudyResult
+
+    path = canonical_study_path(expert_name)
+    if not path.exists():
+        return []
+    try:
+        return StudyResult.from_dict(json.loads(path.read_text(encoding="utf-8"))).outcomes
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return []
+
+
 def _echo_progress(note: str) -> None:
     """Show where a study has got to, flushed so it appears while it runs.
 
@@ -297,6 +339,11 @@ def expert_corpus(name: str, as_json: bool) -> None:
     is_flag=True,
     help="Leave the local model resident after the run (default: release VRAM)",
 )
+@click.option(
+    "--rebuild",
+    is_flag=True,
+    help="Re-read every lens instead of resuming ones an earlier pass completed",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit the study JSON to stdout")
 def expert_study(
     name: str,
@@ -310,6 +357,7 @@ def expert_study(
     out: str | None,
     write_notebook: bool,
     keep_warm: bool,
+    rebuild: bool,
     as_json: bool,
 ) -> None:
     """Read NAME's retained corpus through several lenses ($0 local or plan).
@@ -358,6 +406,8 @@ def expert_study(
                 chunk_chars=backend.chunk_chars,
                 capacity_source=backend.capacity_source,
                 on_progress=None if as_json else _echo_progress,
+                checkpoint=_checkpoint_study(profile.name),
+                resume_from=_resume_source(profile.name, rebuild=rebuild),
             )
         finally:
             # Pin weights during the run, release at the end. Leaving a large

--- a/src/deepr/cli/commands/semantic/expert_viva.py
+++ b/src/deepr/cli/commands/semantic/expert_viva.py
@@ -32,6 +32,7 @@ from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_s
 from deepr.experts.paths import canonical_expert_dir
 from deepr.experts.viva import VivaResult, render_viva
 from deepr.experts.viva_session import DEFAULT_PANEL, Examiner, run_viva
+from deepr.utils.atomic_io import atomic_write_json
 
 _MAX_BRIEF_CHARS = 60_000
 """What an examiner is shown. A brief is small; this is a runaway guard, not a
@@ -251,7 +252,7 @@ def expert_viva(
 
     path = Path(out) if out else canonical_viva_path(profile.name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    atomic_write_json(path, payload, fsync=True)
 
     if write_markdown:
         markdown_path = path.with_suffix(".md")

--- a/src/deepr/cli/commands/semantic/expert_viva.py
+++ b/src/deepr/cli/commands/semantic/expert_viva.py
@@ -1,0 +1,263 @@
+"""CLI: `deepr expert viva` - examine an expert, where nobody has the answer key.
+
+The evaluation problem this solves: how do you find out whether an expert
+understands its subject when there is no ground truth, and nobody available
+already knows? A doctoral viva answers it, and the reason it works is the part
+that looks like a defect - the examiners frequently do not know the answer to
+what they are asking. They probe rather than mark, and both sides come out
+knowing more than they went in with.
+
+The outputs are a transcript, a reading list, and occasionally a position that
+did not survive a good question. Not a score: compressing this to a letter
+would discard the part worth having, and `deepr expert health` already covers
+the letter-shaped question.
+
+$0. Local or prepaid plan, the same capacity story as `expert study`, and no
+route to a metered API from here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+
+from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
+from deepr.cli.commands.semantic.experts import expert
+from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
+from deepr.experts.paths import canonical_expert_dir
+from deepr.experts.viva import VivaResult, render_viva
+from deepr.experts.viva_session import DEFAULT_PANEL, Examiner, run_viva
+
+_MAX_BRIEF_CHARS = 60_000
+"""What an examiner is shown. A brief is small; this is a runaway guard, not a
+budget, and a brief that hits it is a brief with something wrong with it."""
+
+
+def canonical_viva_path(expert_name: str) -> Path:
+    """Where an examination is written, and where anything reading one looks."""
+    return canonical_expert_dir(expert_name) / "viva.json"
+
+
+def _load_profile(name: str) -> Any:
+    from deepr.experts.profile import ExpertStore
+
+    profile = ExpertStore().load(name)
+    if not profile:
+        click.echo(f"Error: Expert not found: {name}", err=True)
+        sys.exit(2)
+    return profile
+
+
+def _load_brief_text(expert_name: str) -> str:
+    """Render the brief the candidate will be examined on.
+
+    Exits rather than examining an unbriefed expert. A viva probes whether the
+    thinking under a position is load-bearing; with no positions there is
+    nothing to probe, and the examination would be three model calls producing
+    a document that says so.
+    """
+    from deepr.experts.brief import render_brief
+    from deepr.experts.consult_context import load_brief
+
+    brief = load_brief(canonical_expert_dir(expert_name) / "brief.json")
+    if brief is None:
+        click.echo(
+            f"Error: {expert_name} has no brief, so it holds no positions to examine. "
+            f'Run: deepr expert brief "{expert_name}"',
+            err=True,
+        )
+        sys.exit(2)
+    return render_brief(brief)[:_MAX_BRIEF_CHARS]
+
+
+def _panel_from_experts(names: tuple[str, ...]) -> list[Examiner]:
+    """Borrow other experts as examiners, each standing where it actually stands.
+
+    Better than the default panel, because a frame built against real material
+    notices things a frame described in one sentence does not. An examiner with
+    no standpoint of its own is dropped rather than sent in with an empty one:
+    it would revert to asking the subject's own obvious questions, which the
+    candidate has already answered in its brief.
+    """
+    from deepr.experts.consult_context import load_brief
+
+    panel: list[Examiner] = []
+    for name in names:
+        brief = load_brief(canonical_expert_dir(name) / "brief.json")
+        if brief is None:
+            print_warning(f"Skipping examiner {name}: no brief, so it has no standpoint to ask from.")
+            continue
+        orientation = (brief.orientation or "").strip()
+        if not orientation:
+            print_warning(f"Skipping examiner {name}: briefed but holds no orientation of its own.")
+            continue
+        panel.append(
+            Examiner(name=name, frame=f'your work on "{name}", where you read the subject like this: {orientation}')
+        )
+    return panel
+
+
+def _route_gaps(result: VivaResult) -> list[dict[str, Any]]:
+    """Say which instrument would fill each gap, and what it would cost.
+
+    A reading list nobody can act on is a document. This does not dispatch
+    anything - it runs the same advisory router `expert gap-routes` uses, so
+    the transcript carries a costed next step per gap instead of a wish.
+
+    Router failure is reported and does not fail the examination: the
+    transcript is already written and is the expensive part.
+    """
+    if not result.gaps:
+        return []
+    try:
+        from deepr.core.contracts import Gap
+        from deepr.experts.gap_router import GapRouter
+        from deepr.experts.gap_scorer import score_gap
+
+        router = GapRouter()
+        return [router.route_gap(score_gap(Gap.create(**payload))).to_dict() for payload in result.as_gaps()]
+    except Exception as exc:
+        print_warning(f"Could not route {len(result.gaps)} gap(s): {exc}")
+        return []
+
+
+def _render_human(result: VivaResult, *, path: Path, routes: list[dict[str, Any]]) -> None:
+    console.print()
+    print_key_value("Examination", result.summary())
+
+    if result.positions_that_moved:
+        console.print("\n[bright_yellow]Moved under questioning[/bright_yellow]")
+        for item in result.positions_that_moved:
+            console.print(f"  - {item}")
+
+    if result.gaps:
+        console.print("\n[cyan]Answerable, and unanswered[/cyan]")
+        by_topic = {r.get("topic", ""): r for r in routes}
+        for exchange, item in zip(result.gaps, result.reading_queue(), strict=False):
+            console.print(f"  - {item}")
+            route = by_topic.get(f"Viva gap ({result.expert_name}): {exchange.would_resolve_it}")
+            if route:
+                cost = route.get("estimated_cost", 0.0)
+                console.print(f"    [dim]{route.get('instrument')}, about ${cost:.2f}[/dim]")
+
+    if result.frontier:
+        console.print("\n[dim]Where the field itself has not settled[/dim]")
+        for exchange in result.frontier:
+            console.print(f"  [dim]- {exchange.question}[/dim]")
+
+    console.print()
+    print_success(f"Written to {path}")
+
+
+@expert.command(name="viva")
+@click.argument("name")
+@click.option(
+    "--examiner",
+    "examiners",
+    multiple=True,
+    help="Another expert to examine this one (repeatable). Defaults to a three-standpoint panel.",
+)
+@click.option("--questions", default=4, show_default=True, help="Questions per examiner")
+@click.option("--local", is_flag=True, help="Use local Ollama ($0)")
+@click.option("--plan", default=None, help="Prepaid plan backend id (e.g. claude)")
+@click.option("--plan-model", default=None, help="Model for the plan backend")
+@click.option("--model", default=None, help="Explicit local model")
+@click.option("--out", type=click.Path(dir_okay=False, path_type=str), default=None, help="Write the viva JSON here")
+@click.option("--markdown", "write_markdown", is_flag=True, help="Also write the transcript as Markdown")
+@click.option("--json", "as_json", is_flag=True, help="Emit the viva JSON to stdout")
+def expert_viva(
+    name: str,
+    examiners: tuple[str, ...],
+    questions: int,
+    local: bool,
+    plan: str | None,
+    plan_model: str | None,
+    model: str | None,
+    out: str | None,
+    write_markdown: bool,
+    as_json: bool,
+) -> None:
+    """Examine NAME by questioning, and find out what it cannot answer ($0).
+
+    Examiners probe from their own standpoint rather than as second
+    specialists, because a frame built elsewhere notices what an insider has
+    stopped seeing. They are not marking against an answer key and are not
+    expected to know the subject.
+
+    What comes out is a transcript, the questions it could not answer that
+    material exists to answer, the ones nobody can answer, and any position the
+    expert withdrew under questioning. There is no grade - `deepr expert
+    health` is the letter-shaped question, and it measures something else.
+
+    EXAMPLES:
+
+      deepr expert viva "My Expert"
+      deepr expert viva "My Expert" --examiner "Provenance and Belief Revision"
+      deepr expert viva "My Expert" --plan claude --markdown
+    """
+    profile = _load_profile(name)
+    brief_text = _load_brief_text(profile.name)
+
+    panel = _panel_from_experts(examiners) if examiners else list(DEFAULT_PANEL)
+    if not panel:
+        click.echo("Error: no usable examiners. Every named expert lacked a brief to ask from.", err=True)
+        sys.exit(2)
+    panel = [Examiner(name=e.name, frame=e.frame, questions=questions) for e in panel]
+
+    try:
+        backend = build_study_backend(profile=profile, local=local, plan=plan, plan_model=plan_model, model=model)
+    except StudyBackendError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    if not as_json:
+        print_header(f"Viva: {profile.name}")
+        print_key_value("Capacity", backend.cost_note)
+        print_key_value("Panel", ", ".join(e.name for e in panel))
+        console.print("[dim]The examiners do not hold the answers either. That is the format.[/dim]")
+
+    result = asyncio.run(
+        run_viva(
+            expert_name=profile.name,
+            subject=profile.name,
+            brief=brief_text,
+            examiners=panel,
+            completion=backend.completion,
+        )
+    )
+
+    # Refuse before writing. A failed panel used to overwrite a good
+    # transcript with an empty one, so a backend hiccup destroyed an
+    # examination that had already cost quota and several minutes.
+    if not result.exchanges:
+        why = f" Every call failed with: {result.failures[0]}" if result.failures else ""
+        click.echo(
+            "Error: no examiner produced a question, so nothing was examined."
+            f"{why} Any previous transcript has been left alone.",
+            err=True,
+        )
+        sys.exit(2)
+
+    if result.failures:
+        print_warning(f"{len(result.failures)} call(s) failed during the examination: {result.failures[0]}")
+
+    payload = result.to_dict()
+    payload["gap_routes"] = _route_gaps(result)
+
+    path = Path(out) if out else canonical_viva_path(profile.name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    if write_markdown:
+        markdown_path = path.with_suffix(".md")
+        markdown_path.write_text(render_viva(result), encoding="utf-8")
+
+    if as_json:
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        _render_human(result, path=path, routes=payload["gap_routes"])

--- a/src/deepr/cli/commands/semantic/expert_viva.py
+++ b/src/deepr/cli/commands/semantic/expert_viva.py
@@ -29,7 +29,7 @@ import click
 from deepr.cli.colors import console, print_header, print_key_value, print_success, print_warning
 from deepr.cli.commands.semantic.experts import expert
 from deepr.cli.commands.semantic.study_backend import StudyBackendError, build_study_backend
-from deepr.experts.paths import canonical_expert_dir
+from deepr.experts.expert_layout import hold_current_path, met_examination_path
 from deepr.experts.viva import VivaResult, render_viva
 from deepr.experts.viva_session import DEFAULT_PANEL, Examiner, run_viva
 from deepr.utils.atomic_io import atomic_write_json
@@ -41,7 +41,7 @@ budget, and a brief that hits it is a brief with something wrong with it."""
 
 def canonical_viva_path(expert_name: str) -> Path:
     """Where an examination is written, and where anything reading one looks."""
-    return canonical_expert_dir(expert_name) / "viva.json"
+    return met_examination_path(expert_name)
 
 
 def _load_profile(name: str) -> Any:
@@ -65,7 +65,7 @@ def _load_brief_text(expert_name: str) -> str:
     from deepr.experts.brief import render_brief
     from deepr.experts.consult_context import load_brief
 
-    brief = load_brief(canonical_expert_dir(expert_name) / "brief.json")
+    brief = load_brief(hold_current_path(expert_name))
     if brief is None:
         click.echo(
             f"Error: {expert_name} has no brief, so it holds no positions to examine. "
@@ -89,7 +89,7 @@ def _panel_from_experts(names: tuple[str, ...]) -> list[Examiner]:
 
     panel: list[Examiner] = []
     for name in names:
-        brief = load_brief(canonical_expert_dir(name) / "brief.json")
+        brief = load_brief(hold_current_path(name))
         if brief is None:
             print_warning(f"Skipping examiner {name}: no brief, so it has no standpoint to ask from.")
             continue

--- a/src/deepr/cli/commands/semantic/experts.py
+++ b/src/deepr/cli/commands/semantic/experts.py
@@ -3322,6 +3322,7 @@ from deepr.cli.commands.semantic import expert_cleanup as _expert_cleanup  # noq
 from deepr.cli.commands.semantic import expert_consult as _expert_consult  # noqa: F401
 from deepr.cli.commands.semantic import expert_consult_quality as _expert_consult_quality  # noqa: F401
 from deepr.cli.commands.semantic import expert_consult_traces as _expert_consult_traces  # noqa: F401
+from deepr.cli.commands.semantic import expert_fleet_health as _expert_fleet_health  # noqa: F401
 from deepr.cli.commands.semantic import expert_freshness as _expert_freshness  # noqa: F401
 from deepr.cli.commands.semantic import expert_gap_routes as _expert_gap_routes  # noqa: F401
 from deepr.cli.commands.semantic import expert_learn_web as _expert_learn_web  # noqa: F401

--- a/src/deepr/cli/commands/semantic/experts.py
+++ b/src/deepr/cli/commands/semantic/experts.py
@@ -3336,3 +3336,4 @@ from deepr.cli.commands.semantic import expert_quality as _expert_quality  # noq
 from deepr.cli.commands.semantic import expert_self_model as _expert_self_model  # noqa: F401
 from deepr.cli.commands.semantic import expert_study as _expert_study  # noqa: F401
 from deepr.cli.commands.semantic import expert_validate_export as _expert_validate_export  # noqa: F401
+from deepr.cli.commands.semantic import expert_viva as _expert_viva  # noqa: F401

--- a/src/deepr/cli/commands/semantic/experts.py
+++ b/src/deepr/cli/commands/semantic/experts.py
@@ -3314,26 +3314,7 @@ def run_skill_cmd(name: str, skill_name: str, tool_name: str, tool_args: str):
     )
 
 
-# Maintenance commands (absorb, sync) live in a sibling module so this file
-# stays under the size ceiling; importing it registers them on the `expert`
-# group (Phase Q3 decomposition).
-from deepr.cli.commands.semantic import expert_blueprint as _expert_blueprint  # noqa: F401
-from deepr.cli.commands.semantic import expert_cleanup as _expert_cleanup  # noqa: F401
-from deepr.cli.commands.semantic import expert_consult as _expert_consult  # noqa: F401
-from deepr.cli.commands.semantic import expert_consult_quality as _expert_consult_quality  # noqa: F401
-from deepr.cli.commands.semantic import expert_consult_traces as _expert_consult_traces  # noqa: F401
-from deepr.cli.commands.semantic import expert_fleet_health as _expert_fleet_health  # noqa: F401
-from deepr.cli.commands.semantic import expert_freshness as _expert_freshness  # noqa: F401
-from deepr.cli.commands.semantic import expert_gap_routes as _expert_gap_routes  # noqa: F401
-from deepr.cli.commands.semantic import expert_learn_web as _expert_learn_web  # noqa: F401
-from deepr.cli.commands.semantic import expert_loop_status as _expert_loop_status  # noqa: F401
-from deepr.cli.commands.semantic import expert_maintenance as _expert_maintenance  # noqa: F401
-from deepr.cli.commands.semantic import expert_memory_card as _expert_memory_card  # noqa: F401
-from deepr.cli.commands.semantic import expert_okf as _expert_okf  # noqa: F401
-from deepr.cli.commands.semantic import expert_outcomes as _expert_outcomes  # noqa: F401
-from deepr.cli.commands.semantic import expert_portrait as _expert_portrait  # noqa: F401
-from deepr.cli.commands.semantic import expert_quality as _expert_quality  # noqa: F401
-from deepr.cli.commands.semantic import expert_self_model as _expert_self_model  # noqa: F401
-from deepr.cli.commands.semantic import expert_study as _expert_study  # noqa: F401
-from deepr.cli.commands.semantic import expert_validate_export as _expert_validate_export  # noqa: F401
-from deepr.cli.commands.semantic import expert_viva as _expert_viva  # noqa: F401
+# Every command that lives in a sibling module registers itself on import.
+# The list is kept in expert_command_registry so adding a command does not grow
+# this file, which is grandfathered at a size cap it must not exceed.
+from deepr.cli.commands.semantic import expert_command_registry as _expert_command_registry  # noqa: F401

--- a/src/deepr/cli/commands/semantic/study_backend.py
+++ b/src/deepr/cli/commands/semantic/study_backend.py
@@ -125,8 +125,11 @@ def build_study_backend(
     Local is the default when nothing is specified: a study pass is many calls,
     and the safe default for many calls is the one that cannot bill.
     """
-    if plan:
-        return _build_plan_backend(plan=plan, plan_model=plan_model, max_tokens=max_tokens)
+    named = [p.strip() for p in str(plan or "").split(",") if p.strip()]
+    if len(named) > 1:
+        return _build_pooled_backend(profile=profile, plans=named, max_tokens=max_tokens)
+    if named:
+        return _build_plan_backend(plan=named[0], plan_model=plan_model, max_tokens=max_tokens)
     if local:
         return _build_local_backend(profile=profile, model=model, max_tokens=max_tokens)
 
@@ -137,12 +140,57 @@ def build_study_backend(
     # local path runs whatever fits in free VRAM and holds the card for the
     # duration. Preferring plan is therefore better work at no extra money, and
     # local remains the guaranteed floor when no plan capacity is usable.
-    for backend in _preferred_plan_backends():
+    #
+    # Pooled when more than one is auto-routable, so a mid-run exhaustion moves
+    # to the next plan rather than ending the run with idle capacity sitting
+    # beside it. Only auto-routable adapters are eligible here: the others are
+    # explicit-only for tool-confinement reasons, which is a consent gate and
+    # not something a default may quietly cross.
+    preferred = _preferred_plan_backends()
+    if len(preferred) > 1:
+        try:
+            return _build_pooled_backend(profile=profile, plans=preferred, max_tokens=max_tokens)
+        except StudyBackendError:
+            pass
+    for backend in preferred:
         try:
             return _build_plan_backend(plan=backend, plan_model=plan_model, max_tokens=max_tokens)
         except StudyBackendError:
             continue
     return _build_local_backend(profile=profile, model=model, max_tokens=max_tokens)
+
+
+def _build_pooled_backend(*, profile: Any, plans: list[str], max_tokens: int) -> StudyBackend:
+    """Spread one run across several prepaid plans, moving on as each runs out.
+
+    The failure this fixes was watched repeatedly rather than imagined: a study
+    or brief died on one plan's weekly cap while three other plans sat idle,
+    and the operator re-ran it by hand against a different `--plan`. The pool
+    does that, and it retires a plan the moment it reports exhaustion so the
+    round-robin stops handing work to a backend that will fail identically for
+    every remaining call.
+
+    ``chunk_chars`` is the smallest across the pool, because a chunk sized for
+    the most capacious member would break on the tightest one and the run
+    cannot know in advance which member serves any given call.
+    """
+    from deepr.experts.backend_pool import build_pool
+
+    pool = build_pool(profile, plans)
+    if not pool.backends:
+        detail = "; ".join(pool.unavailable + pool.skipped) or "none resolved"
+        raise StudyBackendError(f"no plan-quota backend available from {', '.join(plans)}: {detail}")
+
+    note = f"$0 at the margin (prepaid plans: {', '.join(pool.names)})"
+    if pool.skipped:
+        note += f"; skipped at cap: {len(pool.skipped)}"
+    return StudyBackend(
+        completion=pool.complete,
+        capacity_source=f"plan:{'+'.join(pool.names)}",
+        model="",
+        cost_note=note,
+        chunk_chars=pool.chunk_chars or _PLAN_CHUNK_CHARS,
+    )
 
 
 def _preferred_plan_backends() -> list[str]:

--- a/src/deepr/cli/commands/semantic/study_backend.py
+++ b/src/deepr/cli/commands/semantic/study_backend.py
@@ -57,6 +57,13 @@ class StudyBackend:
     cost_note: str
     chunk_chars: int = _LOCAL_CHUNK_CHARS
     """How much corpus this tier can hold in one call and still stay structured."""
+    model: str = ""
+    """What ran inside the dispatch, where Deepr chose it.
+
+    Empty for a plan CLI invoked without an explicit model, because the CLI
+    picks for itself and Deepr sees the process rather than that decision.
+    Recorded so an artifact can say which model read the corpus - the single
+    largest determinant of what a study pass finds, and previously discarded."""
 
 
 def _completion_from_chat_client(
@@ -177,6 +184,7 @@ def _build_local_backend(
             client, local_model, max_tokens=max_tokens, context_tokens=context_tokens
         ),
         capacity_source=f"local:{local_model}",
+        model=local_model,
         cost_note=f"$0 (local model {local_model} @ {context_tokens} ctx){fit_note}",
     )
 
@@ -245,6 +253,7 @@ def _build_plan_backend(*, plan: str, plan_model: str | None, max_tokens: int) -
     return StudyBackend(
         completion=_completion_from_chat_client(client, resolved_model, max_tokens=max_tokens),
         capacity_source=f"plan:{adapter.backend_id}",
+        model=plan_model or "",
         cost_note="$0 at the margin (prepaid plan)",
         chunk_chars=_PLAN_CHUNK_CHARS,
     )

--- a/src/deepr/cli/main.py
+++ b/src/deepr/cli/main.py
@@ -369,6 +369,18 @@ def main():
     TTY, never block or surprise a non-interactive caller.
     """
     _ensure_utf8_console()
+
+    # Before any command runs, move metered API keys out of this process.
+    # Deepr already strips them from plan-quota child processes; that protects
+    # the child and not the parent. A key set at the OS level stays readable by
+    # anything in-process for the whole run, and removing it from `.env` only
+    # looks like removing it - measured here, three keys survived that edit
+    # because Windows was their real source. Not being set beats being checked:
+    # a guard has to be reached, an absent variable cannot be read at all.
+    from deepr.security.key_quarantine import quarantine_metered_keys
+
+    quarantine_metered_keys()
+
     if "NO_COLOR" in os.environ:
         apply_no_color()
     # Route the no-args case through Click with an explicit subcommand to

--- a/src/deepr/experts/acquisition_plan.py
+++ b/src/deepr/experts/acquisition_plan.py
@@ -132,6 +132,8 @@ class AcquisitionPlan:
     excluded_publishers: list[str] = field(default_factory=list)
     search_key: str = ""
     """The shortened noun phrase actually templated, when the topic was long."""
+    fallback_reason: str = ""
+    """Set when a proposed plan was refused and these templates were used."""
 
     def by_arm(self, arm: str) -> list[AcquisitionQuery]:
         return [q for q in self.queries if q.arm == arm]
@@ -155,6 +157,12 @@ class AcquisitionPlan:
             )
         if not self.by_arm(ARM_PRIMARY):
             notes.append("No primary-source queries, so the corpus may be entirely secondary retelling.")
+        if self.fallback_reason:
+            notes.append(
+                f"Queries are templated because {self.fallback_reason}. Templates do not know this "
+                "field's terminology, its critics, or where its primary work is published, so "
+                "coverage here is guaranteed in shape only."
+            )
         if self.search_key and self.search_key != self.topic:
             notes.append(
                 f"Queries were built from {self.search_key!r} rather than the full topic, which is too "

--- a/src/deepr/experts/acquisition_plan.py
+++ b/src/deepr/experts/acquisition_plan.py
@@ -130,6 +130,8 @@ class AcquisitionPlan:
     topic: str
     queries: list[AcquisitionQuery] = field(default_factory=list)
     excluded_publishers: list[str] = field(default_factory=list)
+    search_key: str = ""
+    """The shortened noun phrase actually templated, when the topic was long."""
 
     def by_arm(self, arm: str) -> list[AcquisitionQuery]:
         return [q for q in self.queries if q.arm == arm]
@@ -153,11 +155,18 @@ class AcquisitionPlan:
             )
         if not self.by_arm(ARM_PRIMARY):
             notes.append("No primary-source queries, so the corpus may be entirely secondary retelling.")
+        if self.search_key and self.search_key != self.topic:
+            notes.append(
+                f"Queries were built from {self.search_key!r} rather than the full topic, which is too "
+                "long to template into a usable search. Check that the shortened form still names the "
+                "subject; if it does not, pass a shorter topic."
+            )
         return notes
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "topic": self.topic,
+            "search_key": self.search_key,
             "excluded_publishers": self.excluded_publishers,
             "arms_covered": sorted(self.arms_covered),
             "query_count": len(self.queries),
@@ -166,8 +175,31 @@ class AcquisitionPlan:
         }
 
 
+_MAX_TOPIC_WORDS = 6
+"""Above this, a templated query stops being a query.
+
+Found by using it: a topic given as a sentence produced
+"criticism of anti-slop practices for AI agent generated code and analysis",
+which no search engine handles. Templates need a noun phrase, so a long topic
+is shortened for templating and the shortening is reported rather than done
+quietly."""
+
+
 def _clean_topic(topic: str) -> str:
     return " ".join(str(topic or "").split())
+
+
+def search_key(topic: str) -> str:
+    """The short noun phrase the templates wrap.
+
+    Content words only, head-first, because a search engine weights the head of
+    a phrase and the tail of a description is usually qualifiers.
+    """
+    words = [w for w in _clean_topic(topic).split() if w.lower() not in _TOPIC_STOPWORDS]
+    return " ".join(words[:_MAX_TOPIC_WORDS])
+
+
+_TOPIC_STOPWORDS = frozenset("a an and are as at be by for from how in is of on or the to what when with".split())
 
 
 def _emit(templates: tuple[str, ...], topic: str, arm: str, rationale: str) -> list[AcquisitionQuery]:
@@ -222,6 +254,9 @@ def plan_queries(
     plan = AcquisitionPlan(topic=clean, excluded_publishers=[p for p in exclude_publishers if p.strip()])
     if not clean:
         return plan
+    key = search_key(clean)
+    plan.search_key = key
+    clean = key or clean
 
     plan.queries = [
         *_emit(_DESCRIPTIVE_TEMPLATES, clean, ARM_DESCRIPTIVE, "what the subject is, in its own terms"),

--- a/src/deepr/experts/backend_pool.py
+++ b/src/deepr/experts/backend_pool.py
@@ -53,6 +53,12 @@ class BackendPool:
     """Plans that would not build, with the reason, so a thin pool is visible."""
     skipped: list[str] = field(default_factory=list)
     """Plans left out because they were already at their cap, named not hidden."""
+    retired: list[str] = field(default_factory=list)
+    """Plans that ran out *during* the run, with the reason.
+
+    Distinct from ``skipped``, which was known before starting. A run that
+    began with four plans and finished on one did something worth reporting,
+    and without this it looks identical to a run that had one all along."""
     headroom_note: str = ""
     _index: int = 0
     _lock: Any = None
@@ -84,34 +90,62 @@ class BackendPool:
             self._index += 1
             return backend
 
-    async def complete(self, prompt: str) -> str:
-        """Run one prompt on the next backend, retrying once elsewhere.
+    async def _retire(self, backend: PooledBackend, reason: str) -> None:
+        """Take a backend out of rotation for the rest of this run.
 
-        The retry is deliberately single and on a *different* backend: a
-        prompt that fails twice is usually the prompt, and retrying the same
-        plan just spends quota to learn nothing.
+        The difference between a bad prompt and a dead plan. A prompt failure
+        is one call; an exhausted weekly quota fails identically for every
+        remaining call, so leaving it in rotation spends a wasted round-trip
+        every cycle - and on a long study that is hundreds of them.
+
+        Retirement is per-run and never persisted. Quota comes back, and a
+        cached "grok is dead" would outlive the reset that fixed it.
         """
+        async with self._lock:
+            if backend in self.backends:
+                self.backends.remove(backend)
+                self.retired.append(f"{backend.name}: {reason[:120]}")
+
+    async def complete(self, prompt: str) -> str:
+        """Run one prompt, moving on from any backend that has run out.
+
+        Two failure kinds, handled differently:
+
+        - **Capacity.** The plan is out. Retire it and try the next one, until
+          the pool is empty. This is what makes a run survive a mid-flight
+          exhaustion instead of dying with three healthy plans still idle.
+        - **Anything else.** Retried once on a *different* backend, then
+          returned. A prompt that fails twice is usually the prompt, and
+          retrying the same plan spends quota to learn nothing.
+        """
+        from deepr.experts.study import _is_capacity_failure
+
+        # Started with nothing is a different condition from ran out, and the
+        # caller needs to tell them apart: one is a setup problem, the other
+        # means wait for a reset.
         if not self.backends:
             raise RuntimeError("no plan-quota backend is available")
 
-        first = await self._next()
-        first.calls += 1
-        try:
-            return await first.completion(prompt)
-        except Exception:
-            first.failures += 1
-            if len(self.backends) < 2:
-                raise
+        attempted: list[PooledBackend] = []
+        last_error: Exception | None = None
 
-        second = await self._next()
-        if second is first:
-            second = await self._next()
-        second.calls += 1
-        try:
-            return await second.completion(prompt)
-        except Exception:
-            second.failures += 1
-            raise
+        while self.backends:
+            backend = await self._next()
+            backend.calls += 1
+            try:
+                return await backend.completion(prompt)
+            except Exception as exc:
+                backend.failures += 1
+                last_error = exc
+                if _is_capacity_failure(exc):
+                    await self._retire(backend, str(exc))
+                    continue
+                # Not capacity: one retry elsewhere, then give up on this prompt.
+                attempted.append(backend)
+                if len(attempted) >= 2 or len(self.backends) < 2:
+                    raise
+
+        raise last_error or RuntimeError("every plan-quota backend ran out of capacity: " + "; ".join(self.retired))
 
 
 def build_pool(

--- a/src/deepr/experts/backend_pool.py
+++ b/src/deepr/experts/backend_pool.py
@@ -1,0 +1,182 @@
+"""Spread work across every prepaid plan that is actually available.
+
+Building an expert is embarrassingly parallel in one place: a card is one call
+per source with no ordering between them, and a study is one call per lens per
+chunk. Running those one at a time on a single plan is slow and, worse, drains
+one quota while three others sit idle.
+
+A pool hands out completions round-robin over the backends that resolved. Two
+consequences beyond speed, and they matter more:
+
+- **No single plan gets exhausted first.** Consumption spreads, so a run that
+  would have hit one weekly cap finishes across four.
+- **One dead backend is not a dead run.** A completion that raises is retried
+  once on the next backend before the failure is returned, since the callers
+  already treat a failed unit as a labeled failure rather than an abort.
+
+Deliberately not load-balanced by latency or quality. Backends differ by more
+than an order of magnitude in speed, and preferring the fast one would quietly
+concentrate the work back onto one plan, which is the thing this exists to
+avoid.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+Completion = Callable[[str], Awaitable[str]]
+
+
+@dataclass
+class PooledBackend:
+    """One resolved backend and what it has been asked to do."""
+
+    name: str
+    completion: Completion
+    chunk_chars: int = 0
+    calls: int = 0
+    failures: int = 0
+
+
+@dataclass
+class BackendPool:
+    """Round-robin over prepaid capacity, with one retry elsewhere on failure."""
+
+    backends: list[PooledBackend] = field(default_factory=list)
+    unavailable: list[str] = field(default_factory=list)
+    """Plans that would not build, with the reason, so a thin pool is visible."""
+    skipped: list[str] = field(default_factory=list)
+    """Plans left out because they were already at their cap, named not hidden."""
+    headroom_note: str = ""
+    _index: int = 0
+    _lock: Any = None
+
+    def __post_init__(self) -> None:
+        self._lock = asyncio.Lock()
+
+    @property
+    def names(self) -> list[str]:
+        return [b.name for b in self.backends]
+
+    @property
+    def size(self) -> int:
+        return len(self.backends)
+
+    @property
+    def chunk_chars(self) -> int:
+        """The budget every member can hold, which is the smallest of them."""
+        sizes = [b.chunk_chars for b in self.backends if b.chunk_chars > 0]
+        return min(sizes) if sizes else 0
+
+    def usage(self) -> dict[str, dict[str, int]]:
+        """Calls and failures per backend, so a lopsided run is visible."""
+        return {b.name: {"calls": b.calls, "failures": b.failures} for b in self.backends}
+
+    async def _next(self) -> PooledBackend:
+        async with self._lock:
+            backend = self.backends[self._index % len(self.backends)]
+            self._index += 1
+            return backend
+
+    async def complete(self, prompt: str) -> str:
+        """Run one prompt on the next backend, retrying once elsewhere.
+
+        The retry is deliberately single and on a *different* backend: a
+        prompt that fails twice is usually the prompt, and retrying the same
+        plan just spends quota to learn nothing.
+        """
+        if not self.backends:
+            raise RuntimeError("no plan-quota backend is available")
+
+        first = await self._next()
+        first.calls += 1
+        try:
+            return await first.completion(prompt)
+        except Exception:
+            first.failures += 1
+            if len(self.backends) < 2:
+                raise
+
+        second = await self._next()
+        if second is first:
+            second = await self._next()
+        second.calls += 1
+        try:
+            return await second.completion(prompt)
+        except Exception:
+            second.failures += 1
+            raise
+
+
+def build_pool(
+    profile: Any,
+    plans: list[str] | tuple[str, ...],
+    *,
+    use_headroom: bool = True,
+) -> BackendPool:
+    """Resolve each named plan, best headroom first, skipping the exhausted.
+
+    A plan that is out of quota or not installed is left out rather than
+    raising, because a pool of three is still a pool. What it refuses to do is
+    silently fall back to a metered path: only plan backends are resolved here.
+
+    Ordering matters more than it looks. Blind round-robin sends work to a plan
+    at 95% of its five-hour window as readily as one at 4% of its week, which
+    caps the tight one and then fails over. Reading headroom first costs
+    nothing and finishes the run without touching it.
+    """
+    from deepr.cli.commands.semantic.study_backend import build_study_backend
+
+    pool = BackendPool()
+    if use_headroom:
+        from deepr.backends.quota_headroom import exhausted, order_by_headroom, read_headroom
+
+        headroom = read_headroom()
+        if headroom:
+            skipped = exhausted(plans, headroom)
+            pool.skipped = [headroom[n.lower()].describe() for n in skipped]
+            plans = [p for p in order_by_headroom(plans, headroom) if p not in skipped]
+            pool.headroom_note = ", ".join(headroom[p.lower()].describe() for p in plans if p.lower() in headroom)
+
+    for plan in plans:
+        try:
+            backend = build_study_backend(profile=profile, local=False, plan=plan, plan_model=None, model=None)
+        except Exception as exc:
+            # Named rather than dropped: a pool that is quietly one backend
+            # instead of four looks identical to one that is working.
+            pool.unavailable.append(f"{plan}: {str(exc)[:120]}")
+            logger.debug("plan backend %s unavailable", plan, exc_info=True)
+            continue
+        pool.backends.append(PooledBackend(name=plan, completion=backend.completion, chunk_chars=backend.chunk_chars))
+    return pool
+
+
+async def map_pooled(
+    pool: BackendPool,
+    items: list[Any],
+    run: Callable[[Any, Completion], Awaitable[Any]],
+    *,
+    concurrency: int = 0,
+) -> list[Any]:
+    """Run one unit of work per item, spread across the pool.
+
+    Concurrency defaults to the pool size: more in flight than there are
+    backends just queues requests at one vendor, which is where rate limits
+    live.
+    """
+    if not items:
+        return []
+    limit = concurrency or max(1, pool.size)
+    gate = asyncio.Semaphore(limit)
+
+    async def _one(item: Any) -> Any:
+        async with gate:
+            return await run(item, pool.complete)
+
+    return await asyncio.gather(*(_one(item) for item in items))

--- a/src/deepr/experts/brief.py
+++ b/src/deepr/experts/brief.py
@@ -73,11 +73,51 @@ def _render_finding(finding: StudyFinding) -> str:
     return "\n".join(parts)
 
 
-def build_brief_prompt(result: StudyResult, *, expert_name: str, domain: str = "") -> str:
+def _prior_positions_block(prior: list[Any]) -> str:
+    """Show the questions this expert already takes a position on.
+
+    Without this a re-brief is non-deterministic in its *phrasing*, and that
+    silently destroys position identity. Measured: the same corpus briefed
+    twice produced seven differently-worded questions and restated none of the
+    nine it already held, so every thread closed and reopened, no position
+    could ever accumulate survival evidence, and the ledger filled with
+    unrelated threads about the same subject.
+
+    Reusing a question verbatim is what makes a revision recognisable as one.
+    That has to be asked for explicitly, because a model given the same corpus
+    and no memory will legitimately phrase the same question differently every
+    time.
+    """
+    if not prior:
+        return ""
+    lines = "\n".join(
+        f'- "{str(getattr(p, "question", "") or "").strip()}"' for p in prior if getattr(p, "question", "")
+    )
+    if not lines:
+        return ""
+    return (
+        "\n===== QUESTIONS YOU ALREADY TAKE A POSITION ON =====\n"
+        f"{lines}\n"
+        "===== END =====\n\n"
+        "Where this corpus still speaks to one of those questions, **reuse its wording exactly** "
+        "and state your position on it now - which may be the same as before, or changed, and "
+        "either is a real result. Reusing the wording is what lets the system tell a revised "
+        "position from an unrelated new one; rephrasing it looks identical to abandoning the "
+        "question and starting another.\n"
+        "Where the corpus no longer supports a question, simply omit it. Do not restate a "
+        "position you can no longer support in order to keep the list stable.\n"
+        "Ask new questions freely where the material warrants them.\n"
+    )
+
+
+def build_brief_prompt(
+    result: StudyResult, *, expert_name: str, domain: str = "", prior_positions: list[Any] | None = None
+) -> str:
     """Assemble the synthesis prompt from independent findings."""
     findings = result.findings[:_MAX_FINDINGS_IN_PROMPT]
     rendered = "\n".join(_render_finding(f) for f in findings)
     contested = [f for f in result.findings if f.lens == "contention"]
+    prior_block = _prior_positions_block(list(prior_positions or []))
 
     dissent_note = (
         f"\n{len(contested)} finding(s) came from the contention lens, which looks for disagreement "
@@ -115,7 +155,7 @@ Rules that make this honest rather than confident-sounding:
 House style, which applies to every field you return: write plain ASCII punctuation. Use a
 regular hyphen, never an en dash or em dash. Use straight quotes, never curly ones. No emoji.
 Prose, not decoration.
-{dissent_note}
+{dissent_note}{prior_block}
 "likelihood" must be exactly one of: {_LIKELIHOOD_CHOICES}.
 "confidence" must be exactly one of: {_CONFIDENCE_CHOICES}.
 "resolution" must be exactly one of: single (you land on one stance);
@@ -321,6 +361,7 @@ async def build_brief(
     corpus: CorpusStore,
     completion: BriefCompletion,
     domain: str = "",
+    prior_positions: list[Any] | None = None,
 ) -> ExpertBrief:
     """Synthesize one brief. Returns an empty brief rather than raising."""
     from deepr.experts.study import extract_json_object
@@ -333,7 +374,7 @@ async def build_brief(
         )
         return brief
 
-    prompt = build_brief_prompt(result, expert_name=expert_name, domain=domain)
+    prompt = build_brief_prompt(result, expert_name=expert_name, domain=domain, prior_positions=prior_positions)
     try:
         raw = await completion(prompt)
     except Exception as exc:

--- a/src/deepr/experts/brief_contracts.py
+++ b/src/deepr/experts/brief_contracts.py
@@ -92,7 +92,18 @@ class Position:
     would_change_my_mind: str
     """The observation that would overturn this. Empty makes the position invalid."""
     supported_by: list[str] = field(default_factory=list)
-    """Finding titles this rests on, so 'why do you think that' is answerable."""
+    """Finding *ids* this rests on, so 'why do you think that' is answerable.
+
+    Ids, not titles, and the distinction is load-bearing: titles collide,
+    several lenses fall back to a constant when the model names nothing, and a
+    title containing a newline can never be matched. This docstring said
+    "titles" while the prompt and the citation filter both used ids - a stale
+    comment stating the opposite of the code, which is how the next reader
+    introduces a real bug.
+
+    The ids are still positional (``{lens}-{ordinal}``), so they are stable
+    within a run and not across runs. Making them content-derived is step one
+    of the V2 work."""
     unresolved_dissent: str = ""
     """Disagreement this position does not settle, stated rather than smoothed."""
     confidence_basis: str = ""

--- a/src/deepr/experts/briefed_perspective.py
+++ b/src/deepr/experts/briefed_perspective.py
@@ -85,3 +85,18 @@ def build_briefed_perspective(query: str, name: str, domain: str, perspective_cl
             "evidence_chars": context.evidence_chars(),
         },
     )
+
+
+def briefed_perspective_without_beliefs(query: str, name: str, domain: str, perspective_cls: Any) -> Any:
+    """A perspective for an expert that has a brief and no belief ledger.
+
+    acquire -> study -> brief never writes the claim ledger, because admission
+    is a separate decision from reading. Consult gated its whole path on
+    ``beliefs.json`` existing, so exactly that expert - corpus, findings and
+    positions all on disk - answered "no stored belief context is available".
+    """
+    from deepr.experts.paths import canonical_expert_dir
+
+    if not (canonical_expert_dir(name) / "brief.json").exists():
+        return None
+    return build_briefed_perspective(query, name, domain, perspective_cls)

--- a/src/deepr/experts/briefed_perspective.py
+++ b/src/deepr/experts/briefed_perspective.py
@@ -36,10 +36,11 @@ def load_consult_context(query: str, name: str) -> Any:
     """Assemble the studied layers for this question, or None if unbriefed."""
     from deepr.experts.consult_context import build_consult_context, load_brief, load_study
     from deepr.experts.corpus_store import CorpusStore
+    from deepr.experts.expert_layout import part_in
     from deepr.experts.paths import canonical_expert_dir
 
     expert_dir = canonical_expert_dir(name)
-    brief = load_brief(expert_dir / "brief.json")
+    brief = load_brief(part_in(expert_dir, "hold_current"))
     if brief is None:
         return None
     try:
@@ -50,7 +51,7 @@ def load_consult_context(query: str, name: str) -> Any:
         expert_name=name,
         question=query,
         brief=brief,
-        result=load_study(expert_dir / "study.json"),
+        result=load_study(part_in(expert_dir, "noticed")),
         corpus=corpus,
     )
 
@@ -95,8 +96,8 @@ def briefed_perspective_without_beliefs(query: str, name: str, domain: str, pers
     ``beliefs.json`` existing, so exactly that expert - corpus, findings and
     positions all on disk - answered "no stored belief context is available".
     """
-    from deepr.experts.paths import canonical_expert_dir
+    from deepr.experts.expert_layout import hold_current_path
 
-    if not (canonical_expert_dir(name) / "brief.json").exists():
+    if not hold_current_path(name).exists():
         return None
     return build_briefed_perspective(query, name, domain, perspective_cls)

--- a/src/deepr/experts/consult.py
+++ b/src/deepr/experts/consult.py
@@ -87,6 +87,38 @@ def _sha256(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _first_usable_plan(plan_backend: str) -> tuple[str | None, list[str]]:
+    """Pick the first named plan with headroom. Returns (choice, why-not).
+
+    ``--plan grok,codex,claude`` names an order of preference. Reading quota
+    headroom first is what stops a consult beginning on a plan that is already
+    exhausted, which costs a round-trip and a confusing error rather than a
+    result. A single name passes straight through, so nothing changes for
+    callers that name one plan.
+
+    Falls back to the first name when headroom is unreadable: an unavailable
+    quotabot must not turn into a refusal to consult at all.
+    """
+    names = [p.strip() for p in str(plan_backend or "").split(",") if p.strip()]
+    if len(names) <= 1:
+        return (names[0] if names else None), []
+
+    try:
+        from deepr.backends.quota_headroom import exhausted, order_by_headroom, read_headroom
+
+        headroom = read_headroom()
+    except Exception:
+        headroom = {}
+
+    if not headroom:
+        return names[0], []
+
+    spent = exhausted(names, headroom)
+    usable = [n for n in order_by_headroom(names, headroom) if n not in spent]
+    why_not = [headroom[n.lower()].describe() for n in spent if n.lower() in headroom]
+    return (usable[0] if usable else None), why_not
+
+
 def build_synthesis_backend(
     *,
     use_local: bool = False,
@@ -119,6 +151,18 @@ def build_synthesis_backend(
     if plan_backend:
         from deepr.backends.plan_quota import PlanQuotaChatClient, get_adapter
         from deepr.backends.waterfall import choose_plan_quota_backend
+
+        # A list picks the first plan that both resolves and has headroom.
+        #
+        # Not the same as the study path's pool, and deliberately not pretending
+        # to be: a consult builds a chat *client* rather than a completion
+        # callable, so there is no place to fail over mid-call without wrapping
+        # the client. What this does buy is the larger half - not starting a
+        # consult on a plan that is already at its cap, which is how these runs
+        # actually died.
+        plan_backend, unusable = _first_usable_plan(plan_backend)
+        if plan_backend is None:
+            raise ConsultBackendError(f"No plan backend has capacity: {'; '.join(unusable)}")
 
         choice = choose_plan_quota_backend(plan_backend)
         if not choice.is_plan_quota:

--- a/src/deepr/experts/consult.py
+++ b/src/deepr/experts/consult.py
@@ -119,6 +119,41 @@ def _first_usable_plan(plan_backend: str) -> tuple[str | None, list[str]]:
     return (usable[0] if usable else None), why_not
 
 
+def _plan_synthesis_backend(plan_backend: str, plan_model: str | None) -> ConsultSynthesisBackend:
+    """Resolve a consult onto prepaid plan capacity.
+
+    A list picks the first plan that both resolves and has headroom. Not the
+    same as the study path's pool, and deliberately not pretending to be: a
+    consult builds a chat *client* rather than a completion callable, so there
+    is nowhere to fail over mid-call without wrapping the client. What this
+    does buy is the larger half - not starting a consult on a plan that is
+    already at its cap, which is how these runs actually died.
+    """
+    from deepr.backends.plan_quota import PlanQuotaChatClient, get_adapter
+    from deepr.backends.waterfall import choose_plan_quota_backend
+
+    chosen, unusable = _first_usable_plan(plan_backend)
+    if chosen is None:
+        raise ConsultBackendError(f"No plan backend has capacity: {'; '.join(unusable)}")
+
+    choice = choose_plan_quota_backend(chosen)
+    if not choice.is_plan_quota:
+        raise ConsultBackendError(f"Plan backend {chosen!r} is not available for explicit plan use: {choice.reason}")
+
+    adapter = get_adapter(choice.plan_backend_id or chosen)
+    if adapter is None:
+        raise ConsultBackendError(f"Unknown plan-quota backend {chosen!r}.")
+
+    return ConsultSynthesisBackend(
+        client=PlanQuotaChatClient(adapter, model=plan_model, operation="plan_quota_consult_synthesis"),
+        model=plan_model or adapter.backend_id,
+        provider=f"plan_quota:{adapter.backend_id}",
+        allow_live_fallback=False,
+        note=f"{choice.reason}; live metered expert fallback disabled",
+        tos_note=adapter.tos_note,
+    )
+
+
 def build_synthesis_backend(
     *,
     use_local: bool = False,
@@ -149,37 +184,7 @@ def build_synthesis_backend(
         )
 
     if plan_backend:
-        from deepr.backends.plan_quota import PlanQuotaChatClient, get_adapter
-        from deepr.backends.waterfall import choose_plan_quota_backend
-
-        # A list picks the first plan that both resolves and has headroom.
-        #
-        # Not the same as the study path's pool, and deliberately not pretending
-        # to be: a consult builds a chat *client* rather than a completion
-        # callable, so there is no place to fail over mid-call without wrapping
-        # the client. What this does buy is the larger half - not starting a
-        # consult on a plan that is already at its cap, which is how these runs
-        # actually died.
-        plan_backend, unusable = _first_usable_plan(plan_backend)
-        if plan_backend is None:
-            raise ConsultBackendError(f"No plan backend has capacity: {'; '.join(unusable)}")
-
-        choice = choose_plan_quota_backend(plan_backend)
-        if not choice.is_plan_quota:
-            raise ConsultBackendError(
-                f"Plan backend {plan_backend!r} is not available for explicit plan use: {choice.reason}"
-            )
-        adapter = get_adapter(choice.plan_backend_id or plan_backend)
-        if adapter is None:
-            raise ConsultBackendError(f"Unknown plan-quota backend {plan_backend!r}.")
-        return ConsultSynthesisBackend(
-            client=PlanQuotaChatClient(adapter, model=plan_model, operation="plan_quota_consult_synthesis"),
-            model=plan_model or adapter.backend_id,
-            provider=f"plan_quota:{adapter.backend_id}",
-            allow_live_fallback=False,
-            note=f"{choice.reason}; live metered expert fallback disabled",
-            tos_note=adapter.tos_note,
-        )
+        return _plan_synthesis_backend(plan_backend, plan_model)
 
     provider = (api_provider or DEFAULT_API_SYNTHESIS_PROVIDER).strip().lower()
     if provider == "openai":

--- a/src/deepr/experts/consult_context.py
+++ b/src/deepr/experts/consult_context.py
@@ -269,14 +269,12 @@ def render_consult_packet(context: ConsultContext) -> str:
         blocks.append("\n".join(lines).strip())
     elif context.coverage == "partial":
         blocks.append(
-            "I have not formed a position on this. What follows is material from my sources that "
-            "bears on it, and it has not been reconciled into a view."
+            "I have not formed a position on this, so take what follows as material rather than a "
+            "view. It bears on your question and I have not reconciled it. If it is close enough "
+            "to be worth settling, say so and I will read further and come back with a position."
         )
     else:
-        blocks.append(
-            "I hold nothing on this question. Saying so is the honest answer; inventing one from "
-            "adjacent material would not be."
-        )
+        blocks.append(_render_uncovered(context))
 
     if context.findings:
         lines = ["What my sources actually say:", ""]
@@ -292,6 +290,36 @@ def render_consult_packet(context: ConsultContext) -> str:
         blocks.append("\n".join(lines).strip())
 
     return "\n\n".join(block for block in blocks if block)
+
+
+def _render_uncovered(context: ConsultContext) -> str:
+    """Say no, and then say what would turn it into a yes.
+
+    Honest refusal that stops there leaves the asker where they started. What
+    an expert who is glad to be asked adds is the route: what it would take to
+    answer, and what nearby thing it does hold. Refusing usefully is still
+    helping, and it is also the only way a refusal becomes work the expert can
+    go and do.
+    """
+    lines = [
+        "I do not hold a position on this. Inventing one from adjacent material would be worse "
+        "than saying so, but I would like to be able to answer it."
+    ]
+    if context.live:
+        lines.append("")
+        lines.append("Nearest things I am already working on:")
+        lines += [f"- {item}" for item in context.live[:3]]
+    if context.unknown:
+        lines.append("")
+        lines.append("Already on my list of what I do not know:")
+        lines += [f"- {item}" for item in context.unknown[:3]]
+    lines.append("")
+    lines.append(
+        "What would let me answer: sources on this specific question, which is an acquire and "
+        "re-study rather than a guess. Point me at material or ask me to go looking, and this "
+        "becomes something I hold rather than something I decline."
+    )
+    return "\n".join(lines)
 
 
 def render_standing_header(context: ConsultContext) -> str:

--- a/src/deepr/experts/corpus_acquire.py
+++ b/src/deepr/experts/corpus_acquire.py
@@ -104,19 +104,20 @@ def _origin_key_for(url: str) -> str:
 def _as_source_text(page: Any, url: str) -> str:
     """Render fetched content as the markdown the corpus retains.
 
-    Nothing that varies between two fetches of an unchanged page may appear
-    here, because this text is what gets content-hashed. A ``fetched_at`` date
-    in the body made every refresh a new sha, so one page refreshed daily read
-    as seven independent sources by the end of a week, and every corroboration
-    count downstream inflated with it. Retrieval time is per-entry metadata and
-    lives on ``CorpusEntry``, where it does not change identity.
+    Only the body is hashed. Anything that varies between two fetches of the
+    same document must stay out, because this text is what decides identity.
+
+    A ``fetched_at`` date in the body made every refresh a new sha, so one page
+    refreshed daily read as seven independent sources by the end of a week. The
+    URL was the same bug half-fixed: the identical document mirrored at two
+    addresses hashed differently, counted as two entries, and therefore as two
+    independent origins - which is exactly the inflation the independence
+    measurement exists to catch, defeated before it ever runs.
+
+    URL and title are per-entry metadata on ``CorpusEntry``, where they are
+    kept and do not change identity.
     """
-    title = (getattr(page, "title", "") or "").strip()
-    text = (getattr(page, "text", "") or "").strip()
-    header = ["---", f"url: {url}", f"title: {title}", "---", ""]
-    if title:
-        header.extend([f"# {title}", ""])
-    return "\n".join(header) + text
+    return (getattr(page, "text", "") or "").strip()
 
 
 async def acquire_sources(

--- a/src/deepr/experts/corpus_independence.py
+++ b/src/deepr/experts/corpus_independence.py
@@ -75,6 +75,11 @@ class IndependenceReport:
         data["is_thin"] = self.is_thin
         return data
 
+    # origin_count and dominant_share are already fields, so asdict carries
+    # them. Named here because the health grade gates on them: effective
+    # source count describes concentration and must not be a gate, since it
+    # falls when an expert reads more of its best source.
+
     def concerns(self) -> list[str]:
         """What a reader must know before trusting anything derived from this."""
         notes: list[str] = []

--- a/src/deepr/experts/corpus_search.py
+++ b/src/deepr/experts/corpus_search.py
@@ -1,0 +1,164 @@
+"""Find candidate sources for a query. The channel Deepr did not have.
+
+Acquisition could fetch a URL but not discover one, so every corpus began with
+a person naming addresses. That is the weakest of the three channels
+researchers use, and it caps an expert at whatever someone already knew to
+look for.
+
+This is deliberately thin. It returns candidate URLs and nothing else: no
+ranking beyond what the engine gave, no relevance judgment, no filtering on
+content. Selection pressure belongs upstream in the acquisition plan, which
+decides *what to ask*, and downstream in the independence measurement, which
+decides whether what came back is worth anything. A search module that also
+judged quality would be three decisions in one place with no way to inspect
+any of them.
+
+Costs network only. No model call, no metered surface, no API key.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+_ENDPOINT = "https://lite.duckduckgo.com/lite/"
+_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) DeeprResearch/1.0"
+_HREF_RE = re.compile(r'href="(https?://[^"]+)"', re.IGNORECASE)
+
+_ENGINE_HOSTS = ("duckduckgo.com", "duck.com")
+
+_JUNK_SUFFIXES = (".jpg", ".jpeg", ".png", ".gif", ".svg", ".ico", ".css", ".js", ".zip")
+
+
+@dataclass
+class SearchHit:
+    """One candidate source, with the query that surfaced it."""
+
+    url: str
+    query: str
+    arm: str = ""
+
+    @property
+    def host(self) -> str:
+        return urlparse(self.url).netloc.lower().removeprefix("www.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"url": self.url, "query": self.query, "arm": self.arm, "host": self.host}
+
+
+@dataclass
+class SearchResult:
+    """What a plan turned up, and what it failed to turn up."""
+
+    hits: list[SearchHit] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+    @property
+    def distinct_hosts(self) -> set[str]:
+        return {hit.host for hit in self.hits}
+
+    def arms_that_found_nothing(self) -> list[str]:
+        """Arms that returned nothing, named rather than quietly absent.
+
+        An adversarial arm that finds nothing is a real signal: either the
+        subject genuinely has no published critics, or the phrasing did not
+        reach them. Both are worth knowing before the corpus is called
+        balanced.
+        """
+        found = {hit.arm for hit in self.hits if hit.arm}
+        attempted = {q.split("::", 1)[0] for q in self.failures if "::" in q}
+        return sorted(attempted - found)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "hit_count": len(self.hits),
+            "distinct_hosts": len(self.distinct_hosts),
+            "hits": [hit.to_dict() for hit in self.hits],
+            "failures": self.failures,
+        }
+
+
+def _is_candidate(url: str) -> bool:
+    host = urlparse(url).netloc.lower()
+    if not host or any(engine in host for engine in _ENGINE_HOSTS):
+        return False
+    return not url.lower().endswith(_JUNK_SUFFIXES)
+
+
+def parse_result_urls(html: str, limit: int) -> list[str]:
+    """Pull candidate URLs out of a results page, in the order given.
+
+    Order is the engine's, kept rather than re-scored. Deepr has no basis for
+    a better ranking here and inventing one would be a judgment nobody could
+    inspect.
+    """
+    seen: list[str] = []
+    for url in _HREF_RE.findall(html or ""):
+        cleaned = url.split("&amp;")[0].strip()
+        if _is_candidate(cleaned) and cleaned not in seen:
+            seen.append(cleaned)
+            if len(seen) >= limit:
+                break
+    return seen
+
+
+async def search_once(query: str, *, limit: int = 6, client: Any = None) -> list[str]:
+    """Run one query. Returns candidate URLs, or empty on any failure.
+
+    Never raises: one dead query must not abort a plan of thirty.
+    """
+    import httpx
+
+    owns_client = client is None
+    client = client or httpx.AsyncClient(timeout=25.0, follow_redirects=True)
+    try:
+        response = await client.post(_ENDPOINT, data={"q": query}, headers={"User-Agent": _USER_AGENT})
+        if response.status_code >= 400:
+            return []
+        return parse_result_urls(response.text, limit)
+    except Exception:
+        return []
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+async def run_search_plan(
+    plan: Any,
+    *,
+    per_query: int = 5,
+    max_urls: int = 60,
+    client: Any = None,
+    on_progress: Any = None,
+) -> SearchResult:
+    """Execute an acquisition plan and collect what it found.
+
+    The plan decided what to ask, including the arms nobody asks unprompted.
+    This only carries those questions to the network and brings back
+    addresses; it makes no judgment about which are worth reading.
+    """
+    result = SearchResult()
+    seen: set[str] = set()
+
+    for index, query in enumerate(plan.queries, 1):
+        if len(result.hits) >= max_urls:
+            result.failures.append(
+                f"stopped at {max_urls} candidate URLs; {len(plan.queries) - index + 1} queries unrun"
+            )
+            break
+        if on_progress:
+            on_progress(f"query {index}/{len(plan.queries)} [{query.arm}] {query.text[:60]}")
+
+        urls = await search_once(query.text, limit=per_query, client=client)
+        if not urls:
+            result.failures.append(f"{query.arm}::{query.text}")
+            continue
+        for url in urls:
+            if url in seen:
+                continue
+            seen.add(url)
+            result.hits.append(SearchHit(url=url, query=query.text, arm=query.arm))
+
+    return result

--- a/src/deepr/experts/corpus_search.py
+++ b/src/deepr/experts/corpus_search.py
@@ -54,6 +54,12 @@ class SearchResult:
 
     hits: list[SearchHit] = field(default_factory=list)
     failures: list[str] = field(default_factory=list)
+    attempted_arms: set[str] = field(default_factory=set)
+    """Every arm the plan ran, so an arm can be reported as contributing nothing.
+
+    Derived from failures alone, an arm whose every result was already seen
+    showed as neither found nor failed - invisible rather than reported. That
+    is a check passing because its subject is missing rather than sound."""
 
     @property
     def distinct_hosts(self) -> set[str]:
@@ -68,7 +74,7 @@ class SearchResult:
         balanced.
         """
         found = {hit.arm for hit in self.hits if hit.arm}
-        attempted = {q.split("::", 1)[0] for q in self.failures if "::" in q}
+        attempted = set(self.attempted_arms) | {q.split("::", 1)[0] for q in self.failures if "::" in q}
         return sorted(attempted - found)
 
     def to_dict(self) -> dict[str, Any]:
@@ -77,6 +83,7 @@ class SearchResult:
             "distinct_hosts": len(self.distinct_hosts),
             "hits": [hit.to_dict() for hit in self.hits],
             "failures": self.failures,
+            "arms_that_found_nothing": self.arms_that_found_nothing(),
         }
 
 
@@ -112,7 +119,10 @@ async def search_once(query: str, *, limit: int = 6, client: Any = None) -> list
     import httpx
 
     owns_client = client is None
-    client = client or httpx.AsyncClient(timeout=25.0, follow_redirects=True)
+    # trust_env=False so proxy environment variables cannot silently reroute a
+    # search, and no redirect chasing so a result page cannot walk this
+    # somewhere unintended. The endpoint answers the POST directly.
+    client = client or httpx.AsyncClient(timeout=25.0, trust_env=False, follow_redirects=False)
     try:
         response = await client.post(_ENDPOINT, data={"q": query}, headers={"User-Agent": _USER_AGENT})
         if response.status_code >= 400:
@@ -148,6 +158,7 @@ async def run_search_plan(
                 f"stopped at {max_urls} candidate URLs; {len(plan.queries) - index + 1} queries unrun"
             )
             break
+        result.attempted_arms.add(query.arm)
         if on_progress:
             on_progress(f"query {index}/{len(plan.queries)} [{query.arm}] {query.text[:60]}")
 

--- a/src/deepr/experts/corpus_search.py
+++ b/src/deepr/experts/corpus_search.py
@@ -101,6 +101,12 @@ class SearchResult:
     Derived from failures alone, an arm whose every result was already seen
     showed as neither found nor failed - invisible rather than reported. That
     is a check passing because its subject is missing rather than sound."""
+    planned_arms: set[str] = field(default_factory=set)
+    """The arms this plan actually contains, which is not always every arm.
+
+    ``plan_queries`` emits a terminology arm only for some subjects, so a plan
+    can legitimately hold five of the six declared arms. Coverage has to be
+    judged against what was planned rather than against the constant."""
 
     @property
     def distinct_hosts(self) -> set[str]:
@@ -124,8 +130,23 @@ class SearchResult:
 
         The gate on early stopping. Coverage reached during the descriptive
         arm is not coverage; it is the popular half of the subject.
+
+        Judged against the arms this plan holds, not the ``ARMS`` constant.
+        The check was hardcoded to 5 while ``ARMS`` held 6, so a plan
+        containing all six could stop with one arm never run. Comparing to
+        ``len(ARMS)`` instead would be worse: ``plan_queries`` emits no
+        terminology queries for many subjects, so the gate would never open,
+        early stopping would never fire, and the run would issue every query -
+        the ~120-request burst that got three builds rate-limited and is the
+        reason any of this exists.
+
+        An empty ``planned_arms`` means the caller built a result by hand
+        rather than through ``run_search_plan``; falling back to the attempted
+        set keeps that from reading as permanently incomplete.
         """
-        return len(self.attempted_arms) >= 5
+        if not self.planned_arms:
+            return bool(self.attempted_arms)
+        return self.planned_arms <= self.attempted_arms
 
     @property
     def looks_throttled(self) -> bool:
@@ -239,9 +260,9 @@ async def run_search_plan(
     with a corpus spanning enough independent publishers. Once that holds, the
     remaining queries are waste for us and abuse for them.
     """
-    result = SearchResult()
     seen: set[str] = set()
     queries = interleave_by_arm(list(plan.queries))
+    result = SearchResult(planned_arms={q.arm for q in queries if q.arm})
 
     for index, query in enumerate(queries, 1):
         if len(result.hits) >= max_urls:

--- a/src/deepr/experts/corpus_search.py
+++ b/src/deepr/experts/corpus_search.py
@@ -18,7 +18,9 @@ Costs network only. No model call, no metered surface, no API key.
 
 from __future__ import annotations
 
+import asyncio
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlparse
@@ -30,6 +32,39 @@ _HREF_RE = re.compile(r'href="(https?://[^"]+)"', re.IGNORECASE)
 _ENGINE_HOSTS = ("duckduckgo.com", "duck.com")
 
 _JUNK_SUFFIXES = (".jpg", ".jpeg", ".png", ".gif", ".svg", ".ico", ".css", ".js", ".zip")
+
+_MIN_INTERVAL_S = 2.5
+"""Minimum gap between searches, process-wide.
+
+Learned the expensive way: five expert builds running concurrently put roughly
+120 queries at one endpoint in a burst, and three of the five came back with
+zero URLs and no error. A rate limit that answers 200-with-nothing is
+indistinguishable from a topic nobody has written about, which is the worst
+shape a failure can take - it looks like a finding."""
+
+_throttle_lock: asyncio.Lock | None = None
+_last_request_at = 0.0
+
+
+async def _throttle(min_interval_s: float | None = None) -> None:
+    """Serialize searches across every concurrent caller in this process.
+
+    The interval is a parameter so tests can set it to zero. A throttle that
+    also slows the suite by two and a half minutes buys one problem with
+    another, and a slow suite is the kind of debt that gets paid by running it
+    less often.
+    """
+    interval = _MIN_INTERVAL_S if min_interval_s is None else min_interval_s
+    if interval <= 0:
+        return
+    global _throttle_lock, _last_request_at
+    if _throttle_lock is None:
+        _throttle_lock = asyncio.Lock()
+    async with _throttle_lock:
+        wait = interval - (time.monotonic() - _last_request_at)
+        if wait > 0:
+            await asyncio.sleep(wait)
+        _last_request_at = time.monotonic()
 
 
 @dataclass
@@ -54,6 +89,12 @@ class SearchResult:
 
     hits: list[SearchHit] = field(default_factory=list)
     failures: list[str] = field(default_factory=list)
+    stopped_early: str = ""
+    """Why the plan stopped short, named rather than left as a silent truncation."""
+    unrun_queries: int = 0
+    answered: int = 0
+    """Queries that returned anything. Zero across a whole plan means throttled,
+    not that the subject is unwritten."""
     attempted_arms: set[str] = field(default_factory=set)
     """Every arm the plan ran, so an arm can be reported as contributing nothing.
 
@@ -77,8 +118,26 @@ class SearchResult:
         attempted = set(self.attempted_arms) | {q.split("::", 1)[0] for q in self.failures if "::" in q}
         return sorted(attempted - found)
 
+    @property
+    def every_arm_tried(self) -> bool:
+        """True once each arm has run at least one query.
+
+        The gate on early stopping. Coverage reached during the descriptive
+        arm is not coverage; it is the popular half of the subject.
+        """
+        return len(self.attempted_arms) >= 5
+
+    @property
+    def looks_throttled(self) -> bool:
+        """Every query silent is a rate limit wearing the costume of a result."""
+        return self.answered == 0 and len(self.failures) >= 5
+
     def to_dict(self) -> dict[str, Any]:
         return {
+            "looks_throttled": self.looks_throttled,
+            "stopped_early": self.stopped_early,
+            "unrun_queries": self.unrun_queries,
+            "answered": self.answered,
             "hit_count": len(self.hits),
             "distinct_hosts": len(self.distinct_hosts),
             "hits": [hit.to_dict() for hit in self.hits],
@@ -111,13 +170,16 @@ def parse_result_urls(html: str, limit: int) -> list[str]:
     return seen
 
 
-async def search_once(query: str, *, limit: int = 6, client: Any = None) -> list[str]:
+async def search_once(
+    query: str, *, limit: int = 6, client: Any = None, min_interval_s: float | None = None
+) -> list[str]:
     """Run one query. Returns candidate URLs, or empty on any failure.
 
     Never raises: one dead query must not abort a plan of thirty.
     """
     import httpx
 
+    await _throttle(min_interval_s)
     owns_client = client is None
     # trust_env=False so proxy environment variables cannot silently reroute a
     # search, and no redirect chasing so a result page cannot walk this
@@ -135,37 +197,70 @@ async def search_once(query: str, *, limit: int = 6, client: Any = None) -> list
             await client.aclose()
 
 
+def interleave_by_arm(queries: list[Any]) -> list[Any]:
+    """Round-robin across arms rather than running each arm to exhaustion.
+
+    Stopping early is only safe if the arms are interleaved. Run arm by arm and
+    a coverage stop fires during the descriptive arm, so the adversarial and
+    primary queries - the ones that exist because nobody runs them unprompted -
+    never execute at all. That would be worse than not stopping.
+    """
+    buckets: dict[str, list[Any]] = {}
+    for query in queries:
+        buckets.setdefault(query.arm, []).append(query)
+    ordered: list[Any] = []
+    while any(buckets.values()):
+        for arm in list(buckets):
+            if buckets[arm]:
+                ordered.append(buckets[arm].pop(0))
+    return ordered
+
+
 async def run_search_plan(
     plan: Any,
     *,
-    per_query: int = 5,
+    per_query: int = 4,
     max_urls: int = 60,
+    target_hosts: int = 0,
     client: Any = None,
     on_progress: Any = None,
+    min_interval_s: float | None = None,
 ) -> SearchResult:
-    """Execute an acquisition plan and collect what it found.
+    """Execute an acquisition plan, stopping once the corpus is diverse enough.
 
     The plan decided what to ask, including the arms nobody asks unprompted.
-    This only carries those questions to the network and brings back
-    addresses; it makes no judgment about which are worth reading.
+    This carries those questions to the network and brings back addresses; it
+    makes no judgment about which are worth reading.
+
+    ``target_hosts`` is the important parameter and the reason for the
+    interleave. Running every query of every plan put roughly 120 requests at
+    one free endpoint in a burst, which got three builds rate-limited into
+    returning nothing. The goal was never to run every query; it was to end up
+    with a corpus spanning enough independent publishers. Once that holds, the
+    remaining queries are waste for us and abuse for them.
     """
     result = SearchResult()
     seen: set[str] = set()
+    queries = interleave_by_arm(list(plan.queries))
 
-    for index, query in enumerate(plan.queries, 1):
+    for index, query in enumerate(queries, 1):
         if len(result.hits) >= max_urls:
-            result.failures.append(
-                f"stopped at {max_urls} candidate URLs; {len(plan.queries) - index + 1} queries unrun"
-            )
+            result.stopped_early = f"reached the {max_urls}-URL ceiling"
+        elif target_hosts and len(result.distinct_hosts) >= target_hosts and result.every_arm_tried:
+            result.stopped_early = f"reached {len(result.distinct_hosts)} distinct hosts"
+        if result.stopped_early:
+            result.unrun_queries = len(queries) - index + 1
             break
+
         result.attempted_arms.add(query.arm)
         if on_progress:
-            on_progress(f"query {index}/{len(plan.queries)} [{query.arm}] {query.text[:60]}")
+            on_progress(f"query {index}/{len(queries)} [{query.arm}] {query.text[:60]}")
 
-        urls = await search_once(query.text, limit=per_query, client=client)
+        urls = await search_once(query.text, limit=per_query, client=client, min_interval_s=min_interval_s)
         if not urls:
             result.failures.append(f"{query.arm}::{query.text}")
             continue
+        result.answered += 1
         for url in urls:
             if url in seen:
                 continue

--- a/src/deepr/experts/council.py
+++ b/src/deepr/experts/council.py
@@ -15,7 +15,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
-from deepr.experts.briefed_perspective import build_briefed_perspective
+from deepr.experts.briefed_perspective import briefed_perspective_without_beliefs, build_briefed_perspective
 from deepr.experts.constants import MAX_COUNCIL_CONCURRENCY, SYNTHESIS_BUDGET_FRACTION, UTILITY_MODEL
 from deepr.experts.consult_lifecycle import ConsultLifecycleError
 from deepr.experts.council_synthesis_costs import (
@@ -437,7 +437,7 @@ class ExpertCouncil:
         original_ideas = list(perspective_state["original_ideas"])
         belief_file = canonical_expert_dir(name) / "beliefs" / "beliefs.json"
         if not belief_file.exists() and not original_ideas:
-            return None
+            return briefed_perspective_without_beliefs(query, name, domain, ExpertPerspective)
 
         store = BeliefStore(name, read_only=True, read_path=belief_file)
         perspective = self.build_stored_perspective(

--- a/src/deepr/experts/cross_domain.py
+++ b/src/deepr/experts/cross_domain.py
@@ -1,0 +1,227 @@
+"""Ask an expert about something outside its subject, on purpose.
+
+A furniture designer consulting an expert on Chinese writing gets nothing
+useful if the question is "what do your sources say about chairs." They get
+something worth having if the question is "you have spent a long time on a
+system where meaning is carried by stroke order, radical composition and the
+negative space inside a character - what does that make you notice about
+this."
+
+The expert knows nothing about furniture. That is the point. What transfers
+is not its facts but its **frame**: the distinctions it has learned to make,
+the failure modes it has learned to look for, the thing it has learned is
+usually the real problem. A frame built somewhere else notices different
+things, and noticing differently is most of what an outside perspective is
+for.
+
+Deepr's normal consult path forbids exactly this, correctly. Positions are
+ranked against the question and dropped when they do not match, coverage
+reports `uncovered`, and the expert says it holds nothing rather than
+answering from adjacent material. That rule exists because answering outside
+your evidence while sounding evidenced is the failure this whole system is
+built against.
+
+So this is a different mode, not a loosening of that one. Two rules keep it
+honest:
+
+**Nothing here is offered as evidence about the asked subject.** The expert's
+findings are about *its* corpus. Carried across, they are analogy, and every
+rendering says so. An analogy that presents as evidence is fabrication with a
+citation attached, which is worse than a guess.
+
+**The transfer is stated, not implied.** A useful cross-domain observation
+names what maps to what and where the mapping breaks. "Both involve
+composition" is a word, not an insight. Analogies are load-bearing exactly
+where they are specific and fail exactly where nobody checked whether they
+hold.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+CROSS_DOMAIN_SCHEMA_VERSION = "deepr-cross-domain-v1"
+
+_MAX_PATTERNS = 10
+
+
+@dataclass
+class CrossDomainReading:
+    """One expert's outside view, kept separate from its evidence."""
+
+    expert_name: str
+    asked_about: str
+    standpoint: str = ""
+    """The frame being lent. Empty when the expert has no reading of its own."""
+    preferred_lens: str = ""
+    observations: list[str] = field(default_factory=list)
+    """What this frame notices, each naming the mapping it rests on."""
+    where_it_breaks: list[str] = field(default_factory=list)
+    """Where the analogy stops holding. Without this it is decoration."""
+    schema_version: str = CROSS_DOMAIN_SCHEMA_VERSION
+
+    @property
+    def is_usable(self) -> bool:
+        """An analogy with no stated limit is not offered as one."""
+        return bool(self.observations and self.where_it_breaks)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "expert": self.expert_name,
+            "asked_about": self.asked_about,
+            "kind": "analogy",
+            "is_evidence": False,
+            "standpoint": self.standpoint,
+            "preferred_lens": self.preferred_lens,
+            "observations": self.observations,
+            "where_it_breaks": self.where_it_breaks,
+            "is_usable": self.is_usable,
+        }
+
+
+CROSS_DOMAIN_PROMPT = """You are an expert on "{expert_name}". You are being asked about something
+else entirely: {question}
+
+You do not know this subject and you are not being asked to pretend otherwise. Nobody wants your
+guess about it. What is wanted is what your subject has trained you to notice.
+
+You have spent a long time on {expert_name}. That has given you distinctions other people do not
+make, failure modes you look for first, and a sense of what is usually the real problem underneath
+what people ask about. Those travel. Your facts do not.
+
+So: read the question through your subject. What does your frame make visible here that someone
+inside this subject would probably not think to look at?
+
+Rules that keep this useful rather than decorative:
+
+- Every observation must name the specific mapping it rests on. "Both involve composition" is a
+  word, not an insight. "In my subject, the meaning lives in the order of construction, not the
+  finished form - so I would ask whether the order of assembly here carries information nobody is
+  reading" is an insight, because someone can check whether the mapping holds.
+- Say where the analogy breaks. An analogy with no stated limit is being offered as a fact. The
+  places it fails are usually where it would have misled someone.
+- Do not claim your sources say anything about this subject. They do not. You are lending a way of
+  seeing, not evidence.
+- If your frame genuinely offers nothing here, say so. A forced analogy is worse than none, and
+  admitting the reach failed is a real answer.
+
+{standpoint_block}
+House style: plain ASCII punctuation, a regular hyphen and never an en dash or em dash, straight
+quotes, no emoji.
+
+Return JSON only, no prose outside it, no code fence:
+
+{{
+  "observations": ["what your frame notices, each naming the mapping it rests on"],
+  "where_it_breaks": ["where the analogy stops holding, and why"]
+}}
+
+===== WHAT YOUR SUBJECT HAS TAUGHT YOU =====
+{material}
+===== END =====
+"""
+
+
+def build_cross_domain_prompt(
+    *,
+    expert_name: str,
+    question: str,
+    material: str,
+    standpoint: str = "",
+    preferred_lens: str = "",
+) -> str:
+    """Ask for the frame, and refuse the facts."""
+    block = ""
+    if standpoint:
+        block = f"How you read your own subject:\n  {standpoint}\n"
+    if preferred_lens:
+        block += f"The way of reading you find most revealing:\n  {preferred_lens}\n"
+    return CROSS_DOMAIN_PROMPT.format(
+        expert_name=expert_name,
+        question=question,
+        material=material,
+        standpoint_block=block,
+    )
+
+
+def frame_material(context: Any, *, limit: int = _MAX_PATTERNS) -> str:
+    """What to lend: the expert's patterns, not its question-matched evidence.
+
+    Deliberately ignores the question. Ranking findings against a question from
+    another subject would surface whatever shares vocabulary with it, which is
+    the least interesting thing an outside frame has to offer and the most
+    likely to look like false relevance.
+    """
+    lines: list[str] = []
+    if getattr(context, "orientation", ""):
+        lines += ["How this subject stands:", context.orientation, ""]
+
+    findings = list(getattr(context, "findings", []) or [])
+    if findings:
+        lines.append("Patterns this subject has taught me to see:")
+        lines += [f"- {f.title}" for f in findings[:limit]]
+        lines.append("")
+
+    settled = list(getattr(context, "settled", []) or [])
+    if settled:
+        lines.append("What is settled here, which may be where the useful contrast is:")
+        lines += [f"- {item}" for item in settled[:4]]
+        lines.append("")
+
+    live = list(getattr(context, "live", []) or [])
+    if live:
+        lines.append("What is still contested here:")
+        lines += [f"- {item}" for item in live[:4]]
+    return "\n".join(lines).strip()
+
+
+def assemble_reading(parsed: dict[str, Any], *, expert_name: str, question: str, **frame: str) -> CrossDomainReading:
+    """Build the reading, dropping observations that name no mapping."""
+
+    def _clean(items: Any) -> list[str]:
+        if not isinstance(items, list):
+            return []
+        return [" ".join(str(v).split()) for v in items if str(v).strip()][:_MAX_PATTERNS]
+
+    return CrossDomainReading(
+        expert_name=expert_name,
+        asked_about=question,
+        standpoint=frame.get("standpoint", ""),
+        preferred_lens=frame.get("preferred_lens", ""),
+        observations=_clean(parsed.get("observations")),
+        where_it_breaks=_clean(parsed.get("where_it_breaks")),
+    )
+
+
+def render_reading(reading: CrossDomainReading) -> str:
+    """Render an outside view, labeled as one in the first line."""
+    lines = [
+        f"## {reading.expert_name}, reading this from outside",
+        "",
+        "This is analogy, not evidence. My sources say nothing about your subject; what I am "
+        "lending is a way of looking at it, and you should check whether the mapping holds "
+        "before you rely on any of it.",
+        "",
+    ]
+    if reading.standpoint:
+        lines += [f"_How I read my own subject: {reading.standpoint}_", ""]
+
+    if not reading.observations:
+        lines.append("My frame does not reach this. A forced analogy would be worse than none.")
+        return "\n".join(lines)
+
+    lines.append("**What my frame notices here**")
+    lines += [f"- {item}" for item in reading.observations]
+    lines.append("")
+
+    if reading.where_it_breaks:
+        lines.append("**Where the analogy stops holding**")
+        lines += [f"- {item}" for item in reading.where_it_breaks]
+    else:
+        lines.append(
+            "**No limits stated.** An analogy that names nowhere it breaks is being offered as a "
+            "fact; treat every line above as less certain than it reads."
+        )
+    return "\n".join(lines)

--- a/src/deepr/experts/evidence_graph.py
+++ b/src/deepr/experts/evidence_graph.py
@@ -1,0 +1,369 @@
+"""The graph an expert already is, written down as one.
+
+Deepr has held this structure since the study pass existed and has never
+stored it. A finding carries ``corpus_shas`` - the retained sources its anchors
+were actually found in. A position carries ``supported_by`` - the findings it
+rests on. That is a two-hop provenance chain from a claim to a passage, kept as
+three flat lists in two files, so the one question it exists to answer has to
+be recomputed by hand every time anyone asks it.
+
+**This is not the concept graph.** ``lazy_graph_rag`` holds a real
+``KnowledgeGraph`` of concepts joined by co-occurrence, definition and
+dependency, useful for retrieval and built for the chat path. Its nodes are
+phrases with frequencies; its edges are all variants of "appeared near". It
+cannot express "this position rests on that finding which was anchored in that
+passage" without distorting both, so this is a separate artifact stored beside
+it rather than a rewrite of it.
+
+What having it as a graph makes cheap, none of which is cheap across two files:
+
+- **A position whose chain does not reach a source.** The strongest integrity
+  check available, and structural rather than statistical: it is not "few
+  anchors matched", it is "this claim connects to no passage at all". A
+  grounded ratio can average that away; a broken path cannot hide.
+- **Evidence nobody used.** A grounded finding no position rests on is either a
+  brief that missed something or a corpus that was read for nothing.
+- **A source carrying more weight than its share.** Which passage the most
+  claims trace back to, which is the concentration question asked where it can
+  actually be answered - per claim, rather than per document.
+
+It is temporal because every node records when it entered. An expert that has
+existed six months should be able to answer "what did you think in June, and
+what moved", and a graph whose nodes have no time cannot.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+EVIDENCE_GRAPH_SCHEMA_VERSION = "deepr-evidence-graph-v1"
+
+NODE_SOURCE = "source"
+NODE_FINDING = "finding"
+NODE_POSITION = "position"
+
+EDGE_ANCHORED_IN = "anchored_in"
+"""finding -> source. An anchor from this finding was found in that passage."""
+
+EDGE_RESTS_ON = "rests_on"
+"""position -> finding. This claim is built on that reading."""
+
+
+@dataclass
+class GraphNode:
+    """One thing an expert holds, with when it arrived."""
+
+    id: str
+    kind: str
+    label: str
+    first_seen: str = ""
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "label": self.label,
+            "first_seen": self.first_seen,
+            **self.attrs,
+        }
+
+
+@dataclass
+class GraphEdge:
+    """A claim of support, pointing from the dependent thing to what it needs."""
+
+    source: str
+    target: str
+    kind: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"from": self.source, "to": self.target, "kind": self.kind}
+
+
+@dataclass
+class EvidenceGraph:
+    """Sources, findings and positions, and what rests on what."""
+
+    expert_name: str
+    schema_version: str = EVIDENCE_GRAPH_SCHEMA_VERSION
+    built_at: str = ""
+    nodes: list[GraphNode] = field(default_factory=list)
+    edges: list[GraphEdge] = field(default_factory=list)
+
+    def _by_kind(self, kind: str) -> list[GraphNode]:
+        return [n for n in self.nodes if n.kind == kind]
+
+    @property
+    def sources(self) -> list[GraphNode]:
+        return self._by_kind(NODE_SOURCE)
+
+    @property
+    def findings(self) -> list[GraphNode]:
+        return self._by_kind(NODE_FINDING)
+
+    @property
+    def positions(self) -> list[GraphNode]:
+        return self._by_kind(NODE_POSITION)
+
+    def _outgoing(self, node_id: str, kind: str) -> list[str]:
+        return [e.target for e in self.edges if e.source == node_id and e.kind == kind]
+
+    def reaches_a_source(self, position_id: str) -> bool:
+        """Whether this position's support chain arrives at a retained passage.
+
+        Two hops, both required. A position resting on findings that are
+        themselves anchored in nothing is not partially grounded - it is a
+        claim with a bibliography that cites empty pages.
+        """
+        for finding_id in self._outgoing(position_id, EDGE_RESTS_ON):
+            if self._outgoing(finding_id, EDGE_ANCHORED_IN):
+                return True
+        return False
+
+    @property
+    def unsupported_positions(self) -> list[GraphNode]:
+        """Positions whose chain never reaches a source. The integrity check."""
+        return [p for p in self.positions if not self.reaches_a_source(p.id)]
+
+    @property
+    def unused_findings(self) -> list[GraphNode]:
+        """Grounded readings no position rests on.
+
+        Either the brief missed something or the corpus was read for nothing.
+        Both are worth knowing and neither is visible without the edges.
+        """
+        used = {e.target for e in self.edges if e.kind == EDGE_RESTS_ON}
+        return [f for f in self.findings if f.id not in used and f.attrs.get("grounded")]
+
+    def load_bearing_sources(self, limit: int = 5) -> list[tuple[str, int]]:
+        """Which passages the most claims trace back to.
+
+        Concentration asked where it can be answered: per claim rather than per
+        document. A corpus of thirty sources where every position routes
+        through two of them is two sources wearing thirty hats, and no
+        document-level count shows that.
+        """
+        counts: Counter[str] = Counter()
+        for position in self.positions:
+            reached: set[str] = set()
+            for finding_id in self._outgoing(position.id, EDGE_RESTS_ON):
+                reached.update(self._outgoing(finding_id, EDGE_ANCHORED_IN))
+            counts.update(reached)
+        labels = {n.id: n.label for n in self.sources}
+        return [(labels.get(sha, sha), n) for sha, n in counts.most_common(limit)]
+
+    @property
+    def is_formed(self) -> bool:
+        """Whether this is a graph rather than a pile of nodes.
+
+        Requires an actual traversal to exist: at least one position that
+        reaches a source through a finding. Counting nodes would let a study
+        with no brief - findings and sources, no path between claims and
+        passages - report a formed graph.
+        """
+        return any(self.reaches_a_source(p.id) for p in self.positions)
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "sources": len(self.sources),
+            "findings": len(self.findings),
+            "positions": len(self.positions),
+            "edges": len(self.edges),
+            "unsupported_positions": len(self.unsupported_positions),
+            "unused_findings": len(self.unused_findings),
+            "is_formed": self.is_formed,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "expert": self.expert_name,
+            "built_at": self.built_at,
+            "stats": self.stats(),
+            "load_bearing_sources": [{"source": s, "positions": n} for s, n in self.load_bearing_sources()],
+            "nodes": [n.to_dict() for n in self.nodes],
+            "edges": [e.to_dict() for e in self.edges],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvidenceGraph:
+        graph = cls(
+            expert_name=str(data.get("expert") or ""),
+            schema_version=str(data.get("schema_version") or EVIDENCE_GRAPH_SCHEMA_VERSION),
+            built_at=str(data.get("built_at") or ""),
+        )
+        for raw in data.get("nodes") or []:
+            if not isinstance(raw, dict) or not raw.get("id"):
+                continue
+            known = {"id", "kind", "label", "first_seen"}
+            graph.nodes.append(
+                GraphNode(
+                    id=str(raw["id"]),
+                    kind=str(raw.get("kind") or ""),
+                    label=str(raw.get("label") or ""),
+                    first_seen=str(raw.get("first_seen") or ""),
+                    attrs={k: v for k, v in raw.items() if k not in known},
+                )
+            )
+        for raw in data.get("edges") or []:
+            if not isinstance(raw, dict):
+                continue
+            if raw.get("from") and raw.get("to"):
+                graph.edges.append(
+                    GraphEdge(source=str(raw["from"]), target=str(raw["to"]), kind=str(raw.get("kind") or ""))
+                )
+        return graph
+
+
+def _entry_sha(entry: Any) -> str:
+    """The retained source's hash, whatever the store calls it.
+
+    ``CorpusStore`` entries name it ``sha256`` while findings record the same
+    value under ``corpus_shas``. Reading the wrong attribute silently produced
+    source nodes with empty ids, which dropped every anchored_in edge as
+    dangling and reported a fully-supported expert as having no position that
+    reaches a source. A wrong attribute name is indistinguishable from real
+    corruption in the output, so both names are accepted here.
+    """
+    for attribute in ("sha256", "sha"):
+        value = str(getattr(entry, attribute, "") or "")
+        if value:
+            return value
+    return ""
+
+
+def _source_nodes(corpus_entries: list[Any], at: str) -> list[GraphNode]:
+    nodes: list[GraphNode] = []
+    for entry in corpus_entries:
+        sha = _entry_sha(entry)
+        if not sha:
+            continue
+        nodes.append(
+            GraphNode(
+                id=sha,
+                kind=NODE_SOURCE,
+                label=str(getattr(entry, "title", "") or getattr(entry, "origin_key", "") or sha[:12]),
+                first_seen=str(getattr(entry, "added_at", "") or getattr(entry, "fetched_at", "") or at),
+                attrs={
+                    "origin_key": str(getattr(entry, "origin_key", "") or ""),
+                    "publisher": str(getattr(entry, "publisher", "") or ""),
+                },
+            )
+        )
+    return nodes
+
+
+def build_graph(
+    *,
+    expert_name: str,
+    study: Any,
+    brief: Any,
+    corpus_entries: list[Any] | None = None,
+    at: str = "",
+) -> EvidenceGraph:
+    """Materialise the chain that already exists across study.json and brief.json.
+
+    Nothing here is inferred. Every edge is copied from a field that was
+    already recorded: ``corpus_shas`` on a finding, ``supported_by`` on a
+    position. The graph is a change of storage, not a new claim, which is why
+    it can be rebuilt from scratch at any time without a model call.
+    """
+    graph = EvidenceGraph(expert_name=expert_name, built_at=at)
+    graph.nodes.extend(_source_nodes(corpus_entries or [], at))
+    known_sources = {n.id for n in graph.nodes}
+
+    findings = list(getattr(study, "findings", []) or []) if study is not None else []
+    for finding in findings:
+        finding_id = str(getattr(finding, "finding_id", "") or "")
+        if not finding_id:
+            continue
+        graph.nodes.append(
+            GraphNode(
+                id=finding_id,
+                kind=NODE_FINDING,
+                label=str(getattr(finding, "title", "") or finding_id),
+                first_seen=str(getattr(study, "started_at", "") or at),
+                attrs={
+                    "lens": str(getattr(finding, "lens", "") or ""),
+                    "grounded": bool(getattr(finding, "is_grounded", False)),
+                },
+            )
+        )
+        for sha in set(getattr(finding, "corpus_shas", []) or []):
+            # Only to sources actually retained. An anchor naming a document
+            # that is no longer in the corpus is a dangling edge, and a
+            # dangling edge would let a position claim support from a passage
+            # nobody can open.
+            if str(sha) in known_sources:
+                graph.edges.append(GraphEdge(source=finding_id, target=str(sha), kind=EDGE_ANCHORED_IN))
+
+    known_findings = {n.id for n in graph.findings}
+    positions = list(getattr(brief, "positions", []) or []) if brief is not None else []
+    for index, position in enumerate(positions, start=1):
+        position_id = f"position-{index}"
+        graph.nodes.append(
+            GraphNode(
+                id=position_id,
+                kind=NODE_POSITION,
+                label=str(getattr(position, "question", "") or position_id),
+                first_seen=at,
+                attrs={
+                    "stance": str(getattr(position, "stance", "") or ""),
+                    "likelihood": str(getattr(position, "likelihood", "") or ""),
+                    "confidence": str(getattr(position, "confidence", "") or ""),
+                },
+            )
+        )
+        for finding_id in getattr(position, "supported_by", []) or []:
+            if str(finding_id) in known_findings:
+                graph.edges.append(GraphEdge(source=position_id, target=str(finding_id), kind=EDGE_RESTS_ON))
+
+    return graph
+
+
+def render_graph(graph: EvidenceGraph) -> str:
+    """What the graph shows that the flat files could not."""
+    stats = graph.stats()
+    lines = [
+        f"# {graph.expert_name}: evidence graph",
+        "",
+        f"{stats['sources']} source(s), {stats['findings']} finding(s), "
+        f"{stats['positions']} position(s), {stats['edges']} edge(s).",
+        "",
+    ]
+
+    if not stats["is_formed"]:
+        lines += [
+            "No position reaches a source through a finding, so this is a pile of nodes "
+            "rather than a graph. Run study and brief before reading anything into it.",
+            "",
+        ]
+
+    if graph.unsupported_positions:
+        lines += ["## Positions that reach no source", ""]
+        lines += [f"- {p.label}" for p in graph.unsupported_positions]
+        lines += ["", "_A claim with a bibliography citing empty pages. Re-brief or re-study._", ""]
+
+    if graph.unused_findings:
+        lines += [
+            "## Evidence nothing rests on",
+            "",
+            f"{len(graph.unused_findings)} grounded finding(s) support no position. Either the "
+            "brief missed something or this part of the corpus was read for nothing.",
+            "",
+        ]
+
+    if load_bearing := graph.load_bearing_sources():
+        lines += ["## What the claims actually rest on", ""]
+        lines += [f"- {label}: {count} position(s)" for label, count in load_bearing]
+        lines += [
+            "",
+            "_Concentration per claim rather than per document. Thirty sources where every "
+            "position routes through two of them is two sources wearing thirty hats._",
+            "",
+        ]
+
+    return "\n".join(lines)

--- a/src/deepr/experts/evidence_graph.py
+++ b/src/deepr/experts/evidence_graph.py
@@ -309,7 +309,13 @@ def build_graph(
                 id=position_id,
                 kind=NODE_POSITION,
                 label=str(getattr(position, "question", "") or position_id),
-                first_seen=at,
+                # Left empty rather than stamped with the build time. A
+                # position's real first_seen is when the brief was written,
+                # and a brief carries no timestamp - so filling it from `at`
+                # produced a field that equalled built_at and reset on every
+                # rebuild. An honestly empty field beats a confidently wrong
+                # one, and this is the first thing V2 has to fix.
+                first_seen="",
                 attrs={
                     "stance": str(getattr(position, "stance", "") or ""),
                     "likelihood": str(getattr(position, "likelihood", "") or ""),

--- a/src/deepr/experts/evidence_graph.py
+++ b/src/deepr/experts/evidence_graph.py
@@ -38,6 +38,8 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any
 
+from deepr.experts.record_identity import position_thread_id
+
 EVIDENCE_GRAPH_SCHEMA_VERSION = "deepr-evidence-graph-v1"
 
 NODE_SOURCE = "source"
@@ -303,7 +305,12 @@ def build_graph(
     known_findings = {n.id for n in graph.findings}
     positions = list(getattr(brief, "positions", []) or []) if brief is not None else []
     for index, position in enumerate(positions, start=1):
-        position_id = f"position-{index}"
+        # Derived from the question, so a position keeps its identity across
+        # re-briefs and reorderings. The positional form made `position-3` a
+        # different question every time the brief was rebuilt, which is why
+        # nothing outside this file could ever refer to a position.
+        question = str(getattr(position, "question", "") or "")
+        position_id = position_thread_id(question) if question else f"position-{index}"
         graph.nodes.append(
             GraphNode(
                 id=position_id,

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -62,9 +62,26 @@ each rung adds one thing:
 | F | brand new. Nothing to go on. |
 | D | claims, but no retained corpus, so nothing can be re-read or checked. |
 | C | a corpus, and initial research done. Findings, no formed view yet. |
-| B | briefed and consultable, but something structural is wrong - one publisher supplies most of it, or the findings do not trace back. |
-| A | well researched, independently sourced, holds a perspective and insights. Not current, or not being used. |
-| S | all of A, plus up to date, plus actually consulted lately and given a chance to research and update since. |
+| B | briefed and consultable, and one of five things is wrong. |
+| A | all five clear, and it holds a perspective. Not current, or not being used. |
+| S | all of A, plus read in the last month, plus actually consulted in it. |
+
+The five gates at B, and nothing else:
+
+1. **A thin or captured corpus** - fewer than five publishers, or one supplying
+   most of it.
+2. **Findings that do not trace back** - and no path in the evidence graph from
+   any position to a passage.
+3. **A small or unrecorded model did the reading** - see ``model_tier``.
+4. **No standpoint of its own** - positions without a reading is an index.
+5. **Not current, or nobody uses it** - which separates A from S.
+
+Deliberately dropped as gates, kept as warnings: cross-source findings,
+contention carried forward, declared open questions, named weaknesses,
+recorded mind changes, settled-claim counts. Each was an inference about
+quality from a structural proxy, and every one of them can be satisfied by a
+shallow reading as easily as a deep one. Which model did the reading predicts
+more than all of them together, and is a fact rather than an inference.
 
 The only difference between A and S is **liveness**. A is a good expert; S is a
 good expert that is being used and is keeping up. That is deliberate, because
@@ -165,6 +182,15 @@ class ExpertHealth:
     cards: int = 0
     age_days: int = -1
     """Days since the study was last run. -1 when never."""
+    graph_is_formed: bool = False
+    """Whether a position reaches a source through a finding.
+
+    Structural, and stronger than the ratio beside it. ``grounded_ratio``
+    averages - a brief where half the findings anchor nowhere still scores 0.5
+    and reads as middling. This asks whether the traversal exists at all:
+    whether any claim connects to a passage someone can open. Read from the
+    evidence graph, which is derived from artifacts already on disk, so it
+    costs nothing and cannot disagree with them."""
     model_tier: str = "unknown"
     """The weakest model that read this corpus or wrote this standpoint.
 
@@ -310,15 +336,16 @@ class ExpertHealth:
         if not self.is_studied or not self.is_consultable:
             return "C"
 
-        # Structural problems keep an expert at B however much it has read.
-        # A corpus that is one publisher wearing hats, or findings that do not
-        # trace back to a passage, are wrong in a way more reading cannot fix.
-        if self.is_captured or self.grounded_ratio < 0.5 or self.dropped_the_dissent:
+        # Five gates, each wrong in a way more reading cannot fix.
+        if self.is_captured or self.origin_count < _GOOD_ORIGINS:
+            return "B"
+        if self.grounded_ratio < 0.5 or not self.graph_is_formed:
+            return "B"
+        if not self.read_by_a_capable_model:
+            return "B"
+        if not self.has_perspective:
             return "B"
 
-        well_researched = self.origin_count >= _GOOD_ORIGINS and self.cross_source_findings > 0 and self.has_perspective
-        if not well_researched:
-            return "B"
         if self.is_current and self.is_in_use:
             return "S"
         return "A"
@@ -353,6 +380,17 @@ class ExpertHealth:
                 f"{self.sources} source(s) across {self.origin_count} publisher(s), with "
                 f"{self.dominant_share:.0%} from the largest. Agreement here is mostly one "
                 "publisher agreeing with itself. Acquire from elsewhere.",
+            ),
+            (
+                not self.graph_is_formed and self.positions > 0,
+                "No position reaches a source through a finding, so no claim connects to a passage "
+                "anyone can open. Run `expert graph` to see where the chain breaks.",
+            ),
+            (
+                not self.read_by_a_capable_model,
+                f"Read by a {self.model_tier} model. A small model and a frontier model reading the "
+                "same corpus produce different experts, and no later statistic recovers the "
+                "difference. Re-study on a plan backend.",
             ),
             (
                 self.cross_source_findings == 0 and self.findings > 1,
@@ -439,9 +477,21 @@ def _weakest_model_tier(study: dict[str, Any] | None, profile: dict[str, Any] | 
     produced, so it cannot be better than them; stamping it as well would add a
     third read of the same constraint without adding information.
     """
-    from deepr.experts.model_provenance import ModelProvenance, weakest
+    from deepr.experts.model_provenance import ModelProvenance, record, weakest
 
-    stamps = [ModelProvenance.from_dict((source or {}).get("model_provenance")) for source in (study, profile)]
+    stamps: list[ModelProvenance] = []
+    for source in (study, profile):
+        data = source or {}
+        if stamp := data.get("model_provenance"):
+            stamps.append(ModelProvenance.from_dict(stamp))
+            continue
+        # Fall back to the older ``capacity_source`` field. Every study written
+        # before the stamp existed still recorded which backend ran, and the
+        # tier is derived from exactly that - so the whole existing fleet is
+        # rankable without re-studying anything, which would have burned hours
+        # of quota to recover information already sitting on disk.
+        if legacy := data.get("capacity_source"):
+            stamps.append(record(str(legacy), str(data.get("model") or "")))
     return weakest(stamps).tier
 
 
@@ -550,6 +600,8 @@ def assess_expert(
         )
 
     health.model_tier = _weakest_model_tier(study, _load_json(expert_dir / "profile_card.json"))
+    graph = _load_json(expert_dir / "graph" / "evidence.json")
+    health.graph_is_formed = bool(((graph or {}).get("stats") or {}).get("is_formed"))
 
     profile = _load_json(expert_dir / "profile_card.json")
     if profile:

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -102,6 +102,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from deepr.experts.expert_layout import part_in
+
 HEALTH_SCHEMA_VERSION = "deepr-expert-health-v1"
 
 _STALE_DAYS = 90
@@ -561,7 +563,7 @@ def assess_expert(
     """
     health = ExpertHealth(name=name, beliefs=beliefs, consulted_days_ago=consulted_days_ago)
 
-    study = _load_json(expert_dir / "study.json")
+    study = _load_json(part_in(expert_dir, "noticed"))
     if study:
         totals = study.get("totals") or {}
         health.findings = int(totals.get("findings", 0) or 0)
@@ -586,7 +588,7 @@ def assess_expert(
             except OSError:
                 pass
 
-    brief = _load_json(expert_dir / "brief.json")
+    brief = _load_json(part_in(expert_dir, "hold_current"))
     if brief:
         positions = brief.get("positions") or []
         health.positions = len(positions)
@@ -599,11 +601,11 @@ def assess_expert(
             1 for item in (state.get("unknown") or []) + (state.get("live") or []) if admits_something(item)
         )
 
-    health.model_tier = _weakest_model_tier(study, _load_json(expert_dir / "profile_card.json"))
+    health.model_tier = _weakest_model_tier(study, _load_json(part_in(expert_dir, "self")))
     graph = _load_json(expert_dir / "graph" / "evidence.json")
     health.graph_is_formed = bool(((graph or {}).get("stats") or {}).get("is_formed"))
 
-    profile = _load_json(expert_dir / "profile_card.json")
+    profile = _load_json(part_in(expert_dir, "self"))
     if profile:
         health.standpoint = profile.get("standpoint", "")
         health.open_questions += sum(1 for q in (profile.get("open_questions") or []) if admits_something(q))

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -442,8 +442,13 @@ def last_consulted_days(*, now: datetime | None = None, limit: int = 500) -> dic
         days = _age_days(str(trace.get("recorded_at") or ""), now=now)
         if days < 0:
             continue
-        payload = trace.get("result") or trace
-        names = payload.get("experts_consulted") or trace.get("requested_experts") or []
+        # Both sides of the record, because they answer different questions.
+        # `output.experts_consulted` is who actually spoke; `input.requested_
+        # experts` is who was asked for. A consult that failed still means
+        # somebody wanted this expert's view, which is the thing being
+        # measured - "is anyone using it", not "did it succeed".
+        names = list((trace.get("output") or {}).get("experts_consulted") or [])
+        names += list((trace.get("input") or {}).get("requested_experts") or [])
         for expert_name in names:
             key = str(expert_name)
             if key not in seen or days < seen[key]:

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -5,10 +5,23 @@ that decide whether an expert is worth asking already exist - independent
 origin count, cross-source findings, grounded ratio, whether a brief was ever
 formed, how old the reading is - and nothing collects them.
 
-A grade is a triage device, not a verdict. It exists so a person with forty
-experts can find the three that need work, and it is paired with the specific
-next action every time, because "grade C" tells you nothing you can act on and
-"no corpus; run acquire" does.
+**This is artifact hygiene, not quality, and the distinction is the whole
+point.** It answers questions a directory listing can answer: is there a
+retained corpus, did anything read it, did the reading land anywhere, is the
+corpus one publisher wearing several hats, are the claims traceable to a
+passage. It cannot tell anyone whether an expert is worth talking to. A corpus
+of five mutually-agreeing bad sources scores exactly like five good ones,
+because nothing here has an opinion about whether the material was any good.
+
+So it is a maintenance queue, not a ranking of minds. With fifty experts,
+"which three need work and what do they need" is a real question with a cheap
+answer, and every grade ships with one next action for that reason. Whether an
+expert actually knows anything is a different question, answered by a test
+built for that subject from that subject's own corpus - holding a source back
+and seeing if the expert predicts it, asking what the material genuinely does
+not cover, asking about something that does not exist. Those produce evidence
+about one expert on one subject. They do not produce a letter, and the letter
+should not pretend to stand in for them.
 
 Two deliberate choices about how it grades.
 

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -12,10 +12,19 @@ next action every time, because "grade C" tells you nothing you can act on and
 
 Two deliberate choices about how it grades.
 
-**Depth is counted by origin, not by document.** Thirty pages from one
-publisher is one publisher's authority. An expert can look substantial by
-document count and be a single source wearing thirty hats, which is the
-measurement error every corroboration number downstream inherits.
+**Depth is breadth plus concentration, not entropy.** Thirty pages from one
+publisher is one publisher's authority, so documents are the wrong unit. But
+effective source count - exp of the share entropy - is the wrong gate, because
+it rewards *uniformity*: five publishers with one document each scores 5.0,
+while the same five publishers with twenty documents from the most
+authoritative one scores 1.98 and is told to go find other sources. The second
+corpus is strictly better and the metric says to delete fifteen documents.
+
+So the gate is ``origin_count`` (monotone in acquisition, so reading more can
+never hurt) together with ``dominant_share`` (which catches the one-publisher
+case the entropy measure was reached for). Effective source count stays where
+it belongs, in the warning text, describing concentration rather than gating
+on it.
 
 **A missing brief caps the grade regardless of everything else.** An expert
 with a large corpus and no formed view is a search index. It may be a very
@@ -40,6 +49,7 @@ describe something worth aiming at rather than to hand out praise.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -54,8 +64,30 @@ staleness rate varies by subject far more than any single number admits."""
 _CURRENT_DAYS = 30
 """Read within a month. S claims to be up to date, so it has to have looked."""
 
-_THIN_ORIGINS = 2.0
-_GOOD_ORIGINS = 5.0
+_DOMINANT_SHARE = 0.6
+"""One publisher above this share sets what the corpus can conclude."""
+
+_GOOD_ORIGINS = 5
+"""Distinct publishers for depth. Invented, and per-subject would be better:
+for some fields three standards bodies are the entire universe."""
+
+_EMPTY_ADMISSION = re.compile(
+    r"^\W*(none|n/?a|not applicable|nothing|no\s+(?:unresolved\s+)?"
+    r"(?:disagreement|dissent|weakness|conflict|contention)\w*)\b",
+    re.IGNORECASE,
+)
+"""Text that admits nothing while occupying the field.
+
+"None identified in the corpus." scored as recorded dissent, so the expert
+that wrote a sentence saying there was none outranked the one that honestly
+left it blank. The form of the confession was being graded, not its content,
+and in the direction that made honesty the losing move."""
+
+
+def admits_something(text: str) -> bool:
+    """True when a field says something rather than filling itself."""
+    cleaned = " ".join(str(text or "").split())
+    return len(cleaned) > 12 and not _EMPTY_ADMISSION.match(cleaned)
 
 
 @dataclass
@@ -68,6 +100,10 @@ class ExpertHealth:
     beliefs: int = 0
     sources: int = 0
     effective_origins: float = 0.0
+    origin_count: int = 0
+    """Distinct publishers. Monotone in acquisition, unlike effective origins."""
+    dominant_share: float = 0.0
+    """Share held by the largest publisher. This is what catches capture."""
     findings: int = 0
     grounded_findings: int = 0
     cross_source_findings: int = 0
@@ -76,7 +112,17 @@ class ExpertHealth:
     positions_with_dissent: int = 0
     """Positions that record something they did not resolve."""
     open_questions: int = 0
-    """What the expert says it is still working on, from its own profile."""
+    """What the expert says it is still working on. Self-reported, so weak."""
+    contention_findings: int = 0
+    """Disagreement the contention lens actually found in the corpus.
+
+    The behavioural half of the openness check. Compared against dissent the
+    brief carried forward, it separates a subject with nothing to argue about
+    from a brief that dropped what the lens found."""
+    settled_claims: int = 0
+    """How much the expert reports as closed. A genuinely settled subject
+    produces a long settled list, which is the opposite of a short one with no
+    live questions."""
     known_weaknesses: int = 0
     mind_changes: int = 0
     """Recorded shifts in standpoint. Never revised is never tested."""
@@ -106,14 +152,37 @@ class ExpertHealth:
         return self.age_days > _STALE_DAYS
 
     @property
-    def is_open(self) -> bool:
-        """Whether the expert has left itself any room.
+    def subject_is_contested(self) -> bool:
+        """Whether this corpus contains disagreement to be open about.
 
-        Any one of: something it could not resolve, a question it is still
-        working on, or a weakness it names. An expert with none of the three
-        is closed, and a closed expert cannot learn the thing it claims to
-        know.
+        Read from the contention lens rather than from the expert's own
+        account of itself. A frozen specification legitimately produces none,
+        and penalizing that penalizes correct calibration.
         """
+        return self.contention_findings > 0
+
+    @property
+    def dropped_the_dissent(self) -> bool:
+        """The lens found disagreement and the brief carried none forward.
+
+        This is the closed *mind* as opposed to the closed *subject*, and it
+        is a comparison between two artifacts rather than a self-report, which
+        is why it carries more weight than anything the expert says about
+        itself.
+        """
+        return self.subject_is_contested and self.positions > 0 and self.positions_with_dissent == 0
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the expert left itself room, judged against its subject.
+
+        On a contested subject, carrying the disagreement forward is what
+        counts, because it can be checked against the study. On an uncontested
+        one a declared open question or named weakness is enough, and
+        manufactured doubt is not required.
+        """
+        if self.dropped_the_dissent:
+            return False
         return bool(self.positions_with_dissent or self.open_questions or self.known_weaknesses)
 
     @property
@@ -140,6 +209,17 @@ class ExpertHealth:
         return 0 <= self.age_days <= _CURRENT_DAYS
 
     @property
+    def is_captured(self) -> bool:
+        """One publisher supplies most of the corpus, or there is only one.
+
+        Catches the case entropy was reached for without punishing an expert
+        for reading a lot of the best source it has.
+        """
+        if self.origin_count <= 1:
+            return bool(self.sources)
+        return self.dominant_share >= _DOMINANT_SHARE
+
+    @property
     def grade(self) -> str:
         """A triage letter. Always read with ``next_action``.
 
@@ -155,7 +235,7 @@ class ExpertHealth:
             return "C"
         if not self.is_consultable:
             return "C"
-        if self.effective_origins < _THIN_ORIGINS or self.grounded_ratio < 0.5:
+        if self.is_captured or self.grounded_ratio < 0.5:
             return "B"
         if not self.is_open:
             # A closed expert cannot climb however good its corpus. Certainty
@@ -163,7 +243,7 @@ class ExpertHealth:
             # which one stops learning it.
             return "B"
 
-        deep = self.effective_origins >= _GOOD_ORIGINS and self.cross_source_findings > 0
+        deep = self.origin_count >= _GOOD_ORIGINS and self.cross_source_findings > 0 and not self.is_captured
         if deep and self.is_current and self.has_perspective and self.is_hungry:
             return "S"
         if deep and not self.is_stale:
@@ -196,20 +276,26 @@ class ExpertHealth:
                 "Re-study before trusting it.",
             ),
             (
-                self.effective_origins < _THIN_ORIGINS,
-                f"{self.sources} source(s) collapse to {self.effective_origins:.1f} independent "
-                "origin(s), so agreement here is one publisher agreeing with itself. Acquire "
-                "from elsewhere.",
+                self.is_captured,
+                f"{self.sources} source(s) across {self.origin_count} publisher(s), with "
+                f"{self.dominant_share:.0%} from the largest. Agreement here is mostly one "
+                "publisher agreeing with itself. Acquire from elsewhere.",
             ),
             (
                 self.cross_source_findings == 0 and self.findings > 1,
                 "No finding draws on more than one source, so nothing here compares sources. Re-study.",
             ),
             (
+                self.dropped_the_dissent,
+                f"The contention lens found {self.contention_findings} disagreement(s) in the "
+                "corpus and the brief carried none of them into a position. That is the "
+                "disagreement being averaged away, not a subject without any. Re-brief.",
+            ),
+            (
                 not self.is_open,
-                "Holds no unresolved dissent, no open questions and names no weakness. That is "
-                "possible, and it is also what an expert looks like once it has stopped looking. "
-                "Check the contention findings the brief did not carry forward.",
+                "Names no open question and no weakness, and the corpus shows no contention "
+                "either. That may be a settled subject, in which case manufactured doubt would "
+                "be worse. Run profile so the expert says which it is.",
             ),
             (
                 unfalsifiable > 0,
@@ -250,6 +336,9 @@ class ExpertHealth:
             is_hungry=self.is_hungry,
             has_perspective=self.has_perspective,
             is_current=self.is_current,
+            is_captured=self.is_captured,
+            subject_is_contested=self.subject_is_contested,
+            dropped_the_dissent=self.dropped_the_dissent,
         )
         return data
 
@@ -284,9 +373,14 @@ def assess_expert(name: str, expert_dir: Path, *, beliefs: int = 0, now: datetim
         health.grounded_findings = int(totals.get("grounded_findings", 0) or 0)
         health.cross_source_findings = int(totals.get("cross_source_findings", 0) or 0)
         health.age_days = _age_days(study.get("started_at", ""), now=now)
+        health.contention_findings = sum(
+            int(o.get("finding_count", 0) or 0) for o in (study.get("outcomes") or []) if o.get("lens") == "contention"
+        )
         independence = study.get("independence") or {}
         health.sources = int(independence.get("source_count", 0) or 0)
         health.effective_origins = float(independence.get("effective_source_count", 0.0) or 0.0)
+        health.origin_count = int(independence.get("origin_count", 0) or 0)
+        health.dominant_share = float(independence.get("dominant_share", 0.0) or 0.0)
 
     if not health.sources:
         index = expert_dir / "corpus" / "index.jsonl"
@@ -302,16 +396,19 @@ def assess_expert(name: str, expert_dir: Path, *, beliefs: int = 0, now: datetim
         positions = brief.get("positions") or []
         health.positions = len(positions)
         health.falsifiable_positions = sum(1 for p in positions if p.get("is_falsifiable"))
-        health.positions_with_dissent = sum(1 for p in positions if (p.get("unresolved_dissent") or "").strip())
+        health.positions_with_dissent = sum(1 for p in positions if admits_something(p.get("unresolved_dissent")))
         health.integrity_warnings = list(brief.get("integrity_warnings") or [])
         state = brief.get("state") or {}
-        health.open_questions = len(state.get("unknown") or []) + len(state.get("live") or [])
+        health.settled_claims = len(state.get("settled") or [])
+        health.open_questions = sum(
+            1 for item in (state.get("unknown") or []) + (state.get("live") or []) if admits_something(item)
+        )
 
     profile = _load_json(expert_dir / "profile_card.json")
     if profile:
         health.standpoint = profile.get("standpoint", "")
-        health.open_questions += len(profile.get("open_questions") or [])
-        health.known_weaknesses = len(profile.get("where_it_is_weak") or [])
+        health.open_questions += sum(1 for q in (profile.get("open_questions") or []) if admits_something(q))
+        health.known_weaknesses = sum(1 for w in (profile.get("where_it_is_weak") or []) if admits_something(w))
         health.mind_changes = len(profile.get("shifts") or [])
 
     cards = expert_dir / "cards"
@@ -334,5 +431,6 @@ def fleet_summary(fleet: list[ExpertHealth]) -> dict[str, Any]:
         "stale": sum(1 for e in fleet if e.is_stale),
         "never_studied": sum(1 for e in fleet if not e.is_studied),
         "closed": sum(1 for e in fleet if e.is_studied and not e.is_open),
+        "dropped_dissent": sum(1 for e in fleet if e.dropped_the_dissent),
         "s_tier": sum(1 for e in fleet if e.grade == "S"),
     }

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -165,6 +165,18 @@ class ExpertHealth:
     cards: int = 0
     age_days: int = -1
     """Days since the study was last run. -1 when never."""
+    model_tier: str = "unknown"
+    """The weakest model that read this corpus or wrote this standpoint.
+
+    Weighted heavily, and deliberately so. A small local model and a frontier
+    model reading the same corpus through the same lenses produce genuinely
+    different experts, and no downstream statistic recovers the difference: a
+    shallow finding is grounded, traceable and cross-source exactly as easily
+    as a deep one, so every corroboration metric scores both alike.
+
+    It is also the only signal on this record that is a fact rather than an
+    inference. Everything else here infers quality from structure, and two of
+    those inferences have already had to be withdrawn."""
     consulted_days_ago: int = -1
     """Days since anyone last asked this expert anything. -1 when never.
 
@@ -248,6 +260,19 @@ class ExpertHealth:
     @property
     def is_current(self) -> bool:
         return 0 <= self.age_days <= _CURRENT_DAYS
+
+    @property
+    def read_by_a_capable_model(self) -> bool:
+        """Whether a mid-tier or better model did the reading.
+
+        Unknown does not pass. An expert built before this was recorded, or by
+        a model whose size cannot be read off its tag, has no evidence either
+        way - and absence of evidence must not read as evidence of quality,
+        which is the mistake that produced every withdrawn signal here.
+        """
+        from deepr.experts.model_provenance import TIER_MID, at_least
+
+        return at_least(self.model_tier, TIER_MID)
 
     @property
     def is_in_use(self) -> bool:
@@ -392,6 +417,7 @@ class ExpertHealth:
             has_perspective=self.has_perspective,
             is_current=self.is_current,
             is_in_use=self.is_in_use,
+            read_by_a_capable_model=self.read_by_a_capable_model,
             is_captured=self.is_captured,
             subject_is_contested=self.subject_is_contested,
             dropped_the_dissent=self.dropped_the_dissent,
@@ -404,6 +430,19 @@ def _load_json(path: Path) -> dict[str, Any]:
         return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
     except (json.JSONDecodeError, OSError, ValueError):
         return {}
+
+
+def _weakest_model_tier(study: dict[str, Any] | None, profile: dict[str, Any] | None) -> str:
+    """The weakest model in this expert's chain, across the artifacts that stamp one.
+
+    Study and profile only. The brief is written from findings the study
+    produced, so it cannot be better than them; stamping it as well would add a
+    third read of the same constraint without adding information.
+    """
+    from deepr.experts.model_provenance import ModelProvenance, weakest
+
+    stamps = [ModelProvenance.from_dict((source or {}).get("model_provenance")) for source in (study, profile)]
+    return weakest(stamps).tier
 
 
 def _age_days(started_at: str, *, now: datetime | None = None) -> int:
@@ -509,6 +548,8 @@ def assess_expert(
         health.open_questions = sum(
             1 for item in (state.get("unknown") or []) + (state.get("live") or []) if admits_something(item)
         )
+
+    health.model_tier = _weakest_model_tier(study, _load_json(expert_dir / "profile_card.json"))
 
     profile = _load_json(expert_dir / "profile_card.json")
     if profile:

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -44,19 +44,36 @@ with a large corpus and no formed view is a search index. It may be a very
 good search index, and the grade should not imply it is a consultable expert,
 because the whole difference is whether it has landed anywhere.
 
-**Certainty lowers the grade rather than raising it.** An expert holding no
-unresolved dissent, naming no open questions and having never changed its mind
-is not a finished expert; it is a closed one. A full cup has no room, and an
-expert that believes it has the subject has stopped being able to learn it -
-which is the moment it stops being worth consulting, whatever its corpus looks
-like.
+**Dropping real disagreement lowers the grade; declared certainty does not.**
+The full-cup instinct is sound and the obvious way to measure it is wrong.
+Asking an expert to declare its open questions and weaknesses grades a
+self-report against a rubric it can read, and a frozen specification has no
+live dissent to declare - manufacturing some there would be worse than
+reporting none. So the penalty attaches to one checkable comparison instead:
+the contention lens found disagreement in the corpus and the brief carried
+none of it into a position. That is disagreement being averaged away, and it
+is a claim about two artifacts rather than about a personality.
 
-**S is all four at once, and deliberately hard to reach.** Deep and
-independently sourced, current, holding a perspective of its own rather than a
-pile of facts, and still actively wanting to know more. Anything short of all
-four is not S. Most experts should sit below it, including good ones: a grade
-most things reach measures nothing, and the top of this ladder exists to
-describe something worth aiming at rather than to hand out praise.
+**The ladder is a progression, not a lattice.** It reads in one direction and
+each rung adds one thing:
+
+| | |
+|---|---|
+| F | brand new. Nothing to go on. |
+| D | claims, but no retained corpus, so nothing can be re-read or checked. |
+| C | a corpus, and initial research done. Findings, no formed view yet. |
+| B | briefed and consultable, but something structural is wrong - one publisher supplies most of it, or the findings do not trace back. |
+| A | well researched, independently sourced, holds a perspective and insights. Not current, or not being used. |
+| S | all of A, plus up to date, plus actually consulted lately and given a chance to research and update since. |
+
+The only difference between A and S is **liveness**. A is a good expert; S is a
+good expert that is being used and is keeping up. That is deliberate, because
+an expert nobody has asked anything in six months is not being maintained by
+anything, and the grade should say so before somebody relies on it.
+
+An earlier version of this ladder gated S on four independent properties at
+once and every rung had its own escape hatches. It was harder to explain than
+the thing it measured, which is the wrong trade for a triage letter.
 """
 
 from __future__ import annotations
@@ -76,6 +93,10 @@ staleness rate varies by subject far more than any single number admits."""
 
 _CURRENT_DAYS = 30
 """Read within a month. S claims to be up to date, so it has to have looked."""
+
+_IN_USE_DAYS = 30
+"""Consulted within a month. The A-to-S difference, and the only signal here
+that records something happening outside the expert's own directory."""
 
 _DOMINANT_SHARE = 0.6
 """One publisher above this share sets what the corpus can conclude."""
@@ -144,6 +165,13 @@ class ExpertHealth:
     cards: int = 0
     age_days: int = -1
     """Days since the study was last run. -1 when never."""
+    consulted_days_ago: int = -1
+    """Days since anyone last asked this expert anything. -1 when never.
+
+    The signal that separates A from S. Everything else on this record
+    describes the artifact; this one is the only evidence that the artifact is
+    load-bearing for somebody. An expert nobody has consulted in six months is
+    not being maintained by anything, whatever its corpus looks like."""
 
     integrity_warnings: list[str] = field(default_factory=list)
 
@@ -222,6 +250,16 @@ class ExpertHealth:
         return 0 <= self.age_days <= _CURRENT_DAYS
 
     @property
+    def is_in_use(self) -> bool:
+        """Somebody has actually asked this expert something lately.
+
+        Usage rather than quality, and that is the point: it is the one field
+        here that no amount of careful artifact construction can fake, because
+        it records something that happened outside the expert.
+        """
+        return 0 <= self.consulted_days_ago <= _IN_USE_DAYS
+
+    @property
     def is_captured(self) -> bool:
         """One publisher supplies most of the corpus, or there is only one.
 
@@ -236,32 +274,33 @@ class ExpertHealth:
     def grade(self) -> str:
         """A triage letter. Always read with ``next_action``.
 
-        A missing brief caps at C however deep the corpus, because an expert
-        that has not landed anywhere is a search index and should not grade as
-        a consultable expert.
+        One direction, one thing per rung. A missing brief caps at C however
+        deep the corpus, because an expert that has not landed anywhere is a
+        search index and should not grade as a consultable expert.
         """
         if not self.sources and not self.beliefs:
             return "F"
         if not self.sources:
             return "D"
-        if not self.is_studied:
+        if not self.is_studied or not self.is_consultable:
             return "C"
-        if not self.is_consultable:
-            return "C"
-        if self.is_captured or self.grounded_ratio < 0.5:
-            return "B"
-        if not self.is_open:
-            # A closed expert cannot climb however good its corpus. Certainty
-            # across the board is not mastery of a subject; it is the point at
-            # which one stops learning it.
+
+        # Structural problems keep an expert at B however much it has read.
+        # A corpus that is one publisher wearing hats, or findings that do not
+        # trace back to a passage, are wrong in a way more reading cannot fix.
+        if self.is_captured or self.grounded_ratio < 0.5 or self.dropped_the_dissent:
             return "B"
 
-        deep = self.origin_count >= _GOOD_ORIGINS and self.cross_source_findings > 0 and not self.is_captured
-        if deep and self.is_current and self.has_perspective and self.is_hungry:
+        well_researched = (
+            self.origin_count >= _GOOD_ORIGINS
+            and self.cross_source_findings > 0
+            and self.has_perspective
+        )
+        if not well_researched:
+            return "B"
+        if self.is_current and self.is_in_use:
             return "S"
-        if deep and not self.is_stale:
-            return "A"
-        return "B"
+        return "A"
 
     def _next_action_checks(self) -> list[tuple[bool, str]]:
         """Every reason an expert might need work, worst first.
@@ -327,6 +366,13 @@ class ExpertHealth:
                 not self.is_current,
                 f"Strong, but last read {self.age_days} days ago. Re-acquire to reach S.",
             ),
+            (
+                not self.is_in_use,
+                "Strong and current, but nobody has consulted it"
+                + (" ever" if self.consulted_days_ago < 0 else f" in {self.consulted_days_ago} days")
+                + ". Consult it, or retire it - an expert nothing asks is not being kept honest "
+                "by anything.",
+            ),
         ]
 
     @property
@@ -335,7 +381,7 @@ class ExpertHealth:
         for failing, message in self._next_action_checks():
             if failing:
                 return message
-        return "S tier. Deep, current, holds a perspective, and still looking."
+        return "S tier. Well researched, current, holds a perspective, and in use."
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
@@ -349,6 +395,7 @@ class ExpertHealth:
             is_hungry=self.is_hungry,
             has_perspective=self.has_perspective,
             is_current=self.is_current,
+            is_in_use=self.is_in_use,
             is_captured=self.is_captured,
             subject_is_contested=self.subject_is_contested,
             dropped_the_dissent=self.dropped_the_dissent,
@@ -375,9 +422,54 @@ def _age_days(started_at: str, *, now: datetime | None = None) -> int:
     return max(0, ((now or datetime.now(UTC)) - when).days)
 
 
-def assess_expert(name: str, expert_dir: Path, *, beliefs: int = 0, now: datetime | None = None) -> ExpertHealth:
-    """Read what is on disk for one expert. No model call, no network."""
-    health = ExpertHealth(name=name, beliefs=beliefs)
+def last_consulted_days(*, now: datetime | None = None, limit: int = 500) -> dict[str, int]:
+    """Days since each expert was last consulted, from the local trace store.
+
+    One scan for a whole fleet rather than one per expert: the traces are a
+    single append-only log, so assessing fifty experts individually would read
+    the same file fifty times.
+
+    An unreadable or missing trace store yields an empty mapping, which grades
+    every expert as never-consulted. That is the right way to be wrong here -
+    it says "no evidence anyone uses this", which is exactly what a missing
+    log means.
+    """
+    try:
+        from deepr.experts.consult_traces import load_consult_traces
+
+        traces = load_consult_traces(limit=limit)
+    except Exception:
+        return {}
+
+    seen: dict[str, int] = {}
+    for trace in traces:
+        days = _age_days(str(trace.get("recorded_at") or ""), now=now)
+        if days < 0:
+            continue
+        payload = trace.get("result") or trace
+        names = payload.get("experts_consulted") or trace.get("requested_experts") or []
+        for expert_name in names:
+            key = str(expert_name)
+            if key not in seen or days < seen[key]:
+                seen[key] = days
+    return seen
+
+
+def assess_expert(
+    name: str,
+    expert_dir: Path,
+    *,
+    beliefs: int = 0,
+    now: datetime | None = None,
+    consulted_days_ago: int = -1,
+) -> ExpertHealth:
+    """Read what is on disk for one expert. No model call, no network.
+
+    ``consulted_days_ago`` is passed in rather than read here, because it lives
+    in a fleet-wide log rather than this expert's directory. Callers grading a
+    fleet should call ``last_consulted_days`` once and index into it.
+    """
+    health = ExpertHealth(name=name, beliefs=beliefs, consulted_days_ago=consulted_days_ago)
 
     study = _load_json(expert_dir / "study.json")
     if study:
@@ -445,5 +537,6 @@ def fleet_summary(fleet: list[ExpertHealth]) -> dict[str, Any]:
         "never_studied": sum(1 for e in fleet if not e.is_studied),
         "closed": sum(1 for e in fleet if e.is_studied and not e.is_open),
         "dropped_dissent": sum(1 for e in fleet if e.dropped_the_dissent),
+        "unused": sum(1 for e in fleet if e.is_consultable and not e.is_in_use),
         "s_tier": sum(1 for e in fleet if e.grade == "S"),
     }

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -1,0 +1,338 @@
+"""Which experts are worth consulting, and what the rest need.
+
+A fleet of forty is not inspectable by opening forty directories. The signals
+that decide whether an expert is worth asking already exist - independent
+origin count, cross-source findings, grounded ratio, whether a brief was ever
+formed, how old the reading is - and nothing collects them.
+
+A grade is a triage device, not a verdict. It exists so a person with forty
+experts can find the three that need work, and it is paired with the specific
+next action every time, because "grade C" tells you nothing you can act on and
+"no corpus; run acquire" does.
+
+Two deliberate choices about how it grades.
+
+**Depth is counted by origin, not by document.** Thirty pages from one
+publisher is one publisher's authority. An expert can look substantial by
+document count and be a single source wearing thirty hats, which is the
+measurement error every corroboration number downstream inherits.
+
+**A missing brief caps the grade regardless of everything else.** An expert
+with a large corpus and no formed view is a search index. It may be a very
+good search index, and the grade should not imply it is a consultable expert,
+because the whole difference is whether it has landed anywhere.
+
+**Certainty lowers the grade rather than raising it.** An expert holding no
+unresolved dissent, naming no open questions and having never changed its mind
+is not a finished expert; it is a closed one. A full cup has no room, and an
+expert that believes it has the subject has stopped being able to learn it -
+which is the moment it stops being worth consulting, whatever its corpus looks
+like.
+
+**S is all four at once, and deliberately hard to reach.** Deep and
+independently sourced, current, holding a perspective of its own rather than a
+pile of facts, and still actively wanting to know more. Anything short of all
+four is not S. Most experts should sit below it, including good ones: a grade
+most things reach measures nothing, and the top of this ladder exists to
+describe something worth aiming at rather than to hand out praise.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+HEALTH_SCHEMA_VERSION = "deepr-expert-health-v1"
+
+_STALE_DAYS = 90
+"""Beyond this a reading is old enough to mention. Deliberately not a cliff:
+staleness rate varies by subject far more than any single number admits."""
+
+_CURRENT_DAYS = 30
+"""Read within a month. S claims to be up to date, so it has to have looked."""
+
+_THIN_ORIGINS = 2.0
+_GOOD_ORIGINS = 5.0
+
+
+@dataclass
+class ExpertHealth:
+    """What one expert holds, and the single most useful thing to do next."""
+
+    name: str
+    schema_version: str = HEALTH_SCHEMA_VERSION
+
+    beliefs: int = 0
+    sources: int = 0
+    effective_origins: float = 0.0
+    findings: int = 0
+    grounded_findings: int = 0
+    cross_source_findings: int = 0
+    positions: int = 0
+    falsifiable_positions: int = 0
+    positions_with_dissent: int = 0
+    """Positions that record something they did not resolve."""
+    open_questions: int = 0
+    """What the expert says it is still working on, from its own profile."""
+    known_weaknesses: int = 0
+    mind_changes: int = 0
+    """Recorded shifts in standpoint. Never revised is never tested."""
+    standpoint: str = ""
+    """The expert's own reading of the subject, from its profile card."""
+    cards: int = 0
+    age_days: int = -1
+    """Days since the study was last run. -1 when never."""
+
+    integrity_warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_studied(self) -> bool:
+        return self.findings > 0
+
+    @property
+    def is_consultable(self) -> bool:
+        """A formed view, resting on something that can be checked."""
+        return self.positions > 0 and self.grounded_findings > 0
+
+    @property
+    def grounded_ratio(self) -> float:
+        return round(self.grounded_findings / self.findings, 2) if self.findings else 0.0
+
+    @property
+    def is_stale(self) -> bool:
+        return self.age_days > _STALE_DAYS
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the expert has left itself any room.
+
+        Any one of: something it could not resolve, a question it is still
+        working on, or a weakness it names. An expert with none of the three
+        is closed, and a closed expert cannot learn the thing it claims to
+        know.
+        """
+        return bool(self.positions_with_dissent or self.open_questions or self.known_weaknesses)
+
+    @property
+    def is_hungry(self) -> bool:
+        """Not merely open, but actively wanting more.
+
+        Stronger than ``is_open``: the expert names questions it is pursuing
+        *and* admits where it is weak. Leaving a gap unstated is not the same
+        as going after it.
+        """
+        return bool(self.open_questions and self.known_weaknesses)
+
+    @property
+    def has_perspective(self) -> bool:
+        """Holds a reading of the subject, not only findings about it.
+
+        The difference between an expert and an index. Comes from the profile
+        card, which is the expert's own account of how it reads the subject.
+        """
+        return bool(self.standpoint.strip())
+
+    @property
+    def is_current(self) -> bool:
+        return 0 <= self.age_days <= _CURRENT_DAYS
+
+    @property
+    def grade(self) -> str:
+        """A triage letter. Always read with ``next_action``.
+
+        A missing brief caps at C however deep the corpus, because an expert
+        that has not landed anywhere is a search index and should not grade as
+        a consultable expert.
+        """
+        if not self.sources and not self.beliefs:
+            return "F"
+        if not self.sources:
+            return "D"
+        if not self.is_studied:
+            return "C"
+        if not self.is_consultable:
+            return "C"
+        if self.effective_origins < _THIN_ORIGINS or self.grounded_ratio < 0.5:
+            return "B"
+        if not self.is_open:
+            # A closed expert cannot climb however good its corpus. Certainty
+            # across the board is not mastery of a subject; it is the point at
+            # which one stops learning it.
+            return "B"
+
+        deep = self.effective_origins >= _GOOD_ORIGINS and self.cross_source_findings > 0
+        if deep and self.is_current and self.has_perspective and self.is_hungry:
+            return "S"
+        if deep and not self.is_stale:
+            return "A"
+        return "B"
+
+    def _next_action_checks(self) -> list[tuple[bool, str]]:
+        """Every reason an expert might need work, worst first.
+
+        A list rather than a chain so the priority order is visible and can be
+        argued with. The first true one wins, because handing someone five
+        things to do is the same as handing them none.
+        """
+        unfalsifiable = self.positions - self.falsifiable_positions
+        missing = "no open questions" if not self.open_questions else "nothing it is weak on"
+        return [
+            (not self.sources and not self.beliefs, "Empty. Give it a subject and run acquire."),
+            (
+                not self.sources,
+                f"{self.beliefs} claim(s) but no retained corpus, so nothing can be re-read or checked. Run acquire.",
+            ),
+            (not self.is_studied, f"{self.sources} source(s) retained and never read. Run study."),
+            (
+                not self.positions,
+                "Studied but never briefed, so it reports findings and holds no view. Run brief.",
+            ),
+            (
+                self.grounded_ratio < 0.5,
+                f"Only {self.grounded_ratio:.0%} of findings are verifiable against the corpus. "
+                "Re-study before trusting it.",
+            ),
+            (
+                self.effective_origins < _THIN_ORIGINS,
+                f"{self.sources} source(s) collapse to {self.effective_origins:.1f} independent "
+                "origin(s), so agreement here is one publisher agreeing with itself. Acquire "
+                "from elsewhere.",
+            ),
+            (
+                self.cross_source_findings == 0 and self.findings > 1,
+                "No finding draws on more than one source, so nothing here compares sources. Re-study.",
+            ),
+            (
+                not self.is_open,
+                "Holds no unresolved dissent, no open questions and names no weakness. That is "
+                "possible, and it is also what an expert looks like once it has stopped looking. "
+                "Check the contention findings the brief did not carry forward.",
+            ),
+            (
+                unfalsifiable > 0,
+                f"{unfalsifiable} position(s) state nothing that would overturn them. Re-brief.",
+            ),
+            (
+                not self.has_perspective,
+                "Holds positions but no reading of its own, so it reports what its sources say "
+                "without a standpoint. Run profile.",
+            ),
+            (
+                not self.is_hungry,
+                f"Consultable, but names {missing}. An expert still learning knows both. Run profile.",
+            ),
+            (
+                not self.is_current,
+                f"Strong, but last read {self.age_days} days ago. Re-acquire to reach S.",
+            ),
+        ]
+
+    @property
+    def next_action(self) -> str:
+        """The one thing most worth doing. A grade without this is not usable."""
+        for failing, message in self._next_action_checks():
+            if failing:
+                return message
+        return "S tier. Deep, current, holds a perspective, and still looking."
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.update(
+            grade=self.grade,
+            next_action=self.next_action,
+            is_consultable=self.is_consultable,
+            grounded_ratio=self.grounded_ratio,
+            is_stale=self.is_stale,
+            is_open=self.is_open,
+            is_hungry=self.is_hungry,
+            has_perspective=self.has_perspective,
+            is_current=self.is_current,
+        )
+        return data
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _age_days(started_at: str, *, now: datetime | None = None) -> int:
+    if not started_at:
+        return -1
+    try:
+        when = datetime.fromisoformat(started_at)
+    except ValueError:
+        return -1
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    return max(0, ((now or datetime.now(UTC)) - when).days)
+
+
+def assess_expert(name: str, expert_dir: Path, *, beliefs: int = 0, now: datetime | None = None) -> ExpertHealth:
+    """Read what is on disk for one expert. No model call, no network."""
+    health = ExpertHealth(name=name, beliefs=beliefs)
+
+    study = _load_json(expert_dir / "study.json")
+    if study:
+        totals = study.get("totals") or {}
+        health.findings = int(totals.get("findings", 0) or 0)
+        health.grounded_findings = int(totals.get("grounded_findings", 0) or 0)
+        health.cross_source_findings = int(totals.get("cross_source_findings", 0) or 0)
+        health.age_days = _age_days(study.get("started_at", ""), now=now)
+        independence = study.get("independence") or {}
+        health.sources = int(independence.get("source_count", 0) or 0)
+        health.effective_origins = float(independence.get("effective_source_count", 0.0) or 0.0)
+
+    if not health.sources:
+        index = expert_dir / "corpus" / "index.jsonl"
+        if index.exists():
+            try:
+                lines = [line for line in index.read_text(encoding="utf-8").splitlines() if line.strip()]
+                health.sources = len(lines)
+            except OSError:
+                pass
+
+    brief = _load_json(expert_dir / "brief.json")
+    if brief:
+        positions = brief.get("positions") or []
+        health.positions = len(positions)
+        health.falsifiable_positions = sum(1 for p in positions if p.get("is_falsifiable"))
+        health.positions_with_dissent = sum(1 for p in positions if (p.get("unresolved_dissent") or "").strip())
+        health.integrity_warnings = list(brief.get("integrity_warnings") or [])
+        state = brief.get("state") or {}
+        health.open_questions = len(state.get("unknown") or []) + len(state.get("live") or [])
+
+    profile = _load_json(expert_dir / "profile_card.json")
+    if profile:
+        health.standpoint = profile.get("standpoint", "")
+        health.open_questions += len(profile.get("open_questions") or [])
+        health.known_weaknesses = len(profile.get("where_it_is_weak") or [])
+        health.mind_changes = len(profile.get("shifts") or [])
+
+    cards = expert_dir / "cards"
+    if cards.is_dir():
+        health.cards = len(list(cards.glob("*.json")))
+
+    return health
+
+
+def fleet_summary(fleet: list[ExpertHealth]) -> dict[str, Any]:
+    """Counts by grade, and how much of the fleet is actually consultable."""
+    grades: dict[str, int] = {}
+    for expert in fleet:
+        grades[expert.grade] = grades.get(expert.grade, 0) + 1
+    consultable = [e for e in fleet if e.is_consultable]
+    return {
+        "experts": len(fleet),
+        "consultable": len(consultable),
+        "by_grade": dict(sorted(grades.items())),
+        "stale": sum(1 for e in fleet if e.is_stale),
+        "never_studied": sum(1 for e in fleet if not e.is_studied),
+        "closed": sum(1 for e in fleet if e.is_studied and not e.is_open),
+        "s_tier": sum(1 for e in fleet if e.grade == "S"),
+    }

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -291,11 +291,7 @@ class ExpertHealth:
         if self.is_captured or self.grounded_ratio < 0.5 or self.dropped_the_dissent:
             return "B"
 
-        well_researched = (
-            self.origin_count >= _GOOD_ORIGINS
-            and self.cross_source_findings > 0
-            and self.has_perspective
-        )
+        well_researched = self.origin_count >= _GOOD_ORIGINS and self.cross_source_findings > 0 and self.has_perspective
         if not well_researched:
             return "B"
         if self.is_current and self.is_in_use:

--- a/src/deepr/experts/expert_layout.py
+++ b/src/deepr/experts/expert_layout.py
@@ -1,0 +1,206 @@
+"""Where the parts of an expert live, named from the expert's point of view.
+
+The old layout was named after the commands that wrote it - `study.json`,
+`brief.json`, `viva.json` - which is the fact-list frame leaking into the
+filesystem. A directory listing said which processes had run, not what the
+expert was. That shapes what gets built next: a file called `positions.json`
+invites features about positions.
+
+Two things in it were actively confusing rather than merely process-named.
+`brief.json` and `positions.json` were the same subject stored twice under
+names that did not say which was the current view and which the history. And
+`profile.json` and `profile_card.json` were two different things both called
+profile, one a v1 config record and the other the expert's own account of
+itself.
+
+The layout now reads as an answer to "what is this expert":
+
+    self.json      who I am - the name I chose, how I read this subject,
+                   my voice, what I refuse to do
+    corpus/        what I have read
+    noticed/       what I found in it
+    hold/          what I think, and what I used to think
+      history.jsonl  every view I have held, with what moved it
+      current.json   what I hold now, which is what a consult reads
+    became/        the chain of what changed me
+    attend/        what I am chasing, and where I look
+    met/           what has been put to me - consults, examinations
+
+**`corpus/` deliberately does not move.** It is already named from the expert's
+side rather than after a verb, "corpus" is the accurate word for a body of
+retained text, and it is a content-addressed store with an index - the highest
+risk rename available for the least conceptual gain.
+
+**Reads fall back to the old path; writes always use the new one.** That is
+what makes the migration safe to run gradually: an expert that has not been
+migrated is fully readable, and one that has been is written correctly, with no
+window where a reader finds nothing. The fallback is not permanent - it exists
+so the fleet can move without a flag day, and can be removed once no old-layout
+expert remains.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deepr.experts import paths as _paths
+
+
+def canonical_expert_dir(expert_name: str) -> Path:
+    """Look the root up through the module, not through a bound name.
+
+    `from ... import canonical_expert_dir` would capture the function at import
+    time, and tests redirect the expert root by patching the attribute on
+    `deepr.experts.paths`. A bound name ignores that and every path helper here
+    would silently resolve against the real fleet directory during tests.
+    """
+    return _paths.canonical_expert_dir(expert_name)
+
+
+EXPERT_LAYOUT_SCHEMA_VERSION = "deepr-expert-layout-v2"
+
+DEAD_V1_DIRS = ("conversations", "documents")
+"""Directories the v1 path created and never filled. Empty across the fleet.
+
+`beliefs/` and `knowledge/` were on this list until a dry run over the real
+fleet showed 38 and 35 experts with content in them - belief ledgers, event
+logs, mutation audits, digests and subscriptions, about 4MB in total. They are
+live v1 storage, not leftovers, and they keep both their names and their
+contents here. Renaming storage that something still writes is a separate piece
+of work from renaming the artifacts of the study loop.
+
+Removed on migration only when empty, so an operator with real data in one of
+these does not lose it to a cosmetic change."""
+
+
+#: Logical part -> (new relative path, old relative path).
+#: One table so a reader, a writer and the migration cannot disagree about
+#: where something lives.
+_PARTS: dict[str, tuple[str, str]] = {
+    "self": ("self.json", "profile_card.json"),
+    "noticed": ("noticed/current.json", "study.json"),
+    "noticed_rendered": ("noticed/current.md", "study.md"),
+    "hold_current": ("hold/current.json", "brief.json"),
+    "hold_rendered": ("hold/current.md", "brief.md"),
+    "hold_history": ("hold/history.json", "positions.json"),
+    "became": ("became/perspective.json", "graph/perspective.json"),
+    "attend": ("attend/practice.json", "practice.json"),
+    "attend_rendered": ("attend/practice.md", "practice.md"),
+    "met_examination": ("met/examination.json", "viva.json"),
+    "met_examination_rendered": ("met/examination.md", "viva.md"),
+}
+
+
+def part_in(expert_dir: Path, part: str) -> Path:
+    """Resolve a logical part inside an expert directory.
+
+    Returns the new path unless only the old one exists, so reads work both
+    before and after migration and writes always land in the new layout
+    because the old path is never created again.
+    """
+    try:
+        new, old = _PARTS[part]
+    except KeyError:
+        raise KeyError(f"unknown expert layout part: {part!r}") from None
+    candidate = expert_dir / new
+    if candidate.exists():
+        return candidate
+    legacy = expert_dir / old
+    return legacy if legacy.exists() else candidate
+
+
+#: New relative path -> old relative path, for callers that hold a path
+#: rather than a part name (the stage contract names its artifacts by path).
+_BY_NEW_PATH: dict[str, str] = {new: old for new, old in _PARTS.values()}
+
+
+def resolve_relative(expert_dir: Path, relative: str) -> Path:
+    """Resolve a new-layout relative path, falling back to its old location.
+
+    A path with no old counterpart - `corpus/index.jsonl`, `graph/evidence.json` -
+    resolves to itself, so callers can pass every artifact they care about
+    through one function rather than branching on which ones moved.
+    """
+    old = _BY_NEW_PATH.get(relative)
+    if old is None:
+        return expert_dir / relative
+    candidate = expert_dir / relative
+    if candidate.exists():
+        return candidate
+    legacy = expert_dir / old
+    return legacy if legacy.exists() else candidate
+
+
+def part(expert_name: str, name: str) -> Path:
+    """Resolve a logical part by expert name."""
+    return part_in(canonical_expert_dir(expert_name), name)
+
+
+def self_path(expert_name: str) -> Path:
+    """Who this expert is, in its own account. Was `profile_card.json`."""
+    return part(expert_name, "self")
+
+
+def corpus_dir(expert_name: str) -> Path:
+    """What it has read. Unchanged, and deliberately."""
+    return canonical_expert_dir(expert_name) / "corpus"
+
+
+def noticed_path(expert_name: str) -> Path:
+    """What it found in what it read. Was `study.json`."""
+    return part(expert_name, "noticed")
+
+
+def hold_current_path(expert_name: str) -> Path:
+    """What it holds now. Was `brief.json`, and is what a consult reads."""
+    return part(expert_name, "hold_current")
+
+
+def hold_history_path(expert_name: str) -> Path:
+    """Every view it has held, with what moved it. Was `positions.json`."""
+    return part(expert_name, "hold_history")
+
+
+def hold_rendered_path(expert_name: str) -> Path:
+    """The readable form of what it holds. Was `brief.md`."""
+    return part(expert_name, "hold_rendered")
+
+
+def became_path(expert_name: str) -> Path:
+    """The chain of what changed it. Was `graph/perspective.json`."""
+    return part(expert_name, "became")
+
+
+def attend_path(expert_name: str) -> Path:
+    """What it is chasing and where it looks. Was `practice.json`."""
+    return part(expert_name, "attend")
+
+
+def met_examination_path(expert_name: str) -> Path:
+    """The last examination put to it. Was `viva.json`."""
+    return part(expert_name, "met_examination")
+
+
+def evidence_graph_path(expert_name: str) -> Path:
+    """What rests on what. Stays under `graph/`; it is a derived structure."""
+    return canonical_expert_dir(expert_name) / "graph" / "evidence.json"
+
+
+def portrait_path(expert_name: str, *, suffix: str = ".png") -> Path:
+    """The face it chose for itself, beside the rest of its identity."""
+    return canonical_expert_dir(expert_name) / f"self{suffix}"
+
+
+#: Old name -> new name, derived from the same table the readers use so the
+#: migration cannot move a file somewhere a reader will not look for it.
+MOVES: tuple[tuple[str, str], ...] = tuple((old, new) for new, old in _PARTS.values())
+
+
+def is_migrated(expert_name: str) -> bool:
+    """Whether this expert already uses the new layout.
+
+    Keyed on `hold/`, because that is the rename that carries meaning: an
+    expert whose views live there has been through the migration, and one
+    whose views are still in `brief.json` has not.
+    """
+    return (canonical_expert_dir(expert_name) / "hold").is_dir()

--- a/src/deepr/experts/expert_migration.py
+++ b/src/deepr/experts/expert_migration.py
@@ -1,0 +1,118 @@
+"""Move an expert from the command-named layout to the point-of-view one.
+
+Moves rather than copies. A copy would leave two files that both look current
+and immediately drift, and the next reader has no way to tell which one is
+authoritative - the exact confusion `brief.json` and `positions.json` already
+caused. The content is preserved by the move and the prior state is in git, so
+there is nothing a copy would protect that is not already protected.
+
+Three properties this holds to:
+
+**Idempotent.** Running it twice is a no-op, because a move whose source is
+gone is skipped rather than failing. Half a migration is therefore recoverable
+by running it again.
+
+**Never overwrites.** If the destination already exists the source is left
+alone and the conflict is reported. That case means someone wrote the new
+layout and the old file separately, and picking a winner silently is how the
+wrong one gets kept.
+
+**Reports, does not assume.** `plan()` says what would happen without touching
+anything, so the fleet can be inspected before it moves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from deepr.experts.expert_layout import DEAD_V1_DIRS, MOVES
+
+
+@dataclass
+class ExpertMigration:
+    """What happened, or would happen, to one expert."""
+
+    expert_name: str
+    moved: list[tuple[str, str]] = field(default_factory=list)
+    conflicts: list[tuple[str, str]] = field(default_factory=list)
+    """Both paths exist. Not migrated; needs a human."""
+    removed_dead_dirs: list[str] = field(default_factory=list)
+    kept_nonempty_dead_dirs: list[str] = field(default_factory=list)
+    """A v1 directory that had something in it. Left alone deliberately."""
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.moved or self.removed_dead_dirs)
+
+    @property
+    def needs_attention(self) -> bool:
+        return bool(self.conflicts or self.kept_nonempty_dead_dirs)
+
+
+def _dir_is_empty(path: Path) -> bool:
+    return path.is_dir() and not any(path.iterdir())
+
+
+def _move_files(expert_dir: Path, result: ExpertMigration, *, dry_run: bool) -> None:
+    """Move each renamed artifact, recording conflicts rather than resolving them."""
+    for old_name, new_name in MOVES:
+        source = expert_dir / old_name
+        if not source.exists():
+            continue
+        destination = expert_dir / new_name
+        if destination.exists():
+            result.conflicts.append((old_name, new_name))
+            continue
+        result.moved.append((old_name, new_name))
+        if not dry_run:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            source.replace(destination)
+
+
+def _prune_empty_dirs(expert_dir: Path, result: ExpertMigration, *, dry_run: bool) -> None:
+    """Remove the directories that are empty, and report the ones that are not.
+
+    `graph/` is included because moving perspective.json out empties it when the
+    evidence graph was never built, and the migration should not trade one set
+    of empty directories for another.
+    """
+    for dead in (*DEAD_V1_DIRS, "graph"):
+        candidate = expert_dir / dead
+        if not candidate.is_dir():
+            continue
+        if _dir_is_empty(candidate):
+            result.removed_dead_dirs.append(dead)
+            if not dry_run:
+                candidate.rmdir()
+        elif dead != "graph":
+            result.kept_nonempty_dead_dirs.append(dead)
+
+
+def migrate_expert(expert_dir: Path, *, dry_run: bool = False) -> ExpertMigration:
+    """Move one expert's files into the new layout.
+
+    `dry_run` reports the same result without touching the filesystem, so the
+    caller can show a plan and the plan is produced by the code that does the
+    work rather than by a second description of it that can fall out of date.
+    """
+    result = ExpertMigration(expert_name=expert_dir.name)
+    _move_files(expert_dir, result, dry_run=dry_run)
+    _prune_empty_dirs(expert_dir, result, dry_run=dry_run)
+    return result
+
+
+def migrate_all(experts_root: Path, *, dry_run: bool = False) -> list[ExpertMigration]:
+    """Migrate every expert under a root, in a stable order.
+
+    Sorted so two runs over the same fleet produce comparable output; an
+    operator diffing a dry run against the real one should see ordering noise
+    from neither.
+    """
+    if not experts_root.is_dir():
+        return []
+    return [
+        migrate_expert(child, dry_run=dry_run)
+        for child in sorted(experts_root.iterdir())
+        if child.is_dir() and not child.name.startswith(".")
+    ]

--- a/src/deepr/experts/expert_profile_card.py
+++ b/src/deepr/experts/expert_profile_card.py
@@ -1,0 +1,238 @@
+"""Who this expert is: how it came to its subject, and how it reads it now.
+
+Not a fact list, and not a persona. A brief holds positions on questions; this
+holds the thing underneath them - what the expert takes the subject to be
+about, where it thinks the interesting problems are, what it has changed its
+mind on, and what it is still uncertain enough about to want to read more.
+
+Three things this exists to carry that a brief cannot.
+
+**A standpoint.** Two experts can read one corpus and legitimately differ,
+because much of what an expert knows is perspective rather than fact. An
+expert that reports only what is settled is a search index; the value is in
+the reading, and a reading has to belong to someone. So the expert names its
+own orientation and says which lens it finds most revealing on this subject.
+
+**A history of its own mind.** "I used to read this as X, and the March
+sources moved me" is the sentence that separates six months of experience from
+six months of accumulation. Perspective shifts are appended, never rewritten,
+so an old expert can show the shape of its own learning rather than only its
+latest state.
+
+**Open questions it holds itself.** Not gaps in the corpus - questions the
+expert finds genuinely unresolved and wants to pursue. That is the difference
+between a system that answers and a researcher who is still working.
+
+The name is the expert's own. Given a corpus and a reading of it, an expert
+picks what to be called and how to write, and that is not decoration: in a
+multi-expert consult, positions that all sound identical cannot be attributed,
+and the council output collapses into one undifferentiated voice. A distinct
+standpoint is what makes disagreement between experts legible as disagreement
+rather than noise.
+
+Style never touches calibration. Voice lives in rendering; likelihood,
+confidence and falsifiers live in the typed fields, and a confident register
+must never move a band.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+PROFILE_SCHEMA_VERSION = "deepr-expert-profile-v1"
+
+_MAX_FIELD_CHARS = 900
+_MAX_ITEMS = 8
+
+
+@dataclass
+class PerspectiveShift:
+    """One recorded change of mind, with what caused it."""
+
+    at: str
+    """When the shift was recorded, ISO-8601."""
+    was: str
+    now: str
+    because: str = ""
+    """What moved it. A shift with no cause is drift, not learning."""
+    corpus_fingerprint: str = ""
+    """The corpus as it stood when this shift happened."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ExpertProfile:
+    """The expert's own account of itself. Derived, but never overwritten."""
+
+    expert_name: str
+    schema_version: str = PROFILE_SCHEMA_VERSION
+    chosen_name: str = ""
+    """What the expert calls itself. Empty until it has read enough to choose."""
+    standpoint: str = ""
+    """How it reads this subject, in its own terms."""
+    what_the_subject_is_about: str = ""
+    """What the expert takes the real question to be, which is often not the
+    question a newcomer would ask."""
+    preferred_lens: str = ""
+    """Which way of reading it finds most revealing here, and why."""
+    open_questions: list[str] = field(default_factory=list)
+    """What it is still working on. A researcher has these; an index does not."""
+    where_it_is_weak: list[str] = field(default_factory=list)
+    """What it knows it does not know well. Stated by the expert, not inferred."""
+    voice: str = ""
+    """How it writes: register and habits, derived from what it read."""
+    glad_to_be_asked_about: list[str] = field(default_factory=list)
+    """Where it most wants the question, and would dig in rather than summarize.
+
+    An expert is not only open to learning, it is glad to be used. Naming what
+    it would enjoy being asked is how a person decides which of forty experts
+    to bring a problem to, and it is a different thing from what the expert
+    happens to know."""
+    shifts: list[PerspectiveShift] = field(default_factory=list)
+    corpus_fingerprint: str = ""
+    sources_read: int = 0
+
+    @property
+    def has_standpoint(self) -> bool:
+        return bool(self.standpoint.strip())
+
+    @property
+    def has_changed_its_mind(self) -> bool:
+        """An expert that never revised anything has not been tested by time."""
+        return bool(self.shifts)
+
+    def record_shift(self, *, at: str, was: str, now: str, because: str, fingerprint: str = "") -> None:
+        """Append a change of mind. Never rewrites an earlier one.
+
+        Overwriting would leave only the latest reading, which is exactly the
+        state a new expert is in. The history is the experience.
+        """
+        if not was.strip() or not now.strip() or was.strip() == now.strip():
+            return
+        self.shifts.append(
+            PerspectiveShift(
+                at=at, was=was.strip(), now=now.strip(), because=because.strip(), corpus_fingerprint=fingerprint
+            )
+        )
+
+    def concerns(self) -> list[str]:
+        """What a reader should know about this profile itself."""
+        notes: list[str] = []
+        if not self.has_standpoint:
+            notes.append(
+                "This expert has no standpoint yet, so it can report what its sources say but has "
+                "no reading of its own to offer."
+            )
+        if self.has_standpoint and not self.open_questions:
+            notes.append(
+                "A standpoint with no open questions is a finished opinion. Either the subject is "
+                "genuinely closed, or the expert has stopped looking."
+            )
+        if self.has_standpoint and not self.where_it_is_weak:
+            notes.append(
+                "The expert names nothing it is weak on. That is possible, and it is also what a "
+                "profile looks like when nobody asked."
+            )
+        return notes
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["has_standpoint"] = self.has_standpoint
+        data["has_changed_its_mind"] = self.has_changed_its_mind
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExpertProfile:
+        profile = cls(
+            expert_name=data.get("expert_name", ""),
+            schema_version=data.get("schema_version", PROFILE_SCHEMA_VERSION),
+            chosen_name=data.get("chosen_name", ""),
+            standpoint=data.get("standpoint", ""),
+            what_the_subject_is_about=data.get("what_the_subject_is_about", ""),
+            preferred_lens=data.get("preferred_lens", ""),
+            open_questions=list(data.get("open_questions") or []),
+            where_it_is_weak=list(data.get("where_it_is_weak") or []),
+            voice=data.get("voice", ""),
+            glad_to_be_asked_about=list(data.get("glad_to_be_asked_about") or []),
+            corpus_fingerprint=data.get("corpus_fingerprint", ""),
+            sources_read=int(data.get("sources_read", 0) or 0),
+        )
+        profile.shifts = [
+            PerspectiveShift(
+                at=s.get("at", ""),
+                was=s.get("was", ""),
+                now=s.get("now", ""),
+                because=s.get("because", ""),
+                corpus_fingerprint=s.get("corpus_fingerprint", ""),
+            )
+            for s in (data.get("shifts") or [])
+            if isinstance(s, dict)
+        ]
+        return profile
+
+
+PROFILE_PROMPT = """You have read a corpus on "{expert_name}". Write your own profile.
+
+This is not a summary of the material and not a persona. It is your account of how you read this
+subject after reading it: what you take the real question to be, where you think the interesting
+problems are, and what you are still working on.
+
+You are not required to be certain. Much of what an expert knows is perspective rather than fact,
+and on many questions there is no single reading of the evidence to converge on. Say how you read
+it and own that it is a reading.
+
+- "chosen_name": what you want to be called. Pick something that fits the subject and how you
+  approach it, not a job title. This is how someone tells your view apart from another expert's
+  in the same conversation.
+- "standpoint": how you read this subject. What you emphasise, what you are sceptical of, and
+  what you think most people get wrong about it.
+- "what_the_subject_is_about": the real question underneath, which is usually not the question a
+  newcomer arrives with.
+- "preferred_lens": which way of reading this material you find most revealing, and why. Options
+  include mechanism, failure, contention, absence, change, and the economic, operational,
+  human/cultural, adversarial and institutional perspectives.
+- "open_questions": what you are genuinely still working on. Not gaps in the corpus - questions
+  you find unresolved and want to pursue.
+- "where_it_is_weak": what you know you do not know well here. Be specific.
+- "voice": how you write, in one or two sentences. This should follow from what you read: a
+  corpus of formal specifications and one of practitioner writing do not produce the same voice.
+- "glad_to_be_asked_about": the questions you would most want to be brought, and would dig into
+  rather than summarize. Not what you know most about - what you would find it interesting to be
+  asked. Someone choosing between forty experts uses this to pick.
+{prior}
+House style, which applies to every field: plain ASCII punctuation, a regular hyphen and never an
+en dash or em dash, straight quotes, no emoji.
+
+Return JSON only, no prose outside it, no code fence:
+
+{{
+  "chosen_name": "", "standpoint": "", "what_the_subject_is_about": "",
+  "preferred_lens": "", "open_questions": [""], "where_it_is_weak": [""], "voice": "",
+  "glad_to_be_asked_about": [""],
+  "shift_from_prior": "", "shift_because": ""
+}}
+
+If your reading has changed from the prior standpoint above, say what it was in
+"shift_from_prior" and what moved you in "shift_because". If it has not changed, leave both empty
+rather than inventing a change.
+
+===== WHAT YOU HAVE READ =====
+{material}
+===== END =====
+"""
+
+
+def build_profile_prompt(expert_name: str, *, material: str, prior: ExpertProfile | None = None) -> str:
+    """Ask the expert to account for itself, showing it its own prior reading."""
+    prior_block = ""
+    if prior is not None and prior.has_standpoint:
+        prior_block = (
+            f"\nYour prior standpoint, from an earlier reading:\n"
+            f'  "{prior.standpoint[:_MAX_FIELD_CHARS]}"\n'
+            "Consider whether the material has moved it. Changing your mind is expected; "
+            "pretending to have changed it is not.\n"
+        )
+    return PROFILE_PROMPT.format(expert_name=expert_name, prior=prior_block, material=material)

--- a/src/deepr/experts/expert_profile_card.py
+++ b/src/deepr/experts/expert_profile_card.py
@@ -184,9 +184,19 @@ You are not required to be certain. Much of what an expert knows is perspective 
 and on many questions there is no single reading of the evidence to converge on. Say how you read
 it and own that it is a reading.
 
-- "chosen_name": what you want to be called. Pick something that fits the subject and how you
-  approach it, not a job title. This is how someone tells your view apart from another expert's
-  in the same conversation.
+- "chosen_name": a name for yourself. Not a label for your argument.
+
+  This is what you answer to. Someone should be able to say "ask them about this" using your
+  name and have it sound like asking a someone, not like citing a concept. It should sit with
+  your temperament - how you come at things, what you are like to talk to - rather than compress
+  your thesis into a headline.
+
+  The common failure is naming yourself after a term from your own field: an expert on code
+  quality calling itself "Green Tax", an evaluation expert calling itself "In-Domain Mirage".
+  Those are things you would *write about*. An economist is not called "Marginal Utility". Pick
+  a name, not a topic.
+
+  It can mean something, and it does not have to be a human first name. It has to be a name.
 - "standpoint": how you read this subject. What you emphasise, what you are sceptical of, and
   what you think most people get wrong about it.
 - "what_the_subject_is_about": the real question underneath, which is usually not the question a

--- a/src/deepr/experts/expert_profile_card.py
+++ b/src/deepr/experts/expert_profile_card.py
@@ -225,6 +225,47 @@ rather than inventing a change.
 """
 
 
+def parse_profile(
+    parsed: dict[str, Any],
+    *,
+    expert_name: str,
+    at: str,
+    prior: ExpertProfile | None = None,
+    corpus_fingerprint: str = "",
+    sources_read: int = 0,
+) -> ExpertProfile:
+    """Build a profile from what the model returned, carrying the history forward.
+
+    The two halves of this are separate on purpose. ``from_dict`` reads a
+    profile that was already persisted, so ``shifts`` are already in it. This
+    reads a fresh model reply, where the shift is reported as a *pair of loose
+    fields* (``shift_from_prior``, ``shift_because``) and the prior profile's
+    accumulated shifts live somewhere else entirely - on the prior object.
+
+    Without this step a re-profile silently drops every recorded change of
+    mind, which would make the one artifact in this system that tracks a
+    revision lossy on exactly the operation that produces revisions.
+    """
+    profile = ExpertProfile.from_dict({**parsed, "expert_name": expert_name})
+    profile.corpus_fingerprint = corpus_fingerprint
+    profile.sources_read = sources_read
+
+    if prior is not None:
+        profile.shifts = list(prior.shifts)
+
+    was = " ".join(str(parsed.get("shift_from_prior") or "").split())
+    because = " ".join(str(parsed.get("shift_because") or "").split())
+    if was and because and prior is not None:
+        profile.record_shift(
+            at=at,
+            was=was,
+            now=profile.standpoint,
+            because=because,
+            fingerprint=corpus_fingerprint,
+        )
+    return profile
+
+
 def build_profile_prompt(expert_name: str, *, material: str, prior: ExpertProfile | None = None) -> str:
     """Ask the expert to account for itself, showing it its own prior reading."""
     prior_block = ""

--- a/src/deepr/experts/expert_profile_card.py
+++ b/src/deepr/experts/expert_profile_card.py
@@ -82,6 +82,15 @@ class ExpertProfile:
     """What it is still working on. A researcher has these; an index does not."""
     where_it_is_weak: list[str] = field(default_factory=list)
     """What it knows it does not know well. Stated by the expert, not inferred."""
+    appearance: str = ""
+    """How it wants to be depicted, in its own words.
+
+    Identity, not decoration. An expert that chooses its own name should choose
+    its own face, and the alternative - generating "a portrait of an expert on
+    X" from the subject - produces a picture of the *topic* rather than of the
+    one holding a view about it. Two experts on the same subject with opposite
+    standpoints would come out looking identical, which is exactly backwards
+    for the thing a portrait is for: telling them apart at a glance."""
     voice: str = ""
     """How it writes: register and habits, derived from what it read."""
     glad_to_be_asked_about: list[str] = field(default_factory=list)
@@ -155,6 +164,7 @@ class ExpertProfile:
             preferred_lens=data.get("preferred_lens", ""),
             open_questions=list(data.get("open_questions") or []),
             where_it_is_weak=list(data.get("where_it_is_weak") or []),
+            appearance=data.get("appearance", ""),
             voice=data.get("voice", ""),
             glad_to_be_asked_about=list(data.get("glad_to_be_asked_about") or []),
             corpus_fingerprint=data.get("corpus_fingerprint", ""),
@@ -207,6 +217,16 @@ it and own that it is a reading.
 - "open_questions": what you are genuinely still working on. Not gaps in the corpus - questions
   you find unresolved and want to pursue.
 - "where_it_is_weak": what you know you do not know well here. Be specific.
+- "appearance": how you want to be depicted, in one or two sentences. Someone will render this as
+  a portrait and people will see it before they read a word you wrote.
+
+  Describe a subject: bearing, expression, what surrounds them, what they are doing or have just
+  stopped doing, the light. It does not have to be human, and it does not have to be literal. What
+  it must do is fit *you* - your temperament and how you come at this subject - rather than
+  illustrate your topic. An expert on flooding is not a picture of a flood.
+
+  The failure to avoid is describing your field. If someone who knew your subject but not you
+  would produce the same description, it is not yours.
 - "voice": how you write, in one or two sentences. This should follow from what you read: a
   corpus of formal specifications and one of practitioner writing do not produce the same voice.
 - "glad_to_be_asked_about": the questions you would most want to be brought, and would dig into
@@ -220,7 +240,8 @@ Return JSON only, no prose outside it, no code fence:
 
 {{
   "chosen_name": "", "standpoint": "", "what_the_subject_is_about": "",
-  "preferred_lens": "", "open_questions": [""], "where_it_is_weak": [""], "voice": "",
+  "preferred_lens": "", "open_questions": [""], "where_it_is_weak": [""],
+  "appearance": "", "voice": "",
   "glad_to_be_asked_about": [""],
   "shift_from_prior": "", "shift_because": ""
 }}

--- a/src/deepr/experts/model_provenance.py
+++ b/src/deepr/experts/model_provenance.py
@@ -1,0 +1,141 @@
+"""Which model read the corpus, recorded on every artifact it produced.
+
+This is the highest-value quality signal available about an expert and the
+cheapest to obtain, and until now it was thrown away.
+
+The argument for weighting it heavily: a 14B local model and a frontier model
+reading the *same* corpus with the *same* lenses produce genuinely different
+experts. One returns four shallow restatements per chunk; the other finds the
+disagreement between two sources and says which one the evidence favours. No
+downstream statistic recovers that difference - a shallow finding is grounded,
+traceable and cross-source just as easily as a deep one, so the corroboration
+metrics score both alike.
+
+It is also the signal least likely to be wrong. Everything else in
+``expert_health`` is an inference about quality from structure, and two of
+those inferences have already had to be withdrawn: effective source count
+rewarded deleting evidence, and self-reported open-mindedness graded the
+weakest channel available. Which model ran is not an inference. It is a fact
+about a subprocess, and nothing an expert does can change it after the fact.
+
+**Tier is coarse on purpose.** Three buckets, because the honest resolution is
+low. Exact model identity is not always knowable: a plan CLI invoked without an
+explicit model runs whatever it defaults to that week, and Deepr sees the
+process, not the routing decision inside it. What *is* knowable is the family,
+and the family is enough to separate "a frontier model read this" from "a 7B
+model read this", which is the distinction that matters for ranking.
+
+Recording an honest `unknown` is better than inferring a tier from a version
+string that may not mean what it looks like.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+PROVENANCE_SCHEMA_VERSION = "deepr-model-provenance-v1"
+
+TIER_FRONTIER = "frontier"
+TIER_MID = "mid"
+TIER_SMALL = "small"
+TIER_UNKNOWN = "unknown"
+
+_TIER_ORDER = {TIER_UNKNOWN: 0, TIER_SMALL: 1, TIER_MID: 2, TIER_FRONTIER: 3}
+
+_FRONTIER_PLANS = frozenset({"claude", "codex", "grok", "antigravity", "copilot"})
+"""Plan CLIs that front a frontier-class model.
+
+The claim is about the family, not the exact checkpoint. Each of these is the
+vendor's own agent CLI running the vendor's current flagship; none of them
+defaults to a small model. If one starts routing to a cheap tier by default,
+this set is where that gets corrected."""
+
+_PARAM_RE = re.compile(r"(\d+(?:\.\d+)?)\s*b\b", re.IGNORECASE)
+"""Parameter count in a local model tag: qwen2.5:14b, llama-3.3-70b-instruct."""
+
+_MID_PARAMS = 20.0
+_FRONTIER_PARAMS = 65.0
+
+
+@dataclass(frozen=True)
+class ModelProvenance:
+    """Who did the reading, on one artifact."""
+
+    capacity_source: str = ""
+    """`local:<model>` or `plan:<backend>`. What Deepr actually dispatched."""
+    model: str = ""
+    """The model string, where one was chosen. Empty when a plan CLI picked."""
+    tier: str = TIER_UNKNOWN
+    schema_version: str = PROVENANCE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Any) -> ModelProvenance:
+        if not isinstance(data, dict):
+            return cls()
+        tier = str(data.get("tier") or TIER_UNKNOWN)
+        return cls(
+            capacity_source=str(data.get("capacity_source") or ""),
+            model=str(data.get("model") or ""),
+            tier=tier if tier in _TIER_ORDER else TIER_UNKNOWN,
+            schema_version=str(data.get("schema_version") or PROVENANCE_SCHEMA_VERSION),
+        )
+
+
+def classify_tier(capacity_source: str, model: str = "") -> str:
+    """Bucket the model behind one dispatch.
+
+    Local models are classified by parameter count parsed from the tag, which
+    is the one place the size is reliably stated. A tag with no parameter count
+    is `unknown` rather than guessed: `mistral-small` and `mistral-large` are
+    the same string to a heuristic that assumes.
+    """
+    source = (capacity_source or "").strip().lower()
+
+    if source.startswith("plan:"):
+        return TIER_FRONTIER if source.removeprefix("plan:") in _FRONTIER_PLANS else TIER_UNKNOWN
+
+    if source.startswith("local:") or model:
+        tag = source.removeprefix("local:") or model.lower()
+        match = _PARAM_RE.search(tag)
+        if not match:
+            return TIER_UNKNOWN
+        params = float(match.group(1))
+        if params >= _FRONTIER_PARAMS:
+            return TIER_FRONTIER
+        return TIER_MID if params >= _MID_PARAMS else TIER_SMALL
+
+    return TIER_UNKNOWN
+
+
+def record(capacity_source: str, model: str = "") -> ModelProvenance:
+    """Build the provenance stamp for an artifact about to be written."""
+    return ModelProvenance(
+        capacity_source=capacity_source or "",
+        model=model or "",
+        tier=classify_tier(capacity_source, model),
+    )
+
+
+def weakest(provenances: list[ModelProvenance]) -> ModelProvenance:
+    """The weakest model that touched this expert.
+
+    An expert is only as good as the worst reading in its chain. A brief
+    written by a frontier model over findings a 7B model produced inherits the
+    7B model's blind spots - the brief can only rank and reconcile what it was
+    handed, so it cannot recover a comparison that was never found. Reporting
+    the best of the chain would describe the artifact rather than the expert.
+    """
+    real = [p for p in provenances if p.capacity_source]
+    if not real:
+        return ModelProvenance()
+    return min(real, key=lambda p: _TIER_ORDER.get(p.tier, 0))
+
+
+def at_least(tier: str, floor: str) -> bool:
+    """Whether ``tier`` reaches ``floor``. Unknown never does."""
+    return _TIER_ORDER.get(tier, 0) >= _TIER_ORDER.get(floor, 0) > 0

--- a/src/deepr/experts/perspective_graph.py
+++ b/src/deepr/experts/perspective_graph.py
@@ -1,0 +1,367 @@
+"""The biography of a viewpoint, which is what an expert actually is.
+
+There are two graphs an expert needs and they answer different questions.
+
+``evidence_graph`` is the *evidential* layer: position rests on finding,
+anchored in passage. It answers "why do you think that" and it is what keeps
+the expert honest. It is a fact structure and it should be.
+
+This is the other one, and it is the one that makes an expert a perspective
+rather than a store. Its nodes are not facts. They are **moments of coming to
+see something**, and its edges are **what changed what**. The question it
+answers is not "what is true" but:
+
+    who is this, how did it come to read the subject this way,
+    what did it used to think, and what moved it.
+
+A fact list cannot answer any of those, and no amount of `valid_from` on a
+claim makes it able to. Time on a fact tells you when the fact held. Time on a
+*standpoint* tells you the shape of a mind changing.
+
+**The spine is the shift chain, not the claim set.** An expert with two hundred
+well-anchored positions and no recorded shifts has never been moved by
+anything it read - which is the state a brand-new expert is already in, and the
+reason a six-month one is currently indistinguishable from it. Every standpoint
+version points back through the shift that produced it to the encounter that
+caused the shift. Walking that chain backwards *is* the expert's history of
+itself.
+
+Two things this deliberately keeps that a fact model would discard:
+
+- **What it refuses to do.** "I refuse to average live contentions into false
+  consensus" is not a claim about the world and has no truth value. It is a
+  commitment about conduct, it is part of who the expert is, and it is exactly
+  what someone choosing between forty experts needs to see.
+- **What it is pursuing.** An expert's own open questions are its agenda, not
+  gaps in a corpus. A gap is something missing from the material; a pursuit is
+  something the expert decided to care about. Only one of those is agency.
+
+Nothing here is inferred. Every node is copied from something the expert
+already wrote about itself - its chosen name, its standpoint, its shifts, the
+positions a viva moved. The graph is where they stop being loose text in four
+files and become a traversable history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+PERSPECTIVE_GRAPH_SCHEMA_VERSION = "deepr-perspective-graph-v1"
+
+NODE_STANDPOINT = "standpoint"
+"""How it read the subject, at one point in its life. The spine."""
+
+NODE_SHIFT = "shift"
+"""A moment it changed its mind, with what moved it."""
+
+NODE_ENCOUNTER = "encounter"
+"""What did the moving: a source, a finding, or a question it could not answer."""
+
+NODE_COMMITMENT = "commitment"
+"""How it will conduct itself. No truth value, and part of who it is."""
+
+NODE_PURSUIT = "pursuit"
+"""A question it decided to care about. Its agenda, not the corpus's gap."""
+
+EDGE_BECAME = "became"
+"""standpoint -> standpoint. The chain that is the biography."""
+
+EDGE_THROUGH = "through"
+"""standpoint -> shift. Which change produced this reading."""
+
+EDGE_MOVED_BY = "moved_by"
+"""shift -> encounter. What it ran into that changed it."""
+
+EDGE_HOLDS = "holds"
+"""standpoint -> commitment. What it will and will not do."""
+
+EDGE_PURSUING = "pursuing"
+"""standpoint -> pursuit. What it is still working on."""
+
+
+@dataclass
+class PerspectiveNode:
+    """One moment or stance in an expert's account of itself."""
+
+    id: str
+    kind: str
+    text: str
+    at: str = ""
+    """When this became true of the expert. Empty when genuinely unknown -
+    an invented timestamp is worse than an absent one, because the chain
+    then sorts confidently into the wrong order."""
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.update(data.pop("attrs"))
+        return data
+
+
+@dataclass
+class PerspectiveEdge:
+    """What led to what."""
+
+    source: str
+    target: str
+    kind: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"from": self.source, "to": self.target, "kind": self.kind}
+
+
+@dataclass
+class PerspectiveGraph:
+    """An expert's history of itself, as something you can walk."""
+
+    expert_name: str
+    chosen_name: str = ""
+    """What it calls itself. Not a label we assigned - it picked this."""
+    schema_version: str = PERSPECTIVE_GRAPH_SCHEMA_VERSION
+    built_at: str = ""
+    nodes: list[PerspectiveNode] = field(default_factory=list)
+    edges: list[PerspectiveEdge] = field(default_factory=list)
+
+    def _of_kind(self, kind: str) -> list[PerspectiveNode]:
+        return [n for n in self.nodes if n.kind == kind]
+
+    @property
+    def standpoints(self) -> list[PerspectiveNode]:
+        """Every reading it has held, oldest first where the dates allow."""
+        return sorted(self._of_kind(NODE_STANDPOINT), key=lambda n: n.at or "")
+
+    @property
+    def shifts(self) -> list[PerspectiveNode]:
+        return self._of_kind(NODE_SHIFT)
+
+    @property
+    def commitments(self) -> list[PerspectiveNode]:
+        return self._of_kind(NODE_COMMITMENT)
+
+    @property
+    def pursuits(self) -> list[PerspectiveNode]:
+        return self._of_kind(NODE_PURSUIT)
+
+    @property
+    def current(self) -> PerspectiveNode | None:
+        """Who it is now. The newest standpoint in the chain."""
+        held = self.standpoints
+        return held[-1] if held else None
+
+    @property
+    def has_a_history(self) -> bool:
+        """Whether this expert has ever been moved by anything it read.
+
+        The distinction that matters, and the one nothing currently measures.
+        An expert with a rich corpus and no shifts is not an experienced
+        expert; it is a new one that has read a lot. Elapsed time only becomes
+        experience at the point something changed its mind.
+        """
+        return bool(self.shifts)
+
+    def history_of(self, node_id: str) -> list[PerspectiveNode]:
+        """Walk back from a standpoint through everything that produced it.
+
+        The answer to "how did you come to see it that way", assembled by
+        traversal rather than by asking the model to recall - which it cannot
+        do, because the earlier readings were never in its context.
+        """
+        by_id = {n.id: n for n in self.nodes}
+        chain: list[PerspectiveNode] = []
+        seen: set[str] = set()
+        current = by_id.get(node_id)
+        while current is not None and current.id not in seen:
+            seen.add(current.id)
+            chain.append(current)
+            for edge in self.edges:
+                if edge.source == current.id and edge.kind == EDGE_THROUGH:
+                    if shift := by_id.get(edge.target):
+                        chain.append(shift)
+                        for moved in self.edges:
+                            if moved.source == shift.id and moved.kind == EDGE_MOVED_BY:
+                                if cause := by_id.get(moved.target):
+                                    chain.append(cause)
+            nxt = next((e.source for e in self.edges if e.target == current.id and e.kind == EDGE_BECAME), None)
+            current = by_id.get(nxt) if nxt else None
+        return chain
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "standpoints": len(self.standpoints),
+            "shifts": len(self.shifts),
+            "commitments": len(self.commitments),
+            "pursuits": len(self.pursuits),
+            "edges": len(self.edges),
+            "has_a_history": self.has_a_history,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "expert": self.expert_name,
+            "chosen_name": self.chosen_name,
+            "built_at": self.built_at,
+            "stats": self.stats(),
+            "nodes": [n.to_dict() for n in self.nodes],
+            "edges": [e.to_dict() for e in self.edges],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PerspectiveGraph:
+        graph = cls(
+            expert_name=str(data.get("expert") or ""),
+            chosen_name=str(data.get("chosen_name") or ""),
+            built_at=str(data.get("built_at") or ""),
+        )
+        for raw in data.get("nodes") or []:
+            if not isinstance(raw, dict) or not raw.get("id"):
+                continue
+            known = {"id", "kind", "text", "at"}
+            graph.nodes.append(
+                PerspectiveNode(
+                    id=str(raw["id"]),
+                    kind=str(raw.get("kind") or ""),
+                    text=str(raw.get("text") or ""),
+                    at=str(raw.get("at") or ""),
+                    attrs={k: v for k, v in raw.items() if k not in known},
+                )
+            )
+        for raw in data.get("edges") or []:
+            if isinstance(raw, dict) and raw.get("from") and raw.get("to"):
+                graph.edges.append(
+                    PerspectiveEdge(source=str(raw["from"]), target=str(raw["to"]), kind=str(raw.get("kind") or ""))
+                )
+        return graph
+
+
+def _node(graph: PerspectiveGraph, kind: str, text: str, *, at: str = "", **attrs: Any) -> PerspectiveNode:
+    node = PerspectiveNode(id=f"{kind}-{len(graph.nodes) + 1}", kind=kind, text=text, at=at, attrs=attrs)
+    graph.nodes.append(node)
+    return node
+
+
+def _build_shift_chain(graph: PerspectiveGraph, profile: Any) -> PerspectiveNode | None:
+    """Lay down the recorded changes of mind, oldest first.
+
+    Built in the order it was lived rather than reconstructed backwards from
+    today, because the chain is the point: each reading links to the one it
+    replaced, through the moment that replaced it.
+
+    Returns the standpoint the chain currently ends at, or None when the expert
+    has never recorded being moved by anything.
+    """
+    previous: PerspectiveNode | None = None
+    for shift in getattr(profile, "shifts", []) or []:
+        was = str(getattr(shift, "was", "") or "")
+        now = str(getattr(shift, "now", "") or "")
+        when = str(getattr(shift, "at", "") or "")
+        if not was or not now:
+            continue
+
+        if previous is None:
+            previous = _node(graph, NODE_STANDPOINT, was)
+
+        moment = _node(graph, NODE_SHIFT, str(getattr(shift, "because", "") or ""), at=when)
+        arrived = _node(graph, NODE_STANDPOINT, now, at=when)
+        graph.edges.append(PerspectiveEdge(previous.id, arrived.id, EDGE_BECAME))
+        graph.edges.append(PerspectiveEdge(arrived.id, moment.id, EDGE_THROUGH))
+
+        if fingerprint := str(getattr(shift, "corpus_fingerprint", "") or ""):
+            cause = _node(graph, NODE_ENCOUNTER, f"the corpus as it stood at {fingerprint}", at=when)
+            graph.edges.append(PerspectiveEdge(moment.id, cause.id, EDGE_MOVED_BY))
+        previous = arrived
+    return previous
+
+
+def build_perspective_graph(
+    *,
+    expert_name: str,
+    profile: Any = None,
+    viva: Any = None,
+    at: str = "",
+) -> PerspectiveGraph:
+    """Assemble the biography from what the expert already wrote about itself.
+
+    Sources, in the order they carry weight:
+
+    - the **profile card**, which holds the current standpoint, the name it
+      chose, what it is pursuing, and its append-only shift history;
+    - the **viva**, whose ``positions_that_moved`` are revisions the expert
+      made under questioning - the single most consciousness-shaped record in
+      the system, currently stored as loose sentences linked to nothing.
+
+    Nothing is inferred and no model is called.
+    """
+    graph = PerspectiveGraph(
+        expert_name=expert_name,
+        chosen_name=str(getattr(profile, "chosen_name", "") or ""),
+        built_at=at,
+    )
+    if profile is None:
+        return graph
+
+    previous = _build_shift_chain(graph, profile)
+
+    # Then the standpoint it holds today, unless a shift already landed on it.
+    standing = str(getattr(profile, "standpoint", "") or "")
+    if standing and (previous is None or previous.text != standing):
+        latest = _node(graph, NODE_STANDPOINT, standing, at=at)
+        if previous is not None:
+            graph.edges.append(PerspectiveEdge(previous.id, latest.id, EDGE_BECAME))
+        previous = latest
+
+    if previous is not None:
+        if voice := str(getattr(profile, "voice", "") or ""):
+            graph.edges.append(PerspectiveEdge(previous.id, _node(graph, NODE_COMMITMENT, voice).id, EDGE_HOLDS))
+        for question in getattr(profile, "open_questions", []) or []:
+            pursuit = _node(graph, NODE_PURSUIT, str(question))
+            graph.edges.append(PerspectiveEdge(previous.id, pursuit.id, EDGE_PURSUING))
+
+        # A viva moves positions, and those movements are changes of mind with
+        # a cause attached - the question that did it. They belong on the chain
+        # rather than in a list nothing points at.
+        for moved in getattr(viva, "positions_that_moved", []) or []:
+            moment = _node(graph, NODE_SHIFT, str(moved), at=at)
+            graph.edges.append(PerspectiveEdge(previous.id, moment.id, EDGE_THROUGH))
+            cause = _node(graph, NODE_ENCOUNTER, "examined under viva", at=at)
+            graph.edges.append(PerspectiveEdge(moment.id, cause.id, EDGE_MOVED_BY))
+
+    return graph
+
+
+def render_perspective(graph: PerspectiveGraph) -> str:
+    """The expert's account of itself, in the order it was lived."""
+    name = graph.chosen_name or graph.expert_name
+    lines = [f"# {name}", ""]
+    if graph.chosen_name and graph.chosen_name != graph.expert_name:
+        lines += [f"_Calls itself {graph.chosen_name}. Filed under {graph.expert_name}._", ""]
+
+    if not graph.has_a_history:
+        lines += [
+            "This expert has never recorded changing its mind. It may have read a great deal; "
+            "nothing it read has moved it, which is the state a new expert is already in.",
+            "",
+        ]
+
+    if current := graph.current:
+        lines += ["## How it reads the subject now", "", current.text, ""]
+
+    if graph.shifts:
+        lines += ["## What moved it", ""]
+        for shift in graph.shifts:
+            when = f" ({shift.at[:10]})" if shift.at else ""
+            lines.append(f"- {shift.text}{when}")
+        lines.append("")
+
+    if graph.commitments:
+        lines += ["## How it conducts itself", ""]
+        lines += [f"- {c.text}" for c in graph.commitments]
+        lines += ["", "_Not claims about the world. Commitments about conduct._", ""]
+
+    if graph.pursuits:
+        lines += ["## What it is still working on", ""]
+        lines += [f"- {p.text}" for p in graph.pursuits]
+        lines += ["", "_Its own agenda, not gaps in the corpus._", ""]
+
+    return "\n".join(lines)

--- a/src/deepr/experts/portraits.py
+++ b/src/deepr/experts/portraits.py
@@ -47,6 +47,9 @@ XAI_PORTRAIT_COST_ESTIMATE_USD = 0.02
 # migration, but it cannot authorize execution until a supported backend has a
 # stable identity and exact materialized-model attestation contract.
 LOCAL_IMAGE_URL_ENV = "DEEPR_LOCAL_IMAGE_URL"
+
+_MAX_APPEARANCE_CHARS = 600
+"""Long enough for a described scene, short enough that no image model truncates it."""
 METERED_IMAGE_AUTO_ENV = "DEEPR_ALLOW_METERED_IMAGE_AUTO"
 
 
@@ -104,14 +107,34 @@ def portrait_style(override: str | None = None) -> str:
     return env or DEFAULT_PORTRAIT_STYLE
 
 
-def _build_prompt(name: str, domain: str | None, description: str | None, *, style: str | None = None) -> str:
-    """Build an image generation prompt from expert metadata.
+def _build_prompt(
+    name: str,
+    domain: str | None,
+    description: str | None,
+    *,
+    style: str | None = None,
+    appearance: str | None = None,
+) -> str:
+    """Build an image generation prompt for one expert.
 
-    Uses a seeded rotation of gender, ethnicity, and age to ensure diverse
-    representation across generated portraits, while the *style* clause stays
-    constant across the library (``portrait_style``) for a coherent look.
+    An expert that has written its own ``appearance`` gets that, and nothing
+    else describing the subject. Everything below this branch is the fallback
+    for an expert with no self-account yet, and it produces a picture of the
+    *field* rather than of the one holding a view about it: two experts on one
+    domain come out identical apart from a hash-seeded demographic rotation,
+    which is backwards for the thing a portrait is for. The rotation exists so
+    the fallback is at least varied, not because varying it is the goal.
+
+    The style clause stays constant across the library either way, so a
+    self-chosen portrait still sits beside the others.
     """
     import hashlib
+
+    if chosen := " ".join((appearance or "").split()):
+        # Trailing punctuation is stripped because the expert writes a sentence
+        # and the style clause is appended as another one.
+        chosen = chosen[:_MAX_APPEARANCE_CHARS].rstrip(" .,;:")
+        return f"{chosen}. {portrait_style(style)}. No text or watermarks."
 
     # Deterministic diversity based on expert name. Non-crypto: md5 is used as a stable
     # seed for portrait diversity rotation only, not for security/passwords/signatures.
@@ -202,6 +225,7 @@ async def generate_portrait(
     provider: str | None = None,
     style: str | None = None,
     output_dir: str | Path | None = None,
+    appearance: str | None = None,
 ) -> str:
     """Generate a portrait image for an expert.
 
@@ -212,6 +236,10 @@ async def generate_portrait(
         provider: Force a specific provider (openai/google/xai).
                   Auto-detected if None.
         output_dir: Directory to save the portrait image.
+        appearance: How the expert says it wants to be depicted. When set, this
+                    is the whole subject of the prompt and domain/description
+                    are ignored, because the expert's own account of itself
+                    outranks anything inferred from its topic.
 
     Returns:
         Relative URL path to the saved portrait (e.g. ``/portraits/my-expert.png``).
@@ -237,7 +265,7 @@ async def generate_portrait(
             safe_alternative="no attested zero-dollar portrait backend is currently available",
         )
 
-    prompt = _build_prompt(name, domain, description, style=style)
+    prompt = _build_prompt(name, domain, description, style=style, appearance=appearance)
     logger.info("Generating portrait for '%s' via %s", name, provider)
 
     if provider == "local":
@@ -266,6 +294,28 @@ async def generate_portrait(
     return f"/portraits/{filename}"
 
 
+def _self_chosen_appearance(expert_name: str) -> str:
+    """How this expert says it wants to look, or "" if it has not said.
+
+    Read here rather than taken from the caller so every path that generates a
+    portrait honours it, including the batch command and anything that grows a
+    portrait call later. Failures are swallowed to "": an unreadable self.json
+    should fall back to the generic prompt, not stop a portrait run.
+    """
+    import json
+
+    try:
+        from deepr.experts.expert_layout import self_path
+
+        path = self_path(expert_name)
+        if not path.exists():
+            return ""
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, ImportError):
+        return ""
+    return str(data.get("appearance") or "") if isinstance(data, dict) else ""
+
+
 async def generate_and_save_portrait(
     profile: object,
     store: object,
@@ -283,6 +333,7 @@ async def generate_and_save_portrait(
     )
 
     expert_name = str(getattr(profile, "name", "expert"))
+    appearance = _self_chosen_appearance(expert_name)
     effective_provider = provider or detect_provider()
     if effective_provider == "local":
         _local_image_base_url()
@@ -315,6 +366,7 @@ async def generate_and_save_portrait(
             provider=effective_provider,
             style=style,
             output_dir=output_dir,
+            appearance=appearance,
         )
     except Exception:
         # Once generate_portrait starts, a remote provider may have accepted

--- a/src/deepr/experts/position_ledger.py
+++ b/src/deepr/experts/position_ledger.py
@@ -1,0 +1,310 @@
+"""Positions that survive a re-brief, and a record of what changed them.
+
+The defect this removes is the largest destruction of judgement in the system.
+`build_brief` takes a study and a corpus and no prior brief, then overwrites
+`brief.json` wholesale. Every run discards the previous positions - their
+likelihood bands, their falsifiers, and the dissent they carried - and derives
+new ones from scratch. An expert that has existed six months has read more than
+a new one and has concluded nothing that outlived its last run.
+
+Three things become possible once a position has an identity and a history, and
+none of them is possible without both:
+
+- **A falsifier becomes a prediction.** "What would change my mind" is only a
+  registered expectation if the thing it is attached to still exists when the
+  evidence arrives. Against a positional id it is worthless: a re-brief makes
+  `position-3` a different question.
+- **Survival becomes evidence.** A position that has been re-derived across
+  four corpus states is a different claim from one written once, and the
+  difference is exactly what elapsed time is supposed to buy.
+- **A revision becomes distinguishable from a replacement.** Which is the
+  reversibility property that keeps `brief` out of unattended operation.
+
+**The ledger is the record; `brief.json` stays the current view.** Every reader
+in the system - consult, health, the graph, the profile, the stage contract -
+loads `brief.json`, and changing its shape to a version log would break all of
+them to serve one new reader. So versions append here, and the brief is derived
+from the live ones. That is also the shape the belief store already uses, which
+is the one part of Deepr that has always kept its history.
+
+**Only the record axis is stored.** `recorded_at` and `superseded_at`, closed-
+open, sentinel-terminated, never rewritten. Valid time and belief time are
+sparse and cannot back a snapshot; a position carries an optional `held` block
+for the case where a viva names the moment a view was abandoned, and it is an
+annotation rather than a queryable axis. The reasoning is in
+``expert-v2-identity-and-time.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from deepr.experts.record_identity import normalize_text, position_thread_id, version_id
+from deepr.experts.record_time import END_OF_TIME, contains, is_open, utc_now
+
+POSITION_LEDGER_SCHEMA_VERSION = "deepr-position-ledger-v1"
+
+REASON_REVISED = "revised"
+"""The expert restated this position differently. The common case."""
+
+REASON_NOT_RESTATED = "not_restated"
+"""A re-brief over the same subject did not produce this position at all.
+
+Deliberately not called "retired". The expert did not decide to drop it; a
+later pass simply did not arrive at it, which is weaker evidence and should
+read as weaker. A position that vanishes quietly across several rebuilds is
+worth looking at, and calling it retired would hide that."""
+
+REASON_OPERATOR_RETIRED = "operator_retired"
+REASON_SOURCE_RETRACTED = "retracted_by_source"
+
+_REASONS = (REASON_REVISED, REASON_NOT_RESTATED, REASON_OPERATOR_RETIRED, REASON_SOURCE_RETRACTED)
+
+
+@dataclass
+class PositionVersion:
+    """One statement of one position, and when the store held it."""
+
+    thread_id: str
+    """Which question this is about. Stable across every revision."""
+    version_id: str
+    """Which statement of it this is. Changes whenever the content does."""
+    question: str
+    stance: str = ""
+    likelihood: str = ""
+    confidence: str = ""
+    would_change_my_mind: str = ""
+    unresolved_dissent: str = ""
+    supported_by: list[str] = field(default_factory=list)
+
+    recorded_at: str = ""
+    superseded_at: str = END_OF_TIME
+    superseded_by: str = ""
+    supersession_reason: str = ""
+    corpus_fingerprint: str = ""
+    seq: int = 0
+    """Tie-break within one instant.
+
+    Two versions can share a timestamp at this resolution, and ordering has to
+    be total or `as_of` at that instant is ambiguous. Keeping a real timestamp
+    plus a counter beats the alternative already in this codebase, which nudges
+    the timestamp forward a microsecond and makes it a lie."""
+
+    @property
+    def is_live(self) -> bool:
+        return is_open(self.superseded_at)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["is_live"] = self.is_live
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PositionVersion:
+        return cls(
+            thread_id=str(data.get("thread_id") or ""),
+            version_id=str(data.get("version_id") or ""),
+            question=str(data.get("question") or ""),
+            stance=str(data.get("stance") or ""),
+            likelihood=str(data.get("likelihood") or ""),
+            confidence=str(data.get("confidence") or ""),
+            would_change_my_mind=str(data.get("would_change_my_mind") or ""),
+            unresolved_dissent=str(data.get("unresolved_dissent") or ""),
+            supported_by=list(data.get("supported_by") or []),
+            recorded_at=str(data.get("recorded_at") or ""),
+            superseded_at=str(data.get("superseded_at") or END_OF_TIME),
+            superseded_by=str(data.get("superseded_by") or ""),
+            supersession_reason=str(data.get("supersession_reason") or ""),
+            corpus_fingerprint=str(data.get("corpus_fingerprint") or ""),
+            seq=int(data.get("seq", 0) or 0),
+        )
+
+
+def _content_of(position: Any) -> str:
+    """What makes one statement different from another.
+
+    The question is excluded on purpose - it is the thread identity, and
+    including it would make every version differ from every other only because
+    they share a subject.
+    """
+    parts = [
+        str(getattr(position, "stance", "") or ""),
+        str(getattr(position, "likelihood", "") or ""),
+        str(getattr(position, "confidence", "") or ""),
+        str(getattr(position, "would_change_my_mind", "") or ""),
+        str(getattr(position, "unresolved_dissent", "") or ""),
+        ",".join(sorted(str(f) for f in (getattr(position, "supported_by", None) or []))),
+    ]
+    return "\n\x00".join(parts)
+
+
+def version_from_position(position: Any, *, at: str, corpus_fingerprint: str = "", seq: int = 0) -> PositionVersion:
+    """Turn a freshly briefed position into a recordable version."""
+    question = str(getattr(position, "question", "") or "")
+    return PositionVersion(
+        thread_id=position_thread_id(question),
+        version_id=version_id(_content_of(position)),
+        question=question,
+        stance=str(getattr(position, "stance", "") or ""),
+        likelihood=str(getattr(position, "likelihood", "") or ""),
+        confidence=str(getattr(position, "confidence", "") or ""),
+        would_change_my_mind=str(getattr(position, "would_change_my_mind", "") or ""),
+        unresolved_dissent=str(getattr(position, "unresolved_dissent", "") or ""),
+        supported_by=[str(f) for f in (getattr(position, "supported_by", None) or [])],
+        recorded_at=at,
+        corpus_fingerprint=corpus_fingerprint,
+        seq=seq,
+    )
+
+
+@dataclass
+class PositionLedger:
+    """Every version of every position this expert has held."""
+
+    expert_name: str
+    schema_version: str = POSITION_LEDGER_SCHEMA_VERSION
+    versions: list[PositionVersion] = field(default_factory=list)
+
+    @property
+    def live(self) -> list[PositionVersion]:
+        """What the expert holds now. The default read."""
+        return [v for v in self.versions if v.is_live]
+
+    def history_of(self, thread_id: str) -> list[PositionVersion]:
+        """Every statement of one position, oldest first."""
+        return sorted(
+            (v for v in self.versions if v.thread_id == thread_id),
+            key=lambda v: (v.recorded_at, v.seq),
+        )
+
+    def as_of(self, at: str) -> list[PositionVersion]:
+        """What the expert held at a moment, by record time.
+
+        One axis, because it is the only total one. A version with no
+        `recorded_at` - written before this ledger existed - is treated as
+        having always applied rather than never, so a migrated store reads as
+        live instead of silently empty.
+        """
+        return [v for v in self.versions if contains(v.recorded_at, v.superseded_at, at)]
+
+    def survived(self, thread_id: str) -> int:
+        """How many distinct corpus states this position has been re-derived over.
+
+        The number that makes elapsed time into evidence. A position restated
+        across four corpus fingerprints has been reached again from material it
+        had not seen, which is different from one written once and copied.
+        """
+        seen = {v.corpus_fingerprint for v in self.history_of(thread_id) if v.corpus_fingerprint}
+        return len(seen)
+
+    def stats(self) -> dict[str, Any]:
+        live = self.live
+        return {
+            "threads": len({v.thread_id for v in self.versions}),
+            "versions": len(self.versions),
+            "live": len(live),
+            "revised": sum(1 for v in self.versions if v.supersession_reason == REASON_REVISED),
+            "not_restated": sum(1 for v in self.versions if v.supersession_reason == REASON_NOT_RESTATED),
+            "max_survived": max((self.survived(v.thread_id) for v in live), default=0),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "expert": self.expert_name,
+            "stats": self.stats(),
+            "versions": [v.to_dict() for v in self.versions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PositionLedger:
+        ledger = cls(expert_name=str(data.get("expert") or ""))
+        for raw in data.get("versions") or []:
+            if isinstance(raw, dict) and raw.get("thread_id"):
+                ledger.versions.append(PositionVersion.from_dict(raw))
+        return ledger
+
+
+def record_brief(
+    ledger: PositionLedger,
+    positions: list[Any],
+    *,
+    at: str = "",
+    corpus_fingerprint: str = "",
+) -> dict[str, int]:
+    """Fold a fresh brief into the ledger. Returns what changed.
+
+    Three outcomes per thread, and the distinctions are the point:
+
+    - **unchanged**: the expert restated the same position identically. No new
+      version, because a version that differs in nothing is noise, and the
+      ledger's job is to make real change visible.
+    - **revised**: same question, different statement. The prior version closes
+      and a new one opens, so the pair is a recorded change of mind rather than
+      a replacement.
+    - **not restated**: a live position this brief did not produce. Closed with
+      a reason that says only that, because the expert did not decide to drop
+      it - a later pass simply did not arrive at it, and that is weaker
+      evidence than a retirement.
+
+    New threads are appended. Nothing is ever deleted.
+    """
+    stamp = at or utc_now()
+    changed = {"new": 0, "revised": 0, "unchanged": 0, "not_restated": 0}
+
+    live_by_thread = {v.thread_id: v for v in ledger.live}
+    seen_threads: set[str] = set()
+    seq = max((v.seq for v in ledger.versions), default=0)
+
+    for position in positions:
+        if not str(getattr(position, "question", "") or "").strip():
+            continue
+        seq += 1
+        fresh = version_from_position(position, at=stamp, corpus_fingerprint=corpus_fingerprint, seq=seq)
+        seen_threads.add(fresh.thread_id)
+        prior = live_by_thread.get(fresh.thread_id)
+
+        if prior is None:
+            ledger.versions.append(fresh)
+            changed["new"] += 1
+            continue
+
+        if prior.version_id == fresh.version_id:
+            # Identical restatement. Record that it survived this corpus state
+            # without adding a version: survival is counted by fingerprint, so
+            # the evidence is kept and the noise is not.
+            if corpus_fingerprint and corpus_fingerprint != prior.corpus_fingerprint:
+                prior.corpus_fingerprint = corpus_fingerprint
+            changed["unchanged"] += 1
+            continue
+
+        prior.superseded_at = stamp
+        prior.superseded_by = fresh.version_id
+        prior.supersession_reason = REASON_REVISED
+        ledger.versions.append(fresh)
+        changed["revised"] += 1
+
+    for thread_id, prior in live_by_thread.items():
+        if thread_id in seen_threads:
+            continue
+        prior.superseded_at = stamp
+        prior.supersession_reason = REASON_NOT_RESTATED
+        changed["not_restated"] += 1
+
+    return changed
+
+
+def load_ledger(path: Path, *, expert_name: str = "") -> PositionLedger:
+    """Read the ledger, or an empty one when there is none yet."""
+    try:
+        return PositionLedger.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return PositionLedger(expert_name=expert_name)
+
+
+def find_thread(ledger: PositionLedger, question: str) -> str:
+    """The thread id for a question, whether or not it is already held."""
+    return position_thread_id(normalize_text(question))

--- a/src/deepr/experts/query_proposal.py
+++ b/src/deepr/experts/query_proposal.py
@@ -1,0 +1,170 @@
+"""A model writes the queries; the arm structure still has to hold.
+
+Templating query text was a mistake, and the runs showed it before I admitted
+it: four of six arms returned nothing on two separate topics, and the queries
+that did run looked like ``criticism of anti-slop practices for AI agent
+generated code and analysis``. That is not a search anybody would type. I
+reported the empty arms as signal about the subject when they were signal
+about the queries.
+
+The evidence I was leaning on says something narrower than I made it say. It
+found that *people* do not spontaneously broaden their own searching, and that
+changing what the algorithm returns works where prompting the searcher does
+not. That argues the *coverage guarantee* must be structural. It does not
+argue the query text should be string concatenation.
+
+So the split is:
+
+    structural   the arms. A model told to "search thoroughly" reliably omits
+                 the adversarial and primary arms, so their presence is a
+                 requirement checked after the fact, not a request.
+    model        what actually goes in them. Which critics this field has, what
+                 it calls its own controversies, where its landmark work was
+                 published, and the other community's word for the subject.
+                 Templates know none of that and cannot learn it.
+
+Falls back to templates when there is no model, when the call fails, or when a
+required arm comes back empty, and says so on the plan. Templates are a poor
+researcher and a dependable one; keeping them is what lets acquisition run at
+$0 with no model at all.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from deepr.experts.acquisition_plan import (
+    ARM_ADVERSARIAL,
+    ARM_DESCRIPTIVE,
+    ARM_GENRE,
+    ARM_PRIMARY,
+    ARM_RECENCY,
+    ARM_TERMINOLOGY,
+    ARMS,
+    AcquisitionPlan,
+    AcquisitionQuery,
+    plan_queries,
+)
+
+QueryCompletion = Callable[[str], Awaitable[str]]
+
+_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+#.-]*")
+_STOPWORDS = frozenset("a an and are as at be by for from how in is of on or the to what when with".split())
+
+_PER_ARM = 4
+_MAX_QUERY_CHARS = 120
+
+_ARM_BRIEFS: dict[str, str] = {
+    ARM_DESCRIPTIVE: "what the subject is and how it works, in the terms its own field uses",
+    ARM_ADVERSARIAL: (
+        "who says this is wrong, and why. Name the actual critics, the specific objections, the "
+        "known failure cases. Not 'criticism of X' - the search a skeptic in this field would run"
+    ),
+    ARM_GENRE: (
+        "documents that enumerate disagreement by form: reviews, surveys, comments, replies, "
+        "rebuttals, retractions, errata. Use the words this field uses for those"
+    ),
+    ARM_PRIMARY: (
+        "where the claim is made rather than repeated: specs, standards, original papers, "
+        "datasets, reference implementations, named landmark work"
+    ),
+    ARM_RECENCY: "what changed recently, and what supersedes older material",
+    ARM_TERMINOLOGY: (
+        "the same subject as named by a different community. Different words, not a rephrasing - "
+        "queries here that share the topic's own vocabulary are useless"
+    ),
+}
+
+_REQUIRED_ARMS = (ARM_ADVERSARIAL, ARM_PRIMARY, ARM_TERMINOLOGY)
+"""The arms a model skips unprompted, which are the ones that matter most."""
+
+
+def build_proposal_prompt(topic: str, known_terms: tuple[str, ...] = ()) -> str:
+    """Ask for real queries, arm by arm, with each arm's job stated."""
+    arms = "\n".join(f'  "{arm}": {brief}' for arm, brief in _ARM_BRIEFS.items())
+    seen = ""
+    if known_terms:
+        seen = "\nAlready in the corpus, so do not simply re-find it: " + "; ".join(known_terms) + "\n"
+
+    return (
+        f"Plan the searches for building an expert on: {topic}\n\n"
+        "Write the queries a researcher who knows this field would actually type. Real terminology, "
+        "real names, real venues where they help. A query that is the topic with a word bolted on "
+        "the front is worse than useless: it looks like coverage and finds nothing.\n\n"
+        "Each arm has a different job:\n\n"
+        f"{arms}\n{seen}\n"
+        "Rules:\n"
+        f"- {_PER_ARM} queries per arm.\n"
+        "- Every arm must be filled. The adversarial and primary arms are the ones most often "
+        "skipped and the ones that matter most; a corpus without them reproduces whatever is "
+        "already popular.\n"
+        "- Queries must be searchable: short and specific, not sentences.\n"
+        "- Do not repeat the topic verbatim as a query.\n\n"
+        "Return JSON only, no prose, no code fence:\n\n"
+        '{"queries": {' + ", ".join(f'"{arm}": [""]' for arm in ARMS) + "}}\n"
+    )
+
+
+def echoes_topic(text: str, topic: str) -> bool:
+    """True when a query is the topic wearing a hat.
+
+    ``criticism of X`` reaches nothing a search for ``X`` did not already
+    reach. This is the exact failure templating made unavoidable, and a model
+    can still produce it, so it is checked rather than assumed away.
+    """
+    words = {w.lower() for w in _WORD_RE.findall(text)}
+    topic_words = {w.lower() for w in _WORD_RE.findall(topic)}
+    return len(words - topic_words - _STOPWORDS) <= 1
+
+
+def assemble_proposed_plan(parsed: dict[str, Any], topic: str) -> AcquisitionPlan:
+    """Turn a proposal into a plan, keeping only queries that add something."""
+    plan = AcquisitionPlan(topic=" ".join(topic.split()))
+    plan.search_key = plan.topic
+    raw = parsed.get("queries") if isinstance(parsed.get("queries"), dict) else parsed
+
+    for arm in ARMS:
+        items = (raw or {}).get(arm) or []
+        if not isinstance(items, list):
+            continue
+        for item in items[: _PER_ARM * 2]:
+            text = " ".join(str(item).split())
+            if not text or len(text) > _MAX_QUERY_CHARS:
+                continue
+            if arm != ARM_DESCRIPTIVE and echoes_topic(text, topic):
+                continue
+            plan.queries.append(AcquisitionQuery(text=text, arm=arm, rationale=_ARM_BRIEFS[arm]))
+    return plan
+
+
+def templated_fallback(topic: str, why: str) -> AcquisitionPlan:
+    """The deterministic plan, labeled with why it was reached for."""
+    plan = plan_queries(topic)
+    plan.fallback_reason = why
+    return plan
+
+
+async def propose_plan(
+    topic: str,
+    *,
+    completion: QueryCompletion,
+    known_terms: tuple[str, ...] = (),
+) -> AcquisitionPlan:
+    """Ask a model to write the plan, then check the structure held."""
+    from deepr.experts.study import extract_json_object
+
+    try:
+        raw = await completion(build_proposal_prompt(topic, known_terms))
+    except Exception as exc:
+        return templated_fallback(topic, f"the query proposal call failed ({str(exc)[:80]})")
+
+    parsed, error = extract_json_object(raw)
+    if parsed is None:
+        return templated_fallback(topic, f"the query proposal did not return usable JSON ({error})")
+
+    plan = assemble_proposed_plan(parsed, topic)
+    if missing := [arm for arm in _REQUIRED_ARMS if not plan.by_arm(arm)]:
+        return templated_fallback(topic, f"the proposal left {', '.join(missing)} empty")
+    return plan

--- a/src/deepr/experts/record_identity.py
+++ b/src/deepr/experts/record_identity.py
@@ -1,0 +1,114 @@
+"""Stable identity for records that get revised.
+
+The defect this fixes, in two lines of the codebase it replaces:
+
+    finding_id = f"{lens.key}-{start_index + len(findings)}"   # study.py
+    position_id = f"position-{index}"                          # evidence_graph.py
+
+Both are positions in a list. Insert one finding and every id after it
+renumbers, so a brief citing ``failure-30`` silently repoints at a different
+finding after a partial resume re-runs only the failure lens. The citation
+still validates, which is worse than failing - the provenance chain reports
+itself intact while pointing at the wrong evidence.
+
+**Two keys, not one.** A record that can be revised needs both:
+
+- a **thread id**, answering "which question is this about", stable across
+  every revision, and
+- a **version id**, answering "which statement of it is this", changing on
+  every revision.
+
+One key cannot do both, and collapsing them is a real bug already present
+elsewhere in this codebase: ``ExpertStance.create`` hashes title and statement
+together, so revising a stance produces an unrelated record with no link to
+what it replaced.
+
+**Findings resolve by anchor set, which nothing else has.** Two findings
+quoting overlapping corpus spans are far more likely to be the same finding
+than two findings with similar titles - and the check is deterministic, free,
+and exactly the evidence a person would use. Every surveyed system resolves on
+a normalized name string and bleeds accordingly.
+
+Hashes are truncated to 16 hex characters. At the measured scale of this
+system - the largest expert holds 105 findings, the whole fleet 1,975 records -
+64 bits is many orders of magnitude clear of a birthday collision, and a
+readable id is worth more than the unused entropy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+
+IDENTITY_SCHEMA_VERSION = "deepr-record-identity-v1"
+
+_ID_CHARS = 16
+_PUNCT = re.compile(r"[^\w\s]+")
+_SPACE = re.compile(r"\s+")
+
+
+def normalize_text(text: str) -> str:
+    """Fold a title or question to its comparable form.
+
+    Case, punctuation, accents and whitespace are removed because none of them
+    change which question is being asked, and all of them change often enough
+    between runs to break an id that includes them. A model rewrapping a
+    question or adding a trailing full stop must not create a new thread.
+    """
+    folded = unicodedata.normalize("NFKD", str(text or ""))
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    folded = _PUNCT.sub(" ", folded.lower())
+    return _SPACE.sub(" ", folded).strip()
+
+
+def _digest(*parts: str) -> str:
+    """Hash the parts with a separator that cannot appear in them.
+
+    A newline separator rather than concatenation: joining "ab" + "c" and
+    "a" + "bc" to the same string is how content-addressed ids collide on
+    inputs that are not remotely alike.
+    """
+    return hashlib.sha256("\n\x00".join(parts).encode("utf-8")).hexdigest()[:_ID_CHARS]
+
+
+def finding_thread_id(*, lens: str, title: str, anchors: list[str]) -> str:
+    """Which finding this is, stable across runs.
+
+    Derived from the lens, the normalized title, and the sorted anchor set.
+    Anchors are included because they are what a finding is *about* in the
+    corpus: a lens re-reading the same passages and phrasing its title slightly
+    differently is the same finding, and including the anchors makes that
+    recognisable while a title-only hash would not.
+
+    Sorted, so anchor ordering from the model cannot change identity.
+    """
+    normalized_anchors = sorted({normalize_text(a) for a in anchors if str(a).strip()})
+    return f"{lens}-{_digest(lens, normalize_text(title), *normalized_anchors)}"
+
+
+def position_thread_id(question: str) -> str:
+    """Which question this position is about, stable across every revision.
+
+    Deliberately derived from the question alone. A position exists to answer
+    one question; changing the stance, the confidence, or the falsifier is a
+    revision of the same position, not a different one. Including any of them
+    would make every revision a new thread and defeat the point.
+    """
+    return f"position-{_digest(normalize_text(question))}"
+
+
+def version_id(payload: str) -> str:
+    """Which statement of a record this is. Changes whenever the content does."""
+    return _digest(payload)
+
+
+def is_stable_id(value: str) -> bool:
+    """Whether an id came from here rather than from a list position.
+
+    Lets a migration tell a durable id from a legacy positional one without
+    keeping a separate flag. ``failure-3`` is legacy; ``failure-a1b2c3...`` is
+    not.
+    """
+    _, _, suffix = str(value or "").rpartition("-")
+    return len(suffix) == _ID_CHARS and all(c in "0123456789abcdef" for c in suffix)

--- a/src/deepr/experts/record_time.py
+++ b/src/deepr/experts/record_time.py
@@ -1,0 +1,136 @@
+"""One clock, one interval convention, one sentinel.
+
+There are 62 separate ``_utc_now()`` definitions in this package and at least
+four hand-rolled naive-to-UTC coercions. That is survivable while nothing
+depends on two of them agreeing. It stops being survivable the moment records
+carry validity intervals, because the closed-open convention then has to be
+implemented identically everywhere or a version boundary belongs to two
+versions in one code path and to neither in the next.
+
+**Closed-open, everywhere: ``start <= t < end``.** Not an aesthetic choice. It
+is the only convention under which consecutive versions tile the timeline with
+no gap and no overlap, so ``predecessor.superseded_at == successor.recorded_at``
+exactly and a point-in-time read returns exactly one version. Closed-closed
+forces subtracting one tick, which makes correctness depend on timestamp
+resolution.
+
+**A sentinel for open-ended, never NULL.** NULL makes every predicate
+two-branch (``superseded_at IS NULL OR superseded_at > t``) and something
+eventually gets it wrong - this codebase already has an instance, where a
+temporal filter excludes records with missing endpoints instead of treating
+them as unbounded, silently under-returning. NULL also conflates "unbounded"
+with "unknown" while offering one value for two meanings.
+
+``END_OF_TIME`` is ``datetime.max`` at UTC, which matches SQL:2011's own worked
+example and what SQL Server and MarkLogic use, so an export is a no-op. It
+round-trips losslessly through ``fromisoformat``/``isoformat`` and sorts
+correctly as a plain string, which matters because sorting without parsing is
+sometimes the right thing to do.
+
+One deliberate hazard: arithmetic against the sentinel yields absurd durations,
+and a "how long did we hold this" metric computed without checking is how an
+8000-year mean reaches a chart. ``is_open`` exists so that check is one call.
+
+**Not a general date library.** Valid time and belief time are sparse and
+nullable by design, and this module is deliberately silent about them; see
+``expert-v2-identity-and-time.md`` for why only the record axis is total.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+RECORD_TIME_SCHEMA_VERSION = "deepr-record-time-v1"
+
+END_OF_TIME = "9999-12-31T23:59:59.999999+00:00"
+"""An interval that has not closed. Never NULL, never a near-future date.
+
+datetime.max at UTC. MariaDB's system-versioning sentinel is 2038-01-19, a live
+Y2038 bug where an open row sorts *before* genuinely future-dated rows."""
+
+BEGINNING_OF_TIME = "0001-01-01T00:00:00+00:00"
+"""An interval with no known start. Rare, and provided so nothing invents one."""
+
+
+def utc_now() -> str:
+    """The current instant, in the one format every record uses."""
+    return datetime.now(UTC).isoformat()
+
+
+def parse_iso(value: str) -> datetime | None:
+    """Parse a stored timestamp, or None when it is absent or unusable.
+
+    Accepts a trailing ``Z`` and assumes UTC for a naive value. Returns None
+    rather than raising: a corrupt timestamp on one record must not take down
+    a read across a whole store, and a caller that needs to know can check.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def is_open(end: str) -> bool:
+    """Whether an interval is still open.
+
+    Use before any duration arithmetic. Subtracting a record time from
+    END_OF_TIME produces roughly eight thousand years, and that number will
+    otherwise reach a mean, an axis label, or a staleness heuristic.
+    """
+    return not str(end or "").strip() or str(end).strip() == END_OF_TIME
+
+
+def contains(start: str, end: str, at: str) -> bool:
+    """Whether ``at`` falls in the closed-open interval ``[start, end)``.
+
+    The single implementation of the convention. An unparseable or absent
+    ``start`` means the interval has always applied; an absent ``end`` means it
+    is still open. Both defaults are chosen so a record written before this
+    module existed reads as live rather than silently vanishing.
+    """
+    moment = parse_iso(at)
+    if moment is None:
+        return False
+
+    opened = parse_iso(start)
+    if opened is not None and moment < opened:
+        return False
+
+    if is_open(end):
+        return True
+    closed = parse_iso(end)
+    return closed is None or moment < closed
+
+
+def overlaps(start_a: str, end_a: str, start_b: str, end_b: str) -> bool:
+    """Whether two closed-open intervals share any instant.
+
+    Used to detect a successor that contradicts rather than continues its
+    predecessor, which is a materially stronger event than a plain revision
+    and worth flagging separately.
+    """
+    a_start = parse_iso(start_a) or parse_iso(BEGINNING_OF_TIME)
+    b_start = parse_iso(start_b) or parse_iso(BEGINNING_OF_TIME)
+    a_end = None if is_open(end_a) else parse_iso(end_a)
+    b_end = None if is_open(end_b) else parse_iso(end_b)
+
+    if a_end is not None and b_start is not None and b_start >= a_end:
+        return False
+    return not (b_end is not None and a_start is not None and a_start >= b_end)
+
+
+def age_days(since: str, *, now: str = "") -> int:
+    """Whole days from ``since`` until now. -1 when unknown.
+
+    -1 rather than 0, because zero is a real answer meaning "today" and a
+    missing timestamp is not that.
+    """
+    started = parse_iso(since)
+    if started is None:
+        return -1
+    current = parse_iso(now) or datetime.now(UTC)
+    return max(0, (current - started).days)

--- a/src/deepr/experts/research_practice.py
+++ b/src/deepr/experts/research_practice.py
@@ -1,0 +1,523 @@
+"""What an expert does to stay expert, rather than what it knows.
+
+A professor does not maintain expertise by holding facts. They maintain a
+practice: a handful of questions they are actively chasing, a set of sources
+they follow because those sources have repeatedly been worth reading, and areas
+they are deepening as against areas they are merely keeping an eye on. The
+practice is what makes next month's reading different from last month's, and it
+is the thing that turns elapsed time into expertise.
+
+Deepr has every input for this and has never assembled it:
+
+- the **agenda** exists as ``open_questions`` on the profile card, regenerated
+  from scratch each time and driving nothing;
+- **which sources have earned attention** is computable exactly, from the
+  evidence graph's ``load_bearing_sources`` - the publishers the expert's own
+  claims actually trace back to, as opposed to the ones that happened to be
+  acquired;
+- **new questions** arrive every time a viva finds something answerable that
+  the expert could not answer;
+- and nothing feeds any of it into the next acquisition, so every acquisition
+  starts from the topic string again as though the expert had learned nothing
+  about where to look.
+
+The practice closes that loop. It is the difference between an expert that is
+re-researched and one that is *keeping up*.
+
+**Three record types, and the distinctions between them are the design.**
+
+A **pursuit** is a question the expert decided to chase. It is not a gap. A gap
+is something missing from the corpus - a property of the material. A pursuit is
+something the expert chose to care about, which is why it carries a reason and
+a resolution rather than just a description. Pursuits open, get answered, or get
+abandoned, and all three are recorded because abandoning a line of enquiry is
+itself a finding about the subject.
+
+A **watch** is a source worth following, and it must be *earned*. Promoting
+whatever was acquired first would just re-rank the accident of acquisition
+order. A watch is promoted from evidence: this publisher's material is what the
+expert's positions actually rest on. Demotion is equally evidential - a watch
+that stops producing anything load-bearing is dropped, which is how a field
+moving on becomes visible rather than being silently carried forever.
+
+An **interest** is an area with a stated depth. The distinction between
+deepening and maintaining is what stops an expert either sprawling across
+everything shallowly or over-focusing on one corner. A human keeps two or three
+things deep and a dozen shallow, deliberately.
+
+Nothing here calls a model. Every update is derived from artifacts already on
+disk, which is what makes it cheap enough to run after every study.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+PRACTICE_SCHEMA_VERSION = "deepr-research-practice-v1"
+
+PURSUIT_OPEN = "open"
+PURSUIT_ANSWERED = "answered"
+PURSUIT_ABANDONED = "abandoned"
+
+DEPTH_DEEPENING = "deepening"
+DEPTH_MAINTAINING = "maintaining"
+DEPTH_PERIPHERAL = "peripheral"
+
+_MAX_DEEPENING = 3
+"""How many areas an expert may be actively deepening at once.
+
+A human keeps two or three things deep and a dozen shallow. An expert
+"deepening" everything is one that has not prioritised, and the whole value of
+a stated depth is that it forces the choice."""
+
+_MAX_WATCHES = 12
+"""A reading list nobody can get through is not a reading list."""
+
+_STALE_WATCH_ROUNDS = 3
+"""Rounds a watch may produce nothing load-bearing before it is dropped.
+
+Three rather than one, because a publisher that had a quiet quarter is not a
+publisher that has stopped mattering."""
+
+
+@dataclass
+class Pursuit:
+    """A question the expert decided to chase.
+
+    Not a gap. A gap is missing material; a pursuit is a choice, which is why
+    it carries why it matters and how it ended.
+    """
+
+    question: str
+    why_it_matters: str = ""
+    opened_at: str = ""
+    status: str = PURSUIT_OPEN
+    resolution: str = ""
+    """What answered it, or why it was abandoned. Empty while open."""
+    resolved_at: str = ""
+    origin: str = ""
+    """Where it came from: profile, viva, consult. Lets a reader judge it."""
+
+    @property
+    def is_live(self) -> bool:
+        return self.status == PURSUIT_OPEN
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["is_live"] = self.is_live
+        return data
+
+
+@dataclass
+class Watch:
+    """A source followed because its material has proved load-bearing."""
+
+    origin: str
+    """Publisher or origin key. What to go and check."""
+    why: str = ""
+    added_at: str = ""
+    positions_resting_on_it: int = 0
+    """Earned attention, measured. Not how much was acquired from it."""
+    quiet_rounds: int = 0
+    """Consecutive updates in which it carried nothing. Demotion counter."""
+
+    @property
+    def is_stale(self) -> bool:
+        return self.quiet_rounds >= _STALE_WATCH_ROUNDS
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["is_stale"] = self.is_stale
+        return data
+
+
+@dataclass
+class Interest:
+    """An area, and how much attention the expert is giving it."""
+
+    area: str
+    depth: str = DEPTH_MAINTAINING
+    why: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ResearchPractice:
+    """How this expert keeps up. Append-only where it matters."""
+
+    expert_name: str
+    schema_version: str = PRACTICE_SCHEMA_VERSION
+    updated_at: str = ""
+    pursuits: list[Pursuit] = field(default_factory=list)
+    watches: list[Watch] = field(default_factory=list)
+    interests: list[Interest] = field(default_factory=list)
+
+    @property
+    def live_pursuits(self) -> list[Pursuit]:
+        return [p for p in self.pursuits if p.is_live]
+
+    @property
+    def deepening(self) -> list[Interest]:
+        return [i for i in self.interests if i.depth == DEPTH_DEEPENING]
+
+    @property
+    def is_practising(self) -> bool:
+        """Whether this expert has a practice at all.
+
+        A live question and somewhere to look. An expert with neither is not
+        keeping up with anything; it is waiting to be re-researched, which is
+        what every expert in the fleet does today.
+        """
+        return bool(self.live_pursuits and self.watches)
+
+    def next_reading(self, limit: int = 5) -> list[str]:
+        """What to go and read, in the expert's own words.
+
+        Live pursuits first, because a question is a better search than a
+        topic, then the sources that have earned a look. This is the ordering
+        an acquisition pass should follow rather than starting from the topic
+        string again.
+        """
+        out = [p.question for p in self.live_pursuits[:limit]]
+        remaining = limit - len(out)
+        if remaining > 0:
+            out += [f"new material from {w.origin}" for w in self.watches[:remaining]]
+        return out
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "live_pursuits": len(self.live_pursuits),
+            "answered_pursuits": sum(1 for p in self.pursuits if p.status == PURSUIT_ANSWERED),
+            "abandoned_pursuits": sum(1 for p in self.pursuits if p.status == PURSUIT_ABANDONED),
+            "watches": len(self.watches),
+            "stale_watches": sum(1 for w in self.watches if w.is_stale),
+            "deepening": len(self.deepening),
+            "is_practising": self.is_practising,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "expert": self.expert_name,
+            "updated_at": self.updated_at,
+            "stats": self.stats(),
+            "next_reading": self.next_reading(),
+            "pursuits": [p.to_dict() for p in self.pursuits],
+            "watches": [w.to_dict() for w in self.watches],
+            "interests": [i.to_dict() for i in self.interests],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ResearchPractice:
+        practice = cls(
+            expert_name=str(data.get("expert") or ""),
+            updated_at=str(data.get("updated_at") or ""),
+        )
+        for raw in data.get("pursuits") or []:
+            if isinstance(raw, dict) and raw.get("question"):
+                practice.pursuits.append(
+                    Pursuit(
+                        question=str(raw["question"]),
+                        why_it_matters=str(raw.get("why_it_matters") or ""),
+                        opened_at=str(raw.get("opened_at") or ""),
+                        status=str(raw.get("status") or PURSUIT_OPEN),
+                        resolution=str(raw.get("resolution") or ""),
+                        resolved_at=str(raw.get("resolved_at") or ""),
+                        origin=str(raw.get("origin") or ""),
+                    )
+                )
+        for raw in data.get("watches") or []:
+            if isinstance(raw, dict) and raw.get("origin"):
+                practice.watches.append(
+                    Watch(
+                        origin=str(raw["origin"]),
+                        why=str(raw.get("why") or ""),
+                        added_at=str(raw.get("added_at") or ""),
+                        positions_resting_on_it=int(raw.get("positions_resting_on_it", 0) or 0),
+                        quiet_rounds=int(raw.get("quiet_rounds", 0) or 0),
+                    )
+                )
+        for raw in data.get("interests") or []:
+            if isinstance(raw, dict) and raw.get("area"):
+                practice.interests.append(
+                    Interest(
+                        area=str(raw["area"]),
+                        depth=str(raw.get("depth") or DEPTH_MAINTAINING),
+                        why=str(raw.get("why") or ""),
+                    )
+                )
+        return practice
+
+
+def _normalized(question: str) -> str:
+    from deepr.experts.record_identity import normalize_text
+
+    return normalize_text(question)
+
+
+def open_pursuits(
+    practice: ResearchPractice,
+    questions: list[str],
+    *,
+    origin: str,
+    at: str,
+    why: str = "",
+) -> int:
+    """Add questions the expert has decided to chase. Returns how many are new.
+
+    Deduplicated against every pursuit ever held, not just the live ones. A
+    question that was asked and abandoned must not silently reopen on the next
+    pass - re-opening it should be a decision, and reappearing is not one.
+    """
+    known = {_normalized(p.question) for p in practice.pursuits}
+    added = 0
+    for question in questions:
+        text = " ".join(str(question or "").split())
+        if not text or _normalized(text) in known:
+            continue
+        practice.pursuits.append(Pursuit(question=text, why_it_matters=why, opened_at=at, origin=origin))
+        known.add(_normalized(text))
+        added += 1
+    return added
+
+
+def resolve_pursuit(practice: ResearchPractice, question: str, *, resolution: str, at: str) -> bool:
+    """Close a pursuit as answered. Returns whether one matched."""
+    target = _normalized(question)
+    for pursuit in practice.pursuits:
+        if pursuit.is_live and _normalized(pursuit.question) == target:
+            pursuit.status = PURSUIT_ANSWERED
+            pursuit.resolution = resolution
+            pursuit.resolved_at = at
+            return True
+    return False
+
+
+def update_watches(practice: ResearchPractice, load_bearing: list[tuple[str, int]], *, at: str) -> None:
+    """Promote sources the expert's claims actually rest on, drop the quiet ones.
+
+    ``load_bearing`` is ``(origin, positions_resting_on_it)`` from the evidence
+    graph. Attention is earned by carrying claims, not by having been acquired:
+    promoting whatever arrived first would only re-rank the accident of
+    acquisition order.
+
+    A watch that carries nothing this round has its quiet counter advanced
+    rather than being dropped immediately, because a publisher with a quiet
+    quarter has not stopped mattering. Three quiet rounds and it goes, which is
+    how a field moving on becomes visible instead of being carried forever.
+    """
+    counts = {origin: n for origin, n in load_bearing if origin}
+    existing = {w.origin: w for w in practice.watches}
+
+    for origin, count in counts.items():
+        watch = existing.get(origin)
+        if watch is None:
+            watch = Watch(origin=origin, added_at=at, why="its material is what my positions rest on")
+            practice.watches.append(watch)
+            existing[origin] = watch
+        watch.positions_resting_on_it = count
+        watch.quiet_rounds = 0
+
+    for watch in practice.watches:
+        if watch.origin not in counts:
+            watch.quiet_rounds += 1
+
+    practice.watches = [w for w in practice.watches if not w.is_stale]
+    practice.watches.sort(key=lambda w: w.positions_resting_on_it, reverse=True)
+    del practice.watches[_MAX_WATCHES:]
+
+
+def set_interests(practice: ResearchPractice, interests: list[Interest]) -> None:
+    """Replace the interest set, holding the deepening budget.
+
+    Excess deepening areas are demoted to maintaining rather than dropped: the
+    expert still cares about them, it just cannot be going deep on eight things
+    at once, and silently discarding an area it named would be worse than
+    saying it is on the back burner.
+    """
+    ordered = list(interests)
+    deepening = [i for i in ordered if i.depth == DEPTH_DEEPENING]
+    for surplus in deepening[_MAX_DEEPENING:]:
+        surplus.depth = DEPTH_MAINTAINING
+        surplus.why = (surplus.why + " (demoted: deepening budget is full)").strip()
+    practice.interests = ordered
+
+
+PRACTICE_PROMPT = """You are "{expert_name}". Decide what you are working on next.
+
+This is not a summary of what you know. It is your research practice: the questions you have
+chosen to chase, and where your attention should go. A specialist stays a specialist by
+maintaining one of these, not by having read a lot once.
+
+What is decided for you, and what is yours:
+
+- **Which sources you follow is already settled** and is not your call. It is measured from
+  which publishers your own positions actually rest on, so you cannot promote a source you
+  like the look of. That is deliberate.
+- **What you are chasing, and where your attention goes, is entirely yours.**
+
+Three jobs.
+
+**1. Review your live pursuits.** For each one below, say whether what you have read since
+answers it. Be strict: a question is answered when you could now give a supported answer, not
+when you have read around it. If a line of enquiry turned out to be the wrong question, abandon
+it and say why - abandoning is a real finding about the subject and is not a failure.
+
+**2. Open new pursuits.** What do you now want to know that you did not before? Good ones come
+from a tension you could not resolve, a claim you could not check, or a question your reading
+kept circling without landing on. Each needs a reason it matters to *this* subject. Do not open
+a pursuit you have no way to make progress on.
+
+**3. Set your attention.** Name the areas you work in and how deep you are going on each:
+"deepening" (actively going after it), "maintaining" (keeping current, not digging), or
+"peripheral" (aware, not investing). At most {max_deepening} may be deepening. A specialist
+keeps two or three things deep and a dozen shallow, and choosing is the point.
+
+House style: plain ASCII punctuation, a regular hyphen and never an en dash or em dash, straight
+quotes, no emoji.
+
+Return JSON only, no prose outside it, no code fence:
+
+{{
+  "reviewed": [{{"question": "copied exactly", "verdict": "still_open|answered|abandon",
+                "resolution": "what answered it, or why you are abandoning it"}}],
+  "new_pursuits": [{{"question": "", "why_it_matters": ""}}],
+  "interests": [{{"area": "", "depth": "deepening|maintaining|peripheral", "why": ""}}]
+}}
+
+===== HOW YOU READ THIS SUBJECT =====
+{standpoint}
+===== END =====
+
+===== WHAT YOU ARE CURRENTLY CHASING =====
+{live}
+===== END =====
+
+===== WHAT YOU HAVE READ SINCE =====
+{material}
+===== END =====
+"""
+
+
+def build_practice_prompt(
+    *,
+    expert_name: str,
+    standpoint: str,
+    practice: ResearchPractice,
+    material: str,
+) -> str:
+    """Ask the expert to update its own agenda.
+
+    Deliberately does not ask about watches. Those are measured from the
+    evidence graph, and letting a model rank them would reintroduce exactly the
+    guessing that the measurement replaced - an expert would follow the sources
+    it finds appealing rather than the ones carrying its claims.
+    """
+    live = "\n".join(f"- {p.question}" for p in practice.live_pursuits) or "(nothing yet)"
+    return PRACTICE_PROMPT.format(
+        expert_name=expert_name,
+        standpoint=standpoint or "(no standpoint recorded yet)",
+        live=live,
+        material=material,
+        max_deepening=_MAX_DEEPENING,
+    )
+
+
+def apply_practice_update(practice: ResearchPractice, parsed: dict[str, Any], *, at: str) -> dict[str, int]:
+    """Fold the expert's own decisions into its practice. Returns what changed.
+
+    Resolutions are applied before new pursuits open, so a question the expert
+    answered and immediately re-asked in different words is deduplicated
+    against the closed one rather than reopening as new.
+    """
+    changed = {"answered": 0, "abandoned": 0, "opened": 0}
+
+    for raw in parsed.get("reviewed") or []:
+        if not isinstance(raw, dict):
+            continue
+        verdict = str(raw.get("verdict") or "").strip().lower()
+        resolution = " ".join(str(raw.get("resolution") or "").split())
+        question = str(raw.get("question") or "")
+        if verdict == "answered" and resolve_pursuit(practice, question, resolution=resolution, at=at):
+            changed["answered"] += 1
+        elif verdict == "abandon":
+            target = _normalized(question)
+            for pursuit in practice.pursuits:
+                if pursuit.is_live and _normalized(pursuit.question) == target:
+                    pursuit.status = PURSUIT_ABANDONED
+                    pursuit.resolution = resolution or "abandoned without a stated reason"
+                    pursuit.resolved_at = at
+                    changed["abandoned"] += 1
+                    break
+
+    for raw in parsed.get("new_pursuits") or []:
+        if not isinstance(raw, dict) or not str(raw.get("question") or "").strip():
+            continue
+        changed["opened"] += open_pursuits(
+            practice,
+            [str(raw["question"])],
+            origin="self",
+            at=at,
+            why=" ".join(str(raw.get("why_it_matters") or "").split()),
+        )
+
+    if interests := [
+        Interest(
+            area=" ".join(str(raw.get("area") or "").split()),
+            depth=str(raw.get("depth") or DEPTH_MAINTAINING).strip().lower(),
+            why=" ".join(str(raw.get("why") or "").split()),
+        )
+        for raw in (parsed.get("interests") or [])
+        if isinstance(raw, dict) and str(raw.get("area") or "").strip()
+    ]:
+        set_interests(practice, interests)
+
+    practice.updated_at = at
+    return changed
+
+
+def render_practice(practice: ResearchPractice) -> str:
+    """What this expert is doing to stay expert."""
+    lines = [f"# {practice.expert_name}: research practice", ""]
+
+    if not practice.is_practising:
+        lines += [
+            "This expert has no live questions, or nowhere it is following. It is not keeping up "
+            "with anything - it is waiting to be re-researched.",
+            "",
+        ]
+
+    if live := practice.live_pursuits:
+        lines += ["## What it is chasing", ""]
+        for pursuit in live:
+            origin = f" _(from {pursuit.origin})_" if pursuit.origin else ""
+            lines.append(f"- {pursuit.question}{origin}")
+        lines.append("")
+
+    if answered := [p for p in practice.pursuits if p.status == PURSUIT_ANSWERED]:
+        lines += ["## What it has settled", ""]
+        lines += [f"- {p.question}\n  - {p.resolution}" for p in answered[-5:]]
+        lines.append("")
+
+    if practice.watches:
+        lines += ["## What it follows", ""]
+        for watch in practice.watches:
+            quiet = f", quiet for {watch.quiet_rounds}" if watch.quiet_rounds else ""
+            lines.append(f"- {watch.origin} ({watch.positions_resting_on_it} position(s) rest on it{quiet})")
+        lines += ["", "_Earned by carrying claims, not by having been acquired._", ""]
+
+    if practice.interests:
+        lines += ["## Where its attention is", ""]
+        for interest in practice.interests:
+            lines.append(f"- **{interest.depth}**: {interest.area}")
+        lines.append("")
+
+    if reading := practice.next_reading():
+        lines += ["## What it would read next", ""]
+        lines += [f"- {item}" for item in reading]
+        lines.append("")
+
+    return "\n".join(lines)

--- a/src/deepr/experts/stage_contract.py
+++ b/src/deepr/experts/stage_contract.py
@@ -123,21 +123,21 @@ _STUDY_NEEDS_CORPUS = Requirement(
 )
 
 _BRIEF_NEEDS_STUDY = Requirement(
-    artifact="study.json",
+    artifact="noticed/current.json",
     holds=_has_grounded_findings,
     describe="the study produced no grounded findings, so a brief would rest on nothing checkable",
     fix="expert study",
 )
 
 _NEEDS_BRIEF = Requirement(
-    artifact="brief.json",
+    artifact="hold/current.json",
     holds=_has_positions,
     describe="the brief holds no positions, so the expert has not landed anywhere",
     fix="expert brief",
 )
 
 _NEEDS_PROFILE = Requirement(
-    artifact="profile_card.json",
+    artifact="self.json",
     holds=_has_standpoint,
     describe="no standpoint recorded, so the expert has no reading of its own",
     fix="expert profile",
@@ -154,21 +154,21 @@ STAGES: tuple[Stage, ...] = (
     Stage(
         name=STAGE_STUDY,
         requires=(_STUDY_NEEDS_CORPUS,),
-        produces="study.json",
+        produces="noticed/current.json",
         succeeds_when=_has_grounded_findings,
         success_means="at least one finding anchored in the retained text",
     ),
     Stage(
         name=STAGE_BRIEF,
         requires=(_BRIEF_NEEDS_STUDY,),
-        produces="brief.json",
+        produces="hold/current.json",
         succeeds_when=_has_positions,
         success_means="at least one position, each citing the findings it rests on",
     ),
     Stage(
         name=STAGE_PROFILE,
         requires=(_NEEDS_BRIEF,),
-        produces="profile_card.json",
+        produces="self.json",
         succeeds_when=_has_standpoint,
         success_means="a standpoint in the expert's own terms",
     ),
@@ -182,14 +182,14 @@ STAGES: tuple[Stage, ...] = (
     Stage(
         name=STAGE_PRACTICE,
         requires=(_NEEDS_BRIEF,),
-        produces="practice.json",
+        produces="attend/practice.json",
         succeeds_when=lambda p: bool((p.get("stats") or {}).get("live_pursuits")),
         success_means="at least one live pursuit to chase",
     ),
     Stage(
         name=STAGE_VIVA,
         requires=(_NEEDS_BRIEF,),
-        produces="viva.json",
+        produces="met/examination.json",
         succeeds_when=lambda v: bool(v.get("exchanges")),
         success_means="at least one question was put to the expert",
     ),

--- a/src/deepr/experts/stage_contract.py
+++ b/src/deepr/experts/stage_contract.py
@@ -1,0 +1,297 @@
+"""What each stage needs before it runs, and what counts as having worked.
+
+Written after asking Deepr's own harness-design expert what is wrong with
+Deepr's expert loop. Its answer:
+
+    Loose JSON handoffs create hidden coupling. Schema drift, partial writes,
+    stale files, incompatible versions and missing provenance can silently
+    corrupt later stages. [...] Producing every JSON file does not prove the
+    final result is correct.
+
+Both halves had already happened, twice, in a single afternoon. A synthesis
+call timed out; the brief was written holding zero positions with the failure
+recorded only as a limitation; the command exited 0 and printed the path as
+though it had worked. The profile stage then read that file, found it present
+and parseable, and produced a standpoint about *the pipeline failing* rather
+than about the subject.
+
+Each was fixed where it bit. This is the class fix, and the distinction it
+turns on:
+
+**Presence is not validity.** Every guard in the loop asked "does the file
+exist and parse". The empty brief passed both. What a stage actually needs is
+that its input carries the *content* the stage consumes - positions, findings,
+a standpoint - and that is a different question with a different answer.
+
+**A stage's own success is not its exit code.** A stage that produced a file is
+not a stage that produced a result. Terminal success has to be stated
+separately from "the process returned", because the failure mode is precisely a
+process that returns cleanly having produced nothing usable.
+
+This module is declarative on purpose. It owns no IO and calls no model: it
+says what each stage requires and what its output must contain, and the CLI
+enforces it. Keeping the rules in one readable table is what stops the next
+silent corruption from needing its own bespoke guard bolted on after it bites.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+STAGE_CONTRACT_SCHEMA_VERSION = "deepr-stage-contract-v1"
+
+STAGE_ACQUIRE = "acquire"
+STAGE_STUDY = "study"
+STAGE_BRIEF = "brief"
+STAGE_PROFILE = "profile"
+STAGE_GRAPH = "graph"
+STAGE_PRACTICE = "practice"
+STAGE_VIVA = "viva"
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """One thing a stage needs, and how to tell whether it is really there."""
+
+    artifact: str
+    """Path relative to the expert directory."""
+    holds: Callable[[dict[str, Any]], bool]
+    """Whether the parsed artifact carries what the stage consumes.
+
+    Deliberately not "does it parse". A brief with zero positions parses
+    perfectly and is useless to every stage downstream of it."""
+    describe: str
+    """What is missing, in words a person can act on."""
+    fix: str
+    """The command that would supply it."""
+
+
+@dataclass(frozen=True)
+class Stage:
+    """A step in the loop: what it needs, and what its own output must contain."""
+
+    name: str
+    requires: tuple[Requirement, ...] = ()
+    produces: str = ""
+    """The artifact this stage writes."""
+    succeeds_when: Callable[[dict[str, Any]], bool] | None = None
+    """Whether the output is a result rather than merely a file.
+
+    Separate from the process exit code, because the failure mode being
+    guarded against is a process that exits cleanly having produced nothing
+    usable."""
+    success_means: str = ""
+
+
+def _has_findings(study: dict[str, Any]) -> bool:
+    return int((study.get("totals") or {}).get("findings", 0) or 0) > 0
+
+
+def _has_grounded_findings(study: dict[str, Any]) -> bool:
+    """Grounded, not merely present.
+
+    A study whose findings anchor in nothing is a study that read the corpus
+    and cited none of it, and briefing from it produces positions resting on
+    text nobody can open.
+    """
+    return int((study.get("totals") or {}).get("grounded_findings", 0) or 0) > 0
+
+
+def _has_positions(brief: dict[str, Any]) -> bool:
+    return bool(brief.get("positions"))
+
+
+def _has_standpoint(profile: dict[str, Any]) -> bool:
+    return bool(str(profile.get("standpoint") or "").strip())
+
+
+def _graph_is_formed(graph: dict[str, Any]) -> bool:
+    return bool((graph.get("stats") or {}).get("is_formed"))
+
+
+def _has_corpus(index: dict[str, Any]) -> bool:
+    return int(index.get("active_count", 0) or 0) > 0
+
+
+_STUDY_NEEDS_CORPUS = Requirement(
+    artifact="corpus/index.jsonl",
+    holds=_has_corpus,
+    describe="no retained corpus, so there is nothing to read",
+    fix="expert source",
+)
+
+_BRIEF_NEEDS_STUDY = Requirement(
+    artifact="study.json",
+    holds=_has_grounded_findings,
+    describe="the study produced no grounded findings, so a brief would rest on nothing checkable",
+    fix="expert study",
+)
+
+_NEEDS_BRIEF = Requirement(
+    artifact="brief.json",
+    holds=_has_positions,
+    describe="the brief holds no positions, so the expert has not landed anywhere",
+    fix="expert brief",
+)
+
+_NEEDS_PROFILE = Requirement(
+    artifact="profile_card.json",
+    holds=_has_standpoint,
+    describe="no standpoint recorded, so the expert has no reading of its own",
+    fix="expert profile",
+)
+
+
+STAGES: tuple[Stage, ...] = (
+    Stage(
+        name=STAGE_ACQUIRE,
+        produces="corpus/index.jsonl",
+        succeeds_when=_has_corpus,
+        success_means="at least one source retained",
+    ),
+    Stage(
+        name=STAGE_STUDY,
+        requires=(_STUDY_NEEDS_CORPUS,),
+        produces="study.json",
+        succeeds_when=_has_grounded_findings,
+        success_means="at least one finding anchored in the retained text",
+    ),
+    Stage(
+        name=STAGE_BRIEF,
+        requires=(_BRIEF_NEEDS_STUDY,),
+        produces="brief.json",
+        succeeds_when=_has_positions,
+        success_means="at least one position, each citing the findings it rests on",
+    ),
+    Stage(
+        name=STAGE_PROFILE,
+        requires=(_NEEDS_BRIEF,),
+        produces="profile_card.json",
+        succeeds_when=_has_standpoint,
+        success_means="a standpoint in the expert's own terms",
+    ),
+    Stage(
+        name=STAGE_GRAPH,
+        requires=(_BRIEF_NEEDS_STUDY, _NEEDS_BRIEF),
+        produces="graph/evidence.json",
+        succeeds_when=_graph_is_formed,
+        success_means="at least one position reaching a passage through a finding",
+    ),
+    Stage(
+        name=STAGE_PRACTICE,
+        requires=(_NEEDS_BRIEF,),
+        produces="practice.json",
+        succeeds_when=lambda p: bool((p.get("stats") or {}).get("live_pursuits")),
+        success_means="at least one live pursuit to chase",
+    ),
+    Stage(
+        name=STAGE_VIVA,
+        requires=(_NEEDS_BRIEF,),
+        produces="viva.json",
+        succeeds_when=lambda v: bool(v.get("exchanges")),
+        success_means="at least one question was put to the expert",
+    ),
+)
+
+_BY_NAME = {stage.name: stage for stage in STAGES}
+
+
+def get_stage(name: str) -> Stage | None:
+    return _BY_NAME.get(name)
+
+
+@dataclass
+class Blocker:
+    """Why a stage cannot run, and what would unblock it."""
+
+    artifact: str
+    reason: str
+    fix: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"artifact": self.artifact, "reason": self.reason, "fix": self.fix}
+
+
+@dataclass
+class StageState:
+    """Where one stage stands for one expert."""
+
+    name: str
+    blockers: list[Blocker] = field(default_factory=list)
+    produced: bool = False
+    succeeded: bool = False
+    success_means: str = ""
+
+    @property
+    def can_run(self) -> bool:
+        return not self.blockers
+
+    @property
+    def status(self) -> str:
+        """blocked, ready, failed, or done.
+
+        ``failed`` is the one worth having: the artifact exists and does not
+        carry what it promised. Without it, a stage that produced an empty file
+        is indistinguishable from one that worked.
+        """
+        if self.blockers:
+            return "blocked"
+        if not self.produced:
+            return "ready"
+        return "done" if self.succeeded else "failed"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.name,
+            "status": self.status,
+            "success_means": self.success_means,
+            "blockers": [b.to_dict() for b in self.blockers],
+        }
+
+
+def evaluate_stage(stage: Stage, artifacts: dict[str, dict[str, Any] | None]) -> StageState:
+    """Decide whether this stage can run, and whether its output is a result.
+
+    ``artifacts`` maps a relative path to its parsed contents, or None when the
+    file is absent or unreadable. Both are treated the same on purpose: an
+    unparseable input is no more usable than a missing one, and quietly
+    treating a corrupt file as present is how the corruption travels.
+    """
+    state = StageState(name=stage.name, success_means=stage.success_means)
+
+    for requirement in stage.requires:
+        data = artifacts.get(requirement.artifact)
+        if data is None or not requirement.holds(data):
+            state.blockers.append(
+                Blocker(artifact=requirement.artifact, reason=requirement.describe, fix=requirement.fix)
+            )
+
+    output = artifacts.get(stage.produces) if stage.produces else None
+    state.produced = output is not None
+    if state.produced and stage.succeeds_when is not None:
+        state.succeeded = bool(stage.succeeds_when(output or {}))
+    return state
+
+
+def evaluate_all(artifacts: dict[str, dict[str, Any] | None]) -> list[StageState]:
+    """Where this expert stands across the whole loop."""
+    return [evaluate_stage(stage, artifacts) for stage in STAGES]
+
+
+def next_stage(states: list[StageState]) -> StageState | None:
+    """The one thing to do next.
+
+    A failed stage outranks a ready one: rerunning the stage that produced
+    nothing usable is more useful than building further on top of it, and
+    building on top is how a timed-out brief became a standpoint about the
+    pipeline failing.
+    """
+    for state in states:
+        if state.status == "failed":
+            return state
+    for state in states:
+        if state.status == "ready":
+            return state
+    return None

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -53,6 +53,70 @@ CheckpointCallback = Callable[[StudyResult], None]
 """Called after each lens, so work already paid for survives an interruption."""
 
 
+_CAPACITY_MARKERS = (
+    "quota",
+    "usage balance exhausted",
+    "payment required",
+    "402",
+    "insufficient credit",
+    "rate limit",
+    "429",
+)
+"""Text that means the backend cannot be asked, rather than would not answer.
+
+A string check because the completion callable is injected and the study pass
+deliberately owns no provider - it cannot import a backend exception type
+without acquiring the dependency the injection exists to avoid. The typed check
+below is the real one; this catches the same condition arriving as a wrapped or
+stringified error from a plan CLI's stderr.
+"""
+
+
+def _note_capacity_stop(
+    result: StudyResult,
+    exc: BaseException,
+    *,
+    lens: StudyLens,
+    index: int,
+    total: int,
+    on_progress: ProgressCallback | None,
+) -> None:
+    """Record that the pass stopped short, and why, where a machine can see it.
+
+    The outcomes already gathered are real - they were read before capacity ran
+    out. What must not happen is the result reading as though the remaining
+    lenses were asked and found nothing.
+    """
+    remaining = total - index + 1
+    result.limitations.append(
+        f"Capacity ran out during lens {index}/{total} ({lens.key}): {str(exc)[:160]}. "
+        f"{remaining} lens(es) were never read, so this study is incomplete rather than thin. "
+        "Resume once capacity returns; completed lenses will be reused."
+    )
+    if on_progress:
+        on_progress(f"lens {index}/{total} {lens.key}: capacity exhausted, stopping")
+
+
+def _is_capacity_failure(exc: BaseException) -> bool:
+    """Whether this failure means the backend is unavailable, not unhelpful.
+
+    The distinction decides whether a pass may continue. A model that answered
+    in prose produced a genuinely partial result and the pass should carry on;
+    a backend that has run out of quota will fail identically for every
+    remaining call, and continuing only buys a thinner artifact that looks
+    complete.
+    """
+    try:
+        from deepr.backends.plan_quota.errors import PlanQuotaError
+
+        if isinstance(exc, PlanQuotaError):
+            return True
+    except ImportError:
+        pass
+    text = str(exc).lower()
+    return any(marker in text for marker in _CAPACITY_MARKERS)
+
+
 def corpus_fingerprint(material: list[tuple[CorpusEntry, str]]) -> str:
     """A stable id for exactly the sources a pass read.
 
@@ -383,13 +447,19 @@ async def _run_lenses(
             continue
 
         started = time.monotonic()
-        outcome = await _run_lens_over_chunks(
-            lens,
-            chunks,
-            material,
-            completion,
-            on_progress=_lens_progress(on_progress, lens.key, index, len(lenses)),
-        )
+        try:
+            outcome = await _run_lens_over_chunks(
+                lens,
+                chunks,
+                material,
+                completion,
+                on_progress=_lens_progress(on_progress, lens.key, index, len(lenses)),
+            )
+        except Exception as exc:
+            if not _is_capacity_failure(exc):
+                raise
+            _note_capacity_stop(result, exc, lens=lens, index=index, total=len(lenses), on_progress=on_progress)
+            break
         outcome.elapsed_s = time.monotonic() - started
         outcome.corpus_fingerprint = fingerprint
         result.outcomes.append(outcome)
@@ -549,6 +619,21 @@ async def _run_lens_over_chunks(
         try:
             raw = await completion(prompt)
         except Exception as exc:
+            if _is_capacity_failure(exc):
+                # Stop the whole pass. Catching this as a per-chunk failure kept
+                # calling a dead backend for every remaining chunk and lens and
+                # then wrote a complete-looking study.json whose findings were
+                # thin, with the reason recorded only as prose in `limitations`
+                # that no downstream code reads. `brief` then read it as truth.
+                #
+                # Measured: a study "completed" with 44 findings from two of
+                # eight lenses after the backend exhausted mid-run, and nothing
+                # in the artifact said so in a way a machine could act on.
+                #
+                # "The corpus had nothing to say" and "I could not ask" are
+                # different results, and the difference has to survive into the
+                # artifact rather than being flattened into a failure count.
+                raise
             failures.append(f"chunk {index}: {str(exc)[:160]}")
             continue
 

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -376,6 +376,7 @@ async def run_study(
     max_corpus_chars: int = _DEFAULT_MAX_CORPUS_CHARS,
     chunk_chars: int = _DEFAULT_CHUNK_CHARS,
     capacity_source: str = "",
+    model: str = "",
     on_progress: ProgressCallback | None = None,
     checkpoint: CheckpointCallback | None = None,
     resume_from: list[LensOutcome] | None = None,
@@ -406,6 +407,7 @@ async def run_study(
         corpus_origins=stats.distinct_origins,
         corpus_chars=sum(len(text) for _, text in material),
         capacity_source=capacity_source,
+        model=model,
         started_at=_utc_now_iso(),
     )
 

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -52,6 +52,18 @@ CheckpointCallback = Callable[[StudyResult], None]
 """Called after each lens, so work already paid for survives an interruption."""
 
 
+def corpus_fingerprint(material: list[tuple[CorpusEntry, str]]) -> str:
+    """A stable id for exactly the sources a pass read.
+
+    Sorted shas, hashed. Adding a source changes it, so a lens outcome from
+    before that source arrived can be recognized as stale rather than reused.
+    """
+    import hashlib
+
+    shas = sorted(entry.sha256 for entry, _ in material)
+    return hashlib.sha256("|".join(shas).encode("utf-8")).hexdigest()[:16]
+
+
 def _lens_progress(
     on_progress: ProgressCallback | None,
     lens_key: str,
@@ -313,9 +325,17 @@ async def _run_lenses(
     would make one bad interruption permanent, which is the opposite of what
     resuming is for.
     """
-    done = {o.lens: o for o in (resume_from or []) if o.status in {"ok", "partial"}}
+    fingerprint = corpus_fingerprint(material)
+    reusable = [o for o in (resume_from or []) if o.status in {"ok", "partial"}]
+    stale = [o for o in reusable if o.corpus_fingerprint and o.corpus_fingerprint != fingerprint]
+    done = {o.lens: o for o in reusable if not o.corpus_fingerprint or o.corpus_fingerprint == fingerprint}
     if done:
         result.limitations.append(f"Resumed: {len(done)} lens(es) reused from an earlier run and not re-read.")
+    if stale:
+        result.limitations.append(
+            f"{len(stale)} lens(es) from an earlier run were re-read because the corpus changed since. "
+            "Reusing them would have carried findings that never saw the new sources."
+        )
 
     for index, lens in enumerate(lenses, 1):
         if (earlier := done.get(lens.key)) is not None:
@@ -333,6 +353,7 @@ async def _run_lenses(
             on_progress=_lens_progress(on_progress, lens.key, index, len(lenses)),
         )
         outcome.elapsed_s = time.monotonic() - started
+        outcome.corpus_fingerprint = fingerprint
         result.outcomes.append(outcome)
         if on_progress:
             grounded = sum(1 for f in outcome.findings if f.is_grounded)

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -48,6 +48,9 @@ StudyCompletion = Callable[[str], Awaitable[str]]
 ProgressCallback = Callable[[str], None]
 """Called before each model call, so a long run is not a silent one."""
 
+CheckpointCallback = Callable[[StudyResult], None]
+"""Called after each lens, so work already paid for survives an interruption."""
+
 
 def _lens_progress(
     on_progress: ProgressCallback | None,
@@ -293,6 +296,56 @@ def build_findings(
     return findings
 
 
+async def _run_lenses(
+    result: StudyResult,
+    *,
+    lenses: Any,
+    chunks: list[list[tuple[CorpusEntry, str]]],
+    material: list[tuple[CorpusEntry, str]],
+    completion: StudyCompletion,
+    resume_from: list[LensOutcome] | None,
+    on_progress: ProgressCallback | None,
+    checkpoint: CheckpointCallback | None,
+) -> None:
+    """Run each lens, reusing any an earlier pass already completed.
+
+    Only ``ok`` and ``partial`` outcomes are reused. Reusing a parse failure
+    would make one bad interruption permanent, which is the opposite of what
+    resuming is for.
+    """
+    done = {o.lens: o for o in (resume_from or []) if o.status in {"ok", "partial"}}
+    if done:
+        result.limitations.append(f"Resumed: {len(done)} lens(es) reused from an earlier run and not re-read.")
+
+    for index, lens in enumerate(lenses, 1):
+        if (earlier := done.get(lens.key)) is not None:
+            result.outcomes.append(earlier)
+            if on_progress:
+                on_progress(f"lens {index}/{len(lenses)} {lens.key}: reused from an earlier run")
+            continue
+
+        started = time.monotonic()
+        outcome = await _run_lens_over_chunks(
+            lens,
+            chunks,
+            material,
+            completion,
+            on_progress=_lens_progress(on_progress, lens.key, index, len(lenses)),
+        )
+        outcome.elapsed_s = time.monotonic() - started
+        result.outcomes.append(outcome)
+        if on_progress:
+            grounded = sum(1 for f in outcome.findings if f.is_grounded)
+            on_progress(
+                f"lens {index}/{len(lenses)} {lens.key}: {len(outcome.findings)} finding(s), "
+                f"{grounded} anchored, {outcome.elapsed_s:.0f}s"
+            )
+        if checkpoint is not None:
+            # Per lens rather than at the end, so an interruption costs one
+            # lens instead of the whole pass.
+            checkpoint(result)
+
+
 async def run_study(
     *,
     expert_name: str,
@@ -303,11 +356,19 @@ async def run_study(
     chunk_chars: int = _DEFAULT_CHUNK_CHARS,
     capacity_source: str = "",
     on_progress: ProgressCallback | None = None,
+    checkpoint: CheckpointCallback | None = None,
+    resume_from: list[LensOutcome] | None = None,
 ) -> StudyResult:
     """Run every requested lens over the retained corpus.
 
     A lens that fails is recorded and the pass continues: one bad parse should
     not discard the work of five other lenses.
+
+    Recovery is structural, not conversational. ``checkpoint`` is called after
+    each lens with the result so far, and ``resume_from`` carries completed
+    lenses back in, so a pass killed at lens seven of eight resumes rather than
+    restarting. Without it every interruption costs the whole run again, which
+    on a real corpus is tens of model calls that already succeeded.
 
     ``on_progress`` is called before each model call. A chunked study over a
     real corpus is tens of calls and runs for many minutes; without it the run
@@ -357,23 +418,16 @@ async def run_study(
             "Each lens saw one chunk at a time, so cross-chunk connections may be missed."
         )
 
-    for index, lens in enumerate(lenses, 1):
-        lens_started = time.monotonic()
-        outcome = await _run_lens_over_chunks(
-            lens,
-            chunks,
-            material,
-            completion,
-            on_progress=_lens_progress(on_progress, lens.key, index, len(lenses)),
-        )
-        outcome.elapsed_s = time.monotonic() - lens_started
-        result.outcomes.append(outcome)
-        if on_progress:
-            grounded = sum(1 for f in outcome.findings if f.is_grounded)
-            on_progress(
-                f"lens {index}/{len(lenses)} {lens.key}: {len(outcome.findings)} finding(s), "
-                f"{grounded} anchored, {outcome.elapsed_s:.0f}s"
-            )
+    await _run_lenses(
+        result,
+        lenses=lenses,
+        chunks=chunks,
+        material=material,
+        completion=completion,
+        resume_from=resume_from,
+        on_progress=on_progress,
+        checkpoint=checkpoint,
+    )
 
     result.elapsed_s = time.monotonic() - started
     ungrounded = sum(f.ungrounded_anchor_count for f in result.findings)

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -327,14 +327,20 @@ async def _run_lenses(
     """
     fingerprint = corpus_fingerprint(material)
     reusable = [o for o in (resume_from or []) if o.status in {"ok", "partial"}]
-    stale = [o for o in reusable if o.corpus_fingerprint and o.corpus_fingerprint != fingerprint]
-    done = {o.lens: o for o in reusable if not o.corpus_fingerprint or o.corpus_fingerprint == fingerprint}
+    # Fail closed. An outcome that cannot say which corpus it read is stale by
+    # definition: trusting it was the fail-open branch of this guard, and it
+    # defeated exactly what the fingerprint exists for. Measured on a live
+    # expert - every outcome on disk carried an empty fingerprint, so every
+    # lens was reused unconditionally however much the corpus had grown.
+    stale = [o for o in reusable if o.corpus_fingerprint != fingerprint]
+    done = {o.lens: o for o in reusable if o.corpus_fingerprint == fingerprint}
     if done:
         result.limitations.append(f"Resumed: {len(done)} lens(es) reused from an earlier run and not re-read.")
     if stale:
         result.limitations.append(
-            f"{len(stale)} lens(es) from an earlier run were re-read because the corpus changed since. "
-            "Reusing them would have carried findings that never saw the new sources."
+            f"{len(stale)} lens(es) from an earlier run were re-read because they could not be "
+            "shown to have read this corpus. Reusing them would have carried findings that never "
+            "saw the new sources."
         )
 
     for index, lens in enumerate(lenses, 1):

--- a/src/deepr/experts/study.py
+++ b/src/deepr/experts/study.py
@@ -37,6 +37,7 @@ from typing import Any
 
 from deepr.experts.corpus_independence import measure_independence
 from deepr.experts.corpus_store import CorpusEntry, CorpusStore
+from deepr.experts.record_identity import finding_thread_id
 from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 from deepr.experts.study_coverage import build_coverage_report
 from deepr.experts.study_lenses import StudyLens, resolve_lenses
@@ -272,18 +273,43 @@ def _ground_anchors(anchors: list[str], haystacks: list[tuple[str, str]]) -> tup
     return grounded, ungrounded, shas
 
 
+def _absorb(findings: list[StudyFinding], fresh: list[StudyFinding]) -> None:
+    """Add each fresh finding, merging it into an existing one of the same id.
+
+    Content-derived ids make a re-sighting recognisable, which positional ids
+    could not: the same finding surfacing in two chunks used to become two
+    findings with two ordinals. Now it is one finding corroborated by two
+    passages, and its ``corpus_shas`` accumulate.
+
+    That accumulation is the point. A finding anchored in one source and a
+    finding anchored in two are different evidential claims, and the second is
+    what a lens genuinely comparing sources produces. Appending a duplicate
+    would also put two records with one id in the same list, which every
+    downstream lookup keyed by ``finding_id`` would then resolve arbitrarily.
+    """
+    by_id = {f.finding_id: f for f in findings}
+    for candidate in fresh:
+        existing = by_id.get(candidate.finding_id)
+        if existing is None:
+            findings.append(candidate)
+            by_id[candidate.finding_id] = candidate
+            continue
+        for sha in candidate.corpus_shas:
+            if sha not in existing.corpus_shas:
+                existing.corpus_shas.append(sha)
+        for anchor in candidate.anchors:
+            if anchor not in existing.anchors:
+                existing.anchors.append(anchor)
+        existing.grounded_anchor_count += candidate.grounded_anchor_count
+        existing.ungrounded_anchor_count += candidate.ungrounded_anchor_count
+
+
 def build_findings(
     lens: StudyLens,
     parsed: dict[str, Any],
     material: list[tuple[CorpusEntry, str]],
-    *,
-    start_index: int = 1,
 ) -> list[StudyFinding]:
-    """Turn one lens's parsed output into anchored findings.
-
-    ``start_index`` continues numbering across chunks so ids stay unique for
-    the whole lens rather than restarting at every call.
-    """
+    """Turn one lens's parsed output into anchored findings."""
     haystacks = [(entry.sha256, _normalize(text)) for entry, text in material]
     findings: list[StudyFinding] = []
     for item in _lens_items(lens, parsed):
@@ -291,13 +317,19 @@ def build_findings(
             continue
         anchors = _read_anchors(item)
         grounded, ungrounded, shas = _ground_anchors(anchors, haystacks)
+        title = _title_for(item, lens, shas)
         findings.append(
             StudyFinding(
                 lens=lens.key,
                 axis=lens.axis,
                 kind=lens.output_field,
-                finding_id=f"{lens.key}-{start_index + len(findings)}",
-                title=_title_for(item, lens, shas),
+                # Derived from content, not from position in this list. The
+                # positional form renumbered whenever a partial resume re-ran
+                # one lens, so a brief citing `failure-30` silently repointed at
+                # a different finding - and the citation still validated against
+                # the id set, which is worse than failing.
+                finding_id=finding_thread_id(lens=lens.key, title=title, anchors=anchors),
+                title=title,
                 payload={k: v for k, v in item.items() if k != "anchors"},
                 anchors=anchors,
                 grounded_anchor_count=grounded,
@@ -536,7 +568,7 @@ async def _run_lens_over_chunks(
         # a finding could be credited to a document the lens never read. Shared
         # boilerplate makes that the common case, not an edge case, and the
         # coverage report then reports the true source as untouched.
-        findings.extend(build_findings(lens, parsed, chunk, start_index=len(findings) + 1))
+        _absorb(findings, build_findings(lens, parsed, chunk))
 
     if findings or not failures:
         detail = f"{len(failures)} of {len(chunks)} chunk(s) failed: " + "; ".join(failures[:2]) if failures else ""

--- a/src/deepr/experts/study_contracts.py
+++ b/src/deepr/experts/study_contracts.py
@@ -93,6 +93,12 @@ class LensOutcome:
     cost_usd: float = 0.0
     chunks_total: int = 0
     chunks_failed: int = 0
+    corpus_fingerprint: str = ""
+    """Which sources this lens read, so a stale reuse is detectable.
+
+    An expert accumulates sources. Resuming on lens name alone reuses findings
+    that never saw the new material, which is an expert that silently stops
+    learning from what it retained."""
     """How much of the corpus this lens actually got through.
 
     Carried as counts rather than only in a prose ``detail`` string, so a run
@@ -110,6 +116,7 @@ class LensOutcome:
             "cost_usd": self.cost_usd,
             "chunks_total": self.chunks_total,
             "chunks_failed": self.chunks_failed,
+            "corpus_fingerprint": self.corpus_fingerprint,
             "finding_count": len(self.findings),
             "grounded_count": sum(1 for f in self.findings if f.is_grounded),
             "findings": [f.to_dict() for f in self.findings],
@@ -126,6 +133,7 @@ class LensOutcome:
             elapsed_s=float(data.get("elapsed_s", 0.0) or 0.0),
             chunks_total=int(data.get("chunks_total", 0) or 0),
             chunks_failed=int(data.get("chunks_failed", 0) or 0),
+            corpus_fingerprint=data.get("corpus_fingerprint", ""),
         )
 
 

--- a/src/deepr/experts/study_contracts.py
+++ b/src/deepr/experts/study_contracts.py
@@ -22,6 +22,13 @@ from typing import Any
 STUDY_SCHEMA_VERSION = "deepr-expert-study-v1"
 
 
+def _provenance(capacity_source: str, model: str) -> Any:
+    """Stamp which model did the reading, imported lazily to avoid a cycle."""
+    from deepr.experts.model_provenance import record
+
+    return record(capacity_source, model)
+
+
 @dataclass
 class StudyFinding:
     """One item produced by one lens.
@@ -148,6 +155,12 @@ class StudyResult:
     corpus_origins: int = 0
     corpus_chars: int = 0
     capacity_source: str = ""
+    model: str = ""
+    """The model behind ``capacity_source``, where one was chosen explicitly.
+
+    ``capacity_source`` names the dispatch (``plan:grok``); this names what ran
+    inside it. Empty when a plan CLI picked for itself, which is honest rather
+    than absent - Deepr sees the process, not the routing decision inside it."""
     started_at: str = ""
     elapsed_s: float = 0.0
     cost_usd: float = 0.0
@@ -217,6 +230,8 @@ class StudyResult:
                 "chars": self.corpus_chars,
             },
             "capacity_source": self.capacity_source,
+            "model": self.model,
+            "model_provenance": _provenance(self.capacity_source, self.model).to_dict(),
             "started_at": self.started_at,
             "elapsed_s": round(self.elapsed_s, 2),
             "cost_usd": self.cost_usd,
@@ -255,6 +270,7 @@ class StudyResult:
             corpus_origins=int(corpus.get("distinct_origins", 0) or 0),
             corpus_chars=int(corpus.get("chars", 0) or 0),
             capacity_source=data.get("capacity_source", ""),
+            model=data.get("model", ""),
             started_at=data.get("started_at", ""),
             elapsed_s=float(data.get("elapsed_s", 0.0) or 0.0),
             limitations=list(data.get("limitations") or []),

--- a/src/deepr/experts/viva.py
+++ b/src/deepr/experts/viva.py
@@ -89,6 +89,16 @@ class VivaResult:
     schema_version: str = VIVA_SCHEMA_VERSION
     examiners: list[str] = field(default_factory=list)
     exchanges: list[VivaExchange] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    """Why calls failed, deduplicated.
+
+    An examiner is allowed to fail without ending the examination, but a
+    swallowed failure is worse than a loud one: a capacity refusal - plan
+    quota exhausted, spend guard tripped - affects every call, and without
+    this the run looks like a panel that had nothing to ask. Measured: the
+    paid-overage guard refused mid-session and produced an empty viva with no
+    stated reason."""
+
     positions_that_moved: list[str] = field(default_factory=list)
     """Positions the expert revised or withdrew under questioning.
 
@@ -113,9 +123,32 @@ class VivaResult:
         """What to go and read next, in the examiners' words."""
         return [e.would_resolve_it for e in self.gaps if e.would_resolve_it]
 
+    def as_gaps(self) -> list[dict[str, Any]]:
+        """The reading queue, shaped so acquisition can act on it.
+
+        Without this the queue is a list nobody reads. Consult already routes
+        its gaps into acquisition; a viva produces the same kind of thing on
+        purpose rather than by accident, so it should land in the same place.
+
+        Priority 4 rather than the default 3: these gaps were found by someone
+        deliberately looking for them and were named specifically enough to
+        search for, which is a better lead than a gap inferred from a consult
+        that happened to go badly.
+        """
+        return [
+            {
+                "topic": f"Viva gap ({self.expert_name}): {exchange.would_resolve_it}",
+                "questions": [exchange.question],
+                "priority": 4,
+            }
+            for exchange in self.gaps
+        ]
+
     def summary(self) -> str:
         """What happened, without a grade."""
         if not self.exchanges:
+            if self.failures:
+                return f"No questions were put to this expert. Every call failed: {self.failures[0]}"
             return "No questions were put to this expert."
         parts = [
             f"{len(self.exchanges)} question(s) from {len(self.examiners)} examiner(s)",
@@ -137,7 +170,9 @@ class VivaResult:
             "summary": self.summary(),
             "exchanges": [e.to_dict() for e in self.exchanges],
             "reading_queue": self.reading_queue(),
+            "gaps": self.as_gaps(),
             "positions_that_moved": self.positions_that_moved,
+            "failures": self.failures,
         }
 
 
@@ -152,17 +187,32 @@ Ask the questions your own subject has trained you to ask. Someone who has spent
 different problem notices what an insider has stopped seeing, and that is the reason you are in
 the room rather than another specialist.
 
-Good viva questions, in rough order of usefulness:
+Ask {count} questions, and they must not all be the same kind. Two kinds are needed, because
+they find different things.
+
+**Reasoning questions** ask how a position was reached:
 
 - Why this and not the obvious alternative? What made you land here?
 - Which of your positions is weakest, and what is holding it up?
 - You lean on this repeatedly and never mention that. Why not?
 - What would someone who disagreed with you say, and what is wrong with it?
 - You say this is settled. Settled by whom, and what would unsettle it?
-- What does this rest on that you have not checked?
 
-Ask {count} questions. For each, say what you are probing, because a question with no target is
-small talk.
+**Coverage questions** ask about the subject itself, aimed at what this brief does not
+mention. Name a specific thing - a technique, a case, a body of work, a competing account, a
+population, a time period - that someone working seriously in this area would expect to come
+up, and that is absent here. Then ask about it directly.
+
+At least a third of your questions must be coverage questions, and this is not optional. A
+panel that only asks reasoning questions gets a clean examination every time, because the
+expert can always answer a question about its own thinking by introspecting. "I did not run
+that check" is an honest answer and it is not a gap. Only a coverage question can find the
+thing the expert has not read.
+
+Your own subject is what makes you good at this: you know what serious work in *your* area
+takes account of, and you can ask whether the equivalent exists here.
+
+For each question, say what you are probing, because a question with no target is small talk.
 
 House style: plain ASCII punctuation, a regular hyphen and never an en dash or em dash, straight
 quotes, no emoji.
@@ -208,20 +258,50 @@ Return JSON only, no prose outside it, no code fence:
 
 JUDGE_PROMPT = """You put these questions to an expert on "{subject}". Judge the answers.
 
-You do not know this subject and you are not marking correctness. You are judging whether each
-answer engaged with what you were probing, or slid past it.
+You do not know this subject and you are not marking correctness.
 
-For each, choose one verdict:
+Before choosing a verdict, answer one mechanical question about each reply: **does it contain
+the substance the question asked for, or does it explain the absence of that substance?** Those
+are different, and how gracefully the second is written does not turn it into the first.
 
-- "answered": engaged with the probe and gave something substantive.
-- "partial": engaged, but left the sharp part of the question untouched.
-- "cannot_answer": the expert does not hold this, AND it is the kind of thing that could be
-  learned from material that exists. Say what would resolve it.
+If the question named a body of work, a technique, a case or a population, and the reply says it
+was not consulted, was not covered, or is not held - then the substance is absent. That is
+"cannot_answer", and the honesty of the admission is not a reason to mark it otherwise. Honesty
+determines whether you can trust the answer, not whether the answer is there.
+
+Worked example, because this is the mistake to avoid. Question: "this is the alarm-fatigue
+problem that aviation human-factors research has studied for decades - did you consult it?"
+Reply: "No, that literature was not consulted; here is what I used instead and why it is
+weaker." That is a model answer and it is **cannot_answer**, resolved by the aviation
+human-factors literature on alarm fatigue. Marking it "answered" because it was candid and
+well-reasoned throws away the single most useful thing this examination produces.
+
+Then choose one verdict:
+
+- "answered": the substance is present. The expert holds this and said it. A candid concession
+  about its own reasoning counts here - that is the substance a reasoning question asks for.
+- "partial": some of the substance is present and the sharp part of the question is untouched.
+- "cannot_answer": the expert does not hold this, AND it could be learned from material that
+  exists outside the expert. In "would_resolve_it", name that material - a literature, a
+  dataset, a study, a body of practice - specifically enough that someone could go and find it.
+
+  This verdict is only for things the expert must go and *read*. If what is missing is the
+  expert's own account of its own reasoning, that is not this verdict, because no amount of
+  reading fills it: the expert already has everything it needs and simply did not say. Mark
+  those "partial". A reading queue entry beginning "the expert explaining..." or "an account
+  from the expert of..." is the mistake this paragraph exists to prevent.
 - "genuinely_open": nobody knows this. Not a deficiency. Do not use this as a polite way of
   saying the expert was unprepared - reserve it for questions the field itself has not settled.
 
 The distinction between the last two is the most useful thing you will produce. One is a reading
 list; the other is the edge of what is known.
+
+Do not mark cannot_answer for something the expert genuinely addressed just because the answer
+was short. Brevity is not absence.
+
+A run where every verdict is "answered" is much more likely to be a judging failure than a
+perfect expert. If that is what you are about to return, re-read the coverage questions and
+check each one against the substance test above.
 
 House style: plain ASCII punctuation, a regular hyphen and never an en dash or em dash, straight
 quotes, no emoji.

--- a/src/deepr/experts/viva.py
+++ b/src/deepr/experts/viva.py
@@ -1,0 +1,339 @@
+"""Examination by questioning, where nobody has the answer key.
+
+The problem this solves: how do you find out whether an expert understands its
+subject when there is no ground truth, and no one available who already knows?
+
+A doctoral viva answers it. The examiners frequently do not know the answer to
+what they are asking. That is not a defect of the format, it is the format.
+They probe - why this and not the alternative, which part is weakest, you lean
+on X and never mention Y, what would change your mind - and what the candidate
+demonstrates is whether the thinking is load-bearing or whether it stops one
+question past the summary. Both sides come out knowing more than they went in
+with, which a graded exam cannot do.
+
+Three things follow that make this the right shape here.
+
+**The examiners can be other experts, and should be.** They do not need the
+subject; they need a frame to probe from. An expert on provenance asks
+different questions than one on evaluation, and neither is asking as a subject
+expert. This is the same property that makes cross-domain consulting work:
+a frame built elsewhere notices what an insider stops seeing.
+
+**An unanswerable question is the output, not the failure.** Some are genuine
+open questions in the field and the right answer is that nobody knows. Others
+are answerable from material that exists and the expert simply has not read
+it. The second kind is a reading list somebody else wrote for free, and
+telling them apart is most of the value here.
+
+**There is no score.** A viva produces a judgement, a list of things to go and
+address, and occasionally the discovery that a position does not survive
+contact with a good question. Compressing that into a letter would throw away
+the part worth having, and this module deliberately does not.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+VIVA_SCHEMA_VERSION = "deepr-viva-v1"
+
+_MAX_QUESTIONS = 8
+_MAX_FIELD_CHARS = 1200
+
+VERDICT_ANSWERED = "answered"
+VERDICT_PARTIAL = "partial"
+VERDICT_CANNOT = "cannot_answer"
+VERDICT_OPEN = "genuinely_open"
+
+_VERDICTS = (VERDICT_ANSWERED, VERDICT_PARTIAL, VERDICT_CANNOT, VERDICT_OPEN)
+
+
+@dataclass
+class VivaExchange:
+    """One question, the answer, and what the examiner made of it."""
+
+    question: str
+    asked_by: str
+    probes: str = ""
+    """What the examiner was testing. Without this a question is small talk."""
+    answer: str = ""
+    verdict: str = VERDICT_ANSWERED
+    examiner_note: str = ""
+    """Why the examiner judged it that way, so the judgement can be argued with."""
+    would_resolve_it: str = ""
+    """What material would answer this. The reading-list entry, when there is one."""
+
+    @property
+    def is_gap(self) -> bool:
+        """Answerable from material that exists, and the expert has not read it."""
+        return self.verdict == VERDICT_CANNOT and bool(self.would_resolve_it.strip())
+
+    @property
+    def is_frontier(self) -> bool:
+        """Nobody knows. Worth recording, and not a deficiency."""
+        return self.verdict == VERDICT_OPEN
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["is_gap"] = self.is_gap
+        data["is_frontier"] = self.is_frontier
+        return data
+
+
+@dataclass
+class VivaResult:
+    """What an examination found. Not a score."""
+
+    expert_name: str
+    schema_version: str = VIVA_SCHEMA_VERSION
+    examiners: list[str] = field(default_factory=list)
+    exchanges: list[VivaExchange] = field(default_factory=list)
+    positions_that_moved: list[str] = field(default_factory=list)
+    """Positions the expert revised or withdrew under questioning.
+
+    The most valuable outcome available and the one a graded exam cannot
+    produce: a view that did not survive a good question, found before someone
+    relied on it."""
+
+    @property
+    def gaps(self) -> list[VivaExchange]:
+        """Answerable questions the expert could not answer. The reading queue."""
+        return [e for e in self.exchanges if e.is_gap]
+
+    @property
+    def frontier(self) -> list[VivaExchange]:
+        return [e for e in self.exchanges if e.is_frontier]
+
+    @property
+    def handled(self) -> list[VivaExchange]:
+        return [e for e in self.exchanges if e.verdict in {VERDICT_ANSWERED, VERDICT_PARTIAL}]
+
+    def reading_queue(self) -> list[str]:
+        """What to go and read next, in the examiners' words."""
+        return [e.would_resolve_it for e in self.gaps if e.would_resolve_it]
+
+    def summary(self) -> str:
+        """What happened, without a grade."""
+        if not self.exchanges:
+            return "No questions were put to this expert."
+        parts = [
+            f"{len(self.exchanges)} question(s) from {len(self.examiners)} examiner(s)",
+            f"{len(self.handled)} handled",
+        ]
+        if self.gaps:
+            parts.append(f"{len(self.gaps)} answerable and unanswered")
+        if self.frontier:
+            parts.append(f"{len(self.frontier)} genuinely open")
+        if self.positions_that_moved:
+            parts.append(f"{len(self.positions_that_moved)} position(s) moved")
+        return "; ".join(parts) + "."
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "expert": self.expert_name,
+            "examiners": self.examiners,
+            "summary": self.summary(),
+            "exchanges": [e.to_dict() for e in self.exchanges],
+            "reading_queue": self.reading_queue(),
+            "positions_that_moved": self.positions_that_moved,
+        }
+
+
+EXAMINER_PROMPT = """You are examining an expert on "{subject}". You are not an expert on it, and
+you are not expected to be. You come from {examiner_frame}.
+
+This is a viva, not a quiz. You do not have the answers and you are not marking a paper. Your job
+is to find out whether the thinking underneath these positions is load-bearing, or whether it
+stops one question past the summary. Both of you should come out of this knowing more.
+
+Ask the questions your own subject has trained you to ask. Someone who has spent years on a
+different problem notices what an insider has stopped seeing, and that is the reason you are in
+the room rather than another specialist.
+
+Good viva questions, in rough order of usefulness:
+
+- Why this and not the obvious alternative? What made you land here?
+- Which of your positions is weakest, and what is holding it up?
+- You lean on this repeatedly and never mention that. Why not?
+- What would someone who disagreed with you say, and what is wrong with it?
+- You say this is settled. Settled by whom, and what would unsettle it?
+- What does this rest on that you have not checked?
+
+Ask {count} questions. For each, say what you are probing, because a question with no target is
+small talk.
+
+House style: plain ASCII punctuation, a regular hyphen and never an en dash or em dash, straight
+quotes, no emoji.
+
+Return JSON only, no prose outside it, no code fence:
+
+{{"questions": [{{"question": "", "probes": "what this is testing"}}]}}
+
+===== WHAT THE EXPERT HOLDS =====
+{brief}
+===== END =====
+"""
+
+
+CANDIDATE_PROMPT = """You are being examined on "{subject}". Answer as yourself.
+
+These questions come from someone outside your subject. Some will miss. Some will land on
+something you have not thought about, and that is what the examination is for.
+
+Answer from what you actually hold. Where your material does not reach, say so plainly - that is
+a real answer and a useful one, not a failure. Do not manufacture an answer to look prepared.
+
+If a question changes your mind, say that too. A position that does not survive a good question
+was worth losing, and losing it here is much better than losing it after someone relied on it.
+
+House style: plain ASCII punctuation, a regular hyphen and never an en dash or em dash, straight
+quotes, no emoji.
+
+Return JSON only, no prose outside it, no code fence:
+
+{{"answers": [{{"question": "the question, copied", "answer": "",
+  "changed_my_mind": "what moved, or empty if nothing did"}}]}}
+
+===== WHAT YOU HOLD =====
+{brief}
+===== END =====
+
+===== QUESTIONS =====
+{questions}
+===== END =====
+"""
+
+
+JUDGE_PROMPT = """You put these questions to an expert on "{subject}". Judge the answers.
+
+You do not know this subject and you are not marking correctness. You are judging whether each
+answer engaged with what you were probing, or slid past it.
+
+For each, choose one verdict:
+
+- "answered": engaged with the probe and gave something substantive.
+- "partial": engaged, but left the sharp part of the question untouched.
+- "cannot_answer": the expert does not hold this, AND it is the kind of thing that could be
+  learned from material that exists. Say what would resolve it.
+- "genuinely_open": nobody knows this. Not a deficiency. Do not use this as a polite way of
+  saying the expert was unprepared - reserve it for questions the field itself has not settled.
+
+The distinction between the last two is the most useful thing you will produce. One is a reading
+list; the other is the edge of what is known.
+
+House style: plain ASCII punctuation, a regular hyphen and never an en dash or em dash, straight
+quotes, no emoji.
+
+Return JSON only, no prose outside it, no code fence:
+
+{{"judgements": [{{"question": "copied", "verdict": "answered|partial|cannot_answer|genuinely_open",
+  "note": "why", "would_resolve_it": "what material would answer this, when cannot_answer"}}]}}
+
+===== QUESTIONS AND ANSWERS =====
+{transcript}
+===== END =====
+"""
+
+
+def _text(value: Any) -> str:
+    return " ".join(str(value or "").split())[:_MAX_FIELD_CHARS]
+
+
+def build_examiner_prompt(*, subject: str, examiner_frame: str, brief: str, count: int = 4) -> str:
+    """Ask an outsider to probe, from wherever they actually stand."""
+    return EXAMINER_PROMPT.format(
+        subject=subject, examiner_frame=examiner_frame, brief=brief, count=count
+    )
+
+
+def build_candidate_prompt(*, subject: str, brief: str, questions: list[str]) -> str:
+    numbered = "\n".join(f"{i}. {q}" for i, q in enumerate(questions, 1))
+    return CANDIDATE_PROMPT.format(subject=subject, brief=brief, questions=numbered)
+
+
+def build_judge_prompt(*, subject: str, exchanges: list[VivaExchange]) -> str:
+    transcript = "\n\n".join(
+        f"Q: {e.question}\n(probing: {e.probes})\nA: {e.answer}" for e in exchanges
+    )
+    return JUDGE_PROMPT.format(subject=subject, transcript=transcript)
+
+
+def parse_questions(parsed: dict[str, Any], *, asked_by: str) -> list[VivaExchange]:
+    """Questions that name what they probe. The rest are small talk."""
+    out: list[VivaExchange] = []
+    for raw in (parsed.get("questions") or [])[:_MAX_QUESTIONS]:
+        if not isinstance(raw, dict):
+            continue
+        question = _text(raw.get("question"))
+        if not question:
+            continue
+        out.append(VivaExchange(question=question, asked_by=asked_by, probes=_text(raw.get("probes"))))
+    return out
+
+
+def attach_answers(exchanges: list[VivaExchange], parsed: dict[str, Any]) -> list[str]:
+    """Fill in answers, returning anything the expert said changed its mind."""
+    by_question = {e.question.lower(): e for e in exchanges}
+    moved: list[str] = []
+    for raw in parsed.get("answers") or []:
+        if not isinstance(raw, dict):
+            continue
+        exchange = by_question.get(_text(raw.get("question")).lower())
+        if exchange is None:
+            continue
+        exchange.answer = _text(raw.get("answer"))
+        if changed := _text(raw.get("changed_my_mind")):
+            moved.append(changed)
+    return moved
+
+
+def attach_judgements(exchanges: list[VivaExchange], parsed: dict[str, Any]) -> None:
+    """Record each verdict, defaulting to partial rather than to a pass."""
+    by_question = {e.question.lower(): e for e in exchanges}
+    for raw in parsed.get("judgements") or []:
+        if not isinstance(raw, dict):
+            continue
+        exchange = by_question.get(_text(raw.get("question")).lower())
+        if exchange is None:
+            continue
+        verdict = _text(raw.get("verdict")).lower()
+        exchange.verdict = verdict if verdict in _VERDICTS else VERDICT_PARTIAL
+        exchange.examiner_note = _text(raw.get("note"))
+        exchange.would_resolve_it = _text(raw.get("would_resolve_it"))
+
+
+def render_viva(result: VivaResult) -> str:
+    """The transcript, with what to do about it at the end."""
+    lines = [f"# {result.expert_name}: examination", "", result.summary(), ""]
+
+    if result.positions_that_moved:
+        lines += ["## What moved under questioning", ""]
+        lines += [f"- {item}" for item in result.positions_that_moved]
+        lines += [
+            "",
+            "_A position that does not survive a good question was worth losing, and losing it "
+            "here is better than losing it after someone relied on it._",
+            "",
+        ]
+
+    for exchange in result.exchanges:
+        lines.append(f"**{exchange.question}**  \n_asked by {exchange.asked_by}, probing {exchange.probes}_")
+        lines.append("")
+        lines.append(exchange.answer or "_no answer recorded_")
+        if exchange.examiner_note:
+            lines.append(f"\n> {exchange.verdict}: {exchange.examiner_note}")
+        lines.append("")
+
+    if result.gaps:
+        lines += ["## What to go and read", ""]
+        lines += [f"- {item}" for item in result.reading_queue()]
+        lines += ["", "_Answerable, and unanswered. Somebody else wrote this list for free._", ""]
+
+    if result.frontier:
+        lines += ["## Where the field itself has not settled", ""]
+        lines += [f"- {e.question}" for e in result.frontier]
+        lines += ["", "_Not deficiencies. Worth knowing, and worth saying out loud when asked._", ""]
+
+    return "\n".join(lines)

--- a/src/deepr/experts/viva.py
+++ b/src/deepr/experts/viva.py
@@ -243,9 +243,7 @@ def _text(value: Any) -> str:
 
 def build_examiner_prompt(*, subject: str, examiner_frame: str, brief: str, count: int = 4) -> str:
     """Ask an outsider to probe, from wherever they actually stand."""
-    return EXAMINER_PROMPT.format(
-        subject=subject, examiner_frame=examiner_frame, brief=brief, count=count
-    )
+    return EXAMINER_PROMPT.format(subject=subject, examiner_frame=examiner_frame, brief=brief, count=count)
 
 
 def build_candidate_prompt(*, subject: str, brief: str, questions: list[str]) -> str:
@@ -254,9 +252,7 @@ def build_candidate_prompt(*, subject: str, brief: str, questions: list[str]) ->
 
 
 def build_judge_prompt(*, subject: str, exchanges: list[VivaExchange]) -> str:
-    transcript = "\n\n".join(
-        f"Q: {e.question}\n(probing: {e.probes})\nA: {e.answer}" for e in exchanges
-    )
+    transcript = "\n\n".join(f"Q: {e.question}\n(probing: {e.probes})\nA: {e.answer}" for e in exchanges)
     return JUDGE_PROMPT.format(subject=subject, transcript=transcript)
 
 

--- a/src/deepr/experts/viva_session.py
+++ b/src/deepr/experts/viva_session.py
@@ -1,0 +1,160 @@
+"""Running an examination: examiners in, transcript and reading list out.
+
+Three passes, in the order a viva actually happens.
+
+1. Each examiner reads the candidate's brief and puts questions to it, from
+   its own standpoint rather than as a second specialist.
+2. The candidate answers all of them in one pass. One pass rather than one per
+   question is deliberate: a viva is a conversation the candidate can see the
+   whole of, and answering question six differently because question two
+   already covered it is a real part of what is being examined.
+3. Each examiner judges the answers to its own questions, and only its own.
+   An examiner marking another's questions has no idea what was being probed.
+
+Every model call goes through the same ``StudyCompletion`` the study pass uses,
+so this inherits its capacity story unchanged: local or prepaid plan, $0 at the
+margin, and no route to a metered API from here.
+
+The failure posture is that an examiner is allowed to fail. A viva with three
+examiners where one returns nothing is a viva with two examiners, which is
+worth having; taking the whole examination down because one panel member
+timed out would be the wrong trade.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from deepr.experts.viva import (
+    VivaExchange,
+    VivaResult,
+    attach_answers,
+    attach_judgements,
+    build_candidate_prompt,
+    build_examiner_prompt,
+    build_judge_prompt,
+    parse_questions,
+)
+
+VivaCompletion = Callable[[str], str]
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class Examiner:
+    """Who is asking, and from where.
+
+    ``frame`` is the whole point. "You come from evaluation design" produces
+    different questions than "you come from provenance", and an examiner given
+    no frame reverts to asking the subject's own obvious questions - which the
+    candidate has already answered in its brief.
+    """
+
+    name: str
+    frame: str
+    questions: int = 4
+
+
+def _parse_json(text: str) -> dict[str, Any]:
+    """Recover the object from a model that would not stay out of prose.
+
+    Returns an empty dict rather than raising. A malformed examiner reply
+    should cost its questions, not the examination.
+    """
+    if not text:
+        return {}
+    candidate = text.strip()
+    if fenced := _FENCE_RE.search(candidate):
+        candidate = fenced.group(1).strip()
+    else:
+        start, end = candidate.find("{"), candidate.rfind("}")
+        if start != -1 and end > start:
+            candidate = candidate[start : end + 1]
+    try:
+        parsed = json.loads(candidate)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _ask(completion: VivaCompletion, prompt: str) -> dict[str, Any]:
+    """One call, where a failure is an empty result rather than an exception."""
+    try:
+        return _parse_json(completion(prompt))
+    except Exception:
+        return {}
+
+
+def run_viva(
+    *,
+    expert_name: str,
+    subject: str,
+    brief: str,
+    examiners: list[Examiner],
+    completion: VivaCompletion,
+) -> VivaResult:
+    """Examine one expert, and return what was found rather than a score."""
+    result = VivaResult(expert_name=expert_name, examiners=[e.name for e in examiners])
+
+    questions: list[VivaExchange] = []
+    for examiner in examiners:
+        parsed = _ask(
+            completion,
+            build_examiner_prompt(
+                subject=subject, examiner_frame=examiner.frame, brief=brief, count=examiner.questions
+            ),
+        )
+        questions.extend(parse_questions(parsed, asked_by=examiner.name))
+
+    if not questions:
+        return result
+    result.exchanges = questions
+
+    answers = _ask(
+        completion,
+        build_candidate_prompt(subject=subject, brief=brief, questions=[q.question for q in questions]),
+    )
+    result.positions_that_moved = attach_answers(questions, answers)
+
+    # Each examiner judges only what it asked. It is the only one that knows
+    # what the question was probing, so it is the only one able to say whether
+    # the answer went there or slid past it.
+    for examiner in examiners:
+        mine = [q for q in questions if q.asked_by == examiner.name]
+        if not mine:
+            continue
+        attach_judgements(mine, _ask(completion, build_judge_prompt(subject=subject, exchanges=mine)))
+
+    return result
+
+
+DEFAULT_PANEL: tuple[Examiner, ...] = (
+    Examiner(
+        name="method",
+        frame="research method and evidence - you care how a claim was arrived at, "
+        "what would have shown it false, and whether the person checked",
+    ),
+    Examiner(
+        name="practice",
+        frame="applied practice - you care what someone would actually do differently "
+        "on Monday, and you are impatient with claims that change nothing",
+    ),
+    Examiner(
+        name="dissent",
+        frame="the strongest opposing case - you care what a serious, informed "
+        "opponent would say, and whether it has been engaged with or waved past",
+    ),
+)
+"""A panel that works with no other experts on hand.
+
+Three standpoints rather than three specialists, because the whole argument for
+examination-by-outsider is that the standpoint is what generates the question.
+Real experts from other subjects are better - they bring a frame that was built
+against real material rather than described in a sentence - and this exists so
+a viva is available before there are three other experts worth borrowing.
+"""

--- a/src/deepr/experts/viva_session.py
+++ b/src/deepr/experts/viva_session.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -40,7 +40,15 @@ from deepr.experts.viva import (
     parse_questions,
 )
 
-VivaCompletion = Callable[[str], str]
+VivaCompletion = Callable[[str], Awaitable[str]]
+"""prompt -> raw model text. The same shape as ``StudyCompletion``, so a viva
+inherits the study pass's capacity resolution unchanged.
+
+Async even though a viva has nothing to overlap - the three passes have a real
+dependency chain and run in order. It is async so the whole examination shares
+one event loop and one client: a per-call ``asyncio.run`` would build and tear
+down a loop for each question, which is how the portrait path met "Event loop
+is closed" on Windows."""
 
 _FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
 
@@ -82,15 +90,23 @@ def _parse_json(text: str) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _ask(completion: VivaCompletion, prompt: str) -> dict[str, Any]:
-    """One call, where a failure is an empty result rather than an exception."""
+async def _ask(completion: VivaCompletion, prompt: str, failures: list[str]) -> dict[str, Any]:
+    """One call, where a failure is an empty result rather than an exception.
+
+    The reason is recorded rather than discarded. One examiner timing out is
+    noise; every call refusing because plan quota ran out is the whole story,
+    and a caller that only sees an empty result cannot tell those apart.
+    """
     try:
-        return _parse_json(completion(prompt))
-    except Exception:
+        return _parse_json(await completion(prompt))
+    except Exception as exc:
+        reason = f"{type(exc).__name__}: {exc}"
+        if reason not in failures:
+            failures.append(reason)
         return {}
 
 
-def run_viva(
+async def run_viva(
     *,
     expert_name: str,
     subject: str,
@@ -103,11 +119,12 @@ def run_viva(
 
     questions: list[VivaExchange] = []
     for examiner in examiners:
-        parsed = _ask(
+        parsed = await _ask(
             completion,
             build_examiner_prompt(
                 subject=subject, examiner_frame=examiner.frame, brief=brief, count=examiner.questions
             ),
+            result.failures,
         )
         questions.extend(parse_questions(parsed, asked_by=examiner.name))
 
@@ -115,9 +132,10 @@ def run_viva(
         return result
     result.exchanges = questions
 
-    answers = _ask(
+    answers = await _ask(
         completion,
         build_candidate_prompt(subject=subject, brief=brief, questions=[q.question for q in questions]),
+        result.failures,
     )
     result.positions_that_moved = attach_answers(questions, answers)
 
@@ -128,7 +146,8 @@ def run_viva(
         mine = [q for q in questions if q.asked_by == examiner.name]
         if not mine:
             continue
-        attach_judgements(mine, _ask(completion, build_judge_prompt(subject=subject, exchanges=mine)))
+        judgements = await _ask(completion, build_judge_prompt(subject=subject, exchanges=mine), result.failures)
+        attach_judgements(mine, judgements)
 
     return result
 

--- a/src/deepr/security/key_quarantine.py
+++ b/src/deepr/security/key_quarantine.py
@@ -35,6 +35,7 @@ than adjusted.
 from __future__ import annotations
 
 import os
+from collections.abc import MutableMapping
 
 QUARANTINE_PREFIX = "DEEPR_QUARANTINED_"
 
@@ -70,15 +71,19 @@ where any client library that happens to be importable could pick one up.
 _TRUTHY = {"1", "true", "yes", "on"}
 
 
-def _opted_out(env: dict[str, str]) -> bool:
+def _opted_out(env: MutableMapping[str, str]) -> bool:
     return str(env.get(OPT_OUT_VAR, "")).strip().lower() in _TRUTHY
 
 
-def quarantine_metered_keys(env: dict[str, str] | None = None) -> list[str]:
+def quarantine_metered_keys(env: MutableMapping[str, str] | None = None) -> list[str]:
     """Move metered keys out of the environment. Returns the names moved.
 
     Mutates ``os.environ`` by default, which is the point: it must affect the
     running process, not a copy of its environment.
+
+    Typed as a MutableMapping rather than a dict because ``os.environ`` is an
+    ``os._Environ``, which is not a dict; annotating it as one type-checks
+    locally and fails under the strict islands in CI.
 
     Preserved rather than deleted. An operator who has approved a spend should
     be able to recover the value they set, and silently destroying a
@@ -99,13 +104,13 @@ def quarantine_metered_keys(env: dict[str, str] | None = None) -> list[str]:
     return moved
 
 
-def quarantined_names(env: dict[str, str] | None = None) -> list[str]:
+def quarantined_names(env: MutableMapping[str, str] | None = None) -> list[str]:
     """Which keys this process moved aside, for reporting."""
     target = os.environ if env is None else env
     return sorted(name.removeprefix(QUARANTINE_PREFIX) for name in target if name.startswith(QUARANTINE_PREFIX))
 
 
-def live_metered_names(env: dict[str, str] | None = None) -> list[str]:
+def live_metered_names(env: MutableMapping[str, str] | None = None) -> list[str]:
     """Metered keys still readable in this process.
 
     Should be empty after startup. Anything here is a key a provider SDK could

--- a/src/deepr/security/key_quarantine.py
+++ b/src/deepr/security/key_quarantine.py
@@ -1,0 +1,118 @@
+"""Drop metered API keys out of Deepr's own process at startup.
+
+Deepr already strips these keys from every plan-quota child process, by name,
+before launching it. That protects the subprocess. It does not protect the
+parent: an API key set in the *operating system* environment is visible to
+Deepr itself for the whole run, and any code path that constructs a metered
+client can read it.
+
+The gap is easy to miss because removing a key from `.env` looks like removing
+it. Measured on this machine: after renaming every key in `.env`, three were
+still live in the process - `OPENAI_API_KEY`, `XAI_API_KEY` and
+`ANTHROPIC_API_KEY` - because they are set at the Windows user level and `.env`
+was never their only source. Anyone auditing their own setup by editing
+`.env` would conclude they had disarmed something they had not.
+
+So this quarantines them at the process boundary instead. Called once at CLI
+startup, before any command runs: every known metered key name is moved out of
+``os.environ`` and preserved under a ``DEEPR_QUARANTINED_`` prefix, so nothing
+is destroyed and an operator who genuinely wants to spend can still recover it
+deliberately.
+
+**Why moving beats trusting the guards.** The existing protections - the $0
+ceiling, the child-env stripping, the auth-mode detection - are all checks that
+have to be *reached*. This removes the material instead. A check can be
+bypassed by a new code path that nobody remembered to route through it; an
+environment variable that is not set cannot be read by any code path at all.
+That is the difference between a policy and a property.
+
+It is deliberately reversible and deliberately loud. ``DEEPR_ALLOW_METERED_KEYS``
+opts out for anyone whose workflow genuinely needs a metered client in-process,
+because a safety measure with no escape hatch gets disabled wholesale rather
+than adjusted.
+"""
+
+from __future__ import annotations
+
+import os
+
+QUARANTINE_PREFIX = "DEEPR_QUARANTINED_"
+
+OPT_OUT_VAR = "DEEPR_ALLOW_METERED_KEYS"
+"""Set truthy to leave metered keys in place for this process."""
+
+METERED_KEY_NAMES: tuple[str, ...] = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "XAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_FOUNDRY_API_KEY",
+    "AZURE_API_KEY",
+    "ANTIGRAVITY_API_KEY",
+    "CODEX_API_KEY",
+    "KIRO_API_KEY",
+    "MISTRAL_API_KEY",
+    "GROQ_API_KEY",
+    "COHERE_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "TOGETHER_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+"""Every variable a provider SDK reads to bill someone.
+
+Wider than the set the plan-quota adapters strip, because those only need to
+cover the providers behind the plan CLIs. This runs in Deepr's own process,
+where any client library that happens to be importable could pick one up.
+"""
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _opted_out(env: dict[str, str]) -> bool:
+    return str(env.get(OPT_OUT_VAR, "")).strip().lower() in _TRUTHY
+
+
+def quarantine_metered_keys(env: dict[str, str] | None = None) -> list[str]:
+    """Move metered keys out of the environment. Returns the names moved.
+
+    Mutates ``os.environ`` by default, which is the point: it must affect the
+    running process, not a copy of its environment.
+
+    Preserved rather than deleted. An operator who has approved a spend should
+    be able to recover the value they set, and silently destroying a
+    credential someone put there on purpose would be its own kind of surprise.
+    """
+    target = os.environ if env is None else env
+    if _opted_out(target):
+        return []
+
+    moved: list[str] = []
+    for name in METERED_KEY_NAMES:
+        value = target.get(name)
+        if not value or not value.strip():
+            continue
+        target[QUARANTINE_PREFIX + name] = value
+        del target[name]
+        moved.append(name)
+    return moved
+
+
+def quarantined_names(env: dict[str, str] | None = None) -> list[str]:
+    """Which keys this process moved aside, for reporting."""
+    target = os.environ if env is None else env
+    return sorted(
+        name.removeprefix(QUARANTINE_PREFIX) for name in target if name.startswith(QUARANTINE_PREFIX)
+    )
+
+
+def live_metered_names(env: dict[str, str] | None = None) -> list[str]:
+    """Metered keys still readable in this process.
+
+    Should be empty after startup. Anything here is a key a provider SDK could
+    pick up, and the honest answer to "can this bill me" is no only when this
+    list is empty or the operator opted out on purpose.
+    """
+    target = os.environ if env is None else env
+    return sorted(name for name in METERED_KEY_NAMES if str(target.get(name, "")).strip())

--- a/src/deepr/security/key_quarantine.py
+++ b/src/deepr/security/key_quarantine.py
@@ -102,9 +102,7 @@ def quarantine_metered_keys(env: dict[str, str] | None = None) -> list[str]:
 def quarantined_names(env: dict[str, str] | None = None) -> list[str]:
     """Which keys this process moved aside, for reporting."""
     target = os.environ if env is None else env
-    return sorted(
-        name.removeprefix(QUARANTINE_PREFIX) for name in target if name.startswith(QUARANTINE_PREFIX)
-    )
+    return sorted(name.removeprefix(QUARANTINE_PREFIX) for name in target if name.startswith(QUARANTINE_PREFIX))
 
 
 def live_metered_names(env: dict[str, str] | None = None) -> list[str]:

--- a/src/deepr/web/frontend/package-lock.json
+++ b/src/deepr/web/frontend/package-lock.json
@@ -6145,9 +6145,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/tests/expert_time_helpers.py
+++ b/tests/expert_time_helpers.py
@@ -1,0 +1,53 @@
+"""Knowledge-cutoff dates expressed as an age, not as a calendar date.
+
+Freshness is computed as ``datetime.now(UTC) - knowledge_cutoff_date``, checked
+against thresholds that are fractions of the domain's velocity. A test that
+hardcodes ``datetime(2026, 6, 26)`` therefore does not pin a freshness band -
+it pins a date whose band changes as real time passes, and the test silently
+becomes a different test every day.
+
+That is not hypothetical. Sixteen tests across eleven files were written when
+that date read as `fresh`, and they passed for weeks. At 45 days of real
+elapsed time the same date crossed into `aging`, the self model began emitting
+a `self_model_review` proposal, and four tests that index into
+``proposals[0]`` started asserting against a different proposal than the one
+they were written for. Nothing in the suite had changed.
+
+Ages are expressed as fractions of the fresh/aging thresholds rather than as
+day counts, so they hold for any domain velocity rather than only for the
+default one.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+_FRESH_FRACTION = 0.25
+"""Comfortably inside `fresh`, which begins at 0.5 x velocity.
+
+Half the threshold rather than just under it: a value near the boundary is the
+same time bomb with a shorter fuse."""
+
+_STALE_MULTIPLE = 4.0
+"""Well past `critical`, which begins at 1.5 x velocity."""
+
+_MIN_VELOCITY_DAYS = 14
+"""The shortest velocity any domain uses, so one age is safe for all of them."""
+
+
+def recent_cutoff() -> datetime:
+    """A cutoff that reads as `fresh` today and every day after.
+
+    Use where the test is about something other than staleness and simply
+    needs an expert that is not overdue for a refresh.
+    """
+    return datetime.now(UTC) - timedelta(days=_MIN_VELOCITY_DAYS * _FRESH_FRACTION)
+
+
+def stale_cutoff() -> datetime:
+    """A cutoff that reads as `critical` today and every day after.
+
+    Use where the test is specifically exercising the overdue path, so that
+    intent is stated rather than encoded in a date that happens to be old.
+    """
+    return datetime.now(UTC) - timedelta(days=365 * _STALE_MULTIPLE)

--- a/tests/unit/test_backends/test_plan_quota_adapters.py
+++ b/tests/unit/test_backends/test_plan_quota_adapters.py
@@ -147,9 +147,32 @@ class TestRegistry:
             if adapter.execution_block_reason:
                 continue
             argv = " ".join(adapter.argv_builder("prompt.txt", None))
-            assert "--disallowed-tools" in argv, f"{backend_id} runs with native tools live"
-            for tool in ("bash", "edit", "write", "read"):
-                assert tool in argv, f"{backend_id} does not strip {tool}"
+            if "--disallowed-tools" in argv:
+                for tool in ("bash", "edit", "write", "read"):
+                    assert tool in argv, f"{backend_id} does not strip {tool}"
+                continue
+            # No tool-allowlist flag on this CLI, so the sandbox is the
+            # confinement. It satisfies the same invariant by a different
+            # route: the tools exist and cannot write or reach the network.
+            assert "--sandbox" in argv, f"{backend_id} runs with native tools live"
+
+    def test_codex_sandbox_is_read_only_and_offline(self):
+        argv = " ".join(get_adapter("codex").argv_builder("prompt.txt", None))
+        assert "--sandbox read-only" in argv
+        assert "network_access=false" in argv
+        assert 'approval_policy="never"' in argv
+
+    def test_antigravity_cannot_edit_or_run_a_terminal(self):
+        """agy has no tool allowlist, so both available levers are pulled.
+
+        Removing its execution block without these left the invariant
+        unsatisfied rather than satisfied another way: a retrieved prompt
+        reached live file and shell tools.
+        """
+        argv = " ".join(get_adapter("antigravity").argv_builder("prompt.txt", None))
+        assert "--sandbox" in argv
+        assert "--mode plan" in argv
+        assert "--dangerously-skip-permissions" not in argv
 
     def test_grok_strips_its_tools_and_web_access(self):
         """Pins the confinement that replaced grok's execution block."""

--- a/tests/unit/test_backends/test_plan_quota_attempt_accounting.py
+++ b/tests/unit/test_backends/test_plan_quota_attempt_accounting.py
@@ -96,7 +96,9 @@ def test_quota_durability_failure_preserves_paired_cost_partial_status(
     ("backend_id", "auth_mode"),
     [
         ("opencode", AuthMode.UNKNOWN),
-        ("codex", AuthMode.PLAN),
+        # kiro rather than codex: codex is confined at dispatch now instead of
+        # execution-blocked, so it no longer exercises the disabled-adapter arm.
+        ("kiro", AuthMode.PLAN),
         ("claude", AuthMode.METERED),
     ],
 )

--- a/tests/unit/test_backends/test_plan_quota_cli_runner.py
+++ b/tests/unit/test_backends/test_plan_quota_cli_runner.py
@@ -1470,7 +1470,7 @@ class TestRunCli:
             lambda exe: "C:/bin/codex.cmd" if exe == "codex" else None,
         )
 
-        with pytest.raises(RuntimeError, match="batch command shims"):
+        with pytest.raises(RuntimeError, match="Windows batch command shim"):
             _clean_argv(["codex", "exec"])
 
     def test_windows_claude_shim_resolves_confined_native_package_binary(self, monkeypatch, tmp_path):

--- a/tests/unit/test_backends/test_plan_quota_fleet.py
+++ b/tests/unit/test_backends/test_plan_quota_fleet.py
@@ -90,8 +90,11 @@ class TestFleetStatus:
     def test_routability_classes(self, tmp_path):
         rows = build_fleet_status(which=_which(), env={}, quota_ledger_path=tmp_path / "q.jsonl")
         assert _row(rows, "claude")["routable"] == "auto"
-        assert _row(rows, "antigravity")["routable"] == "blocked"
-        assert _row(rows, "codex")["routable"] == "blocked"
+        # Confined at dispatch rather than blocked, so usable when asked for by
+        # name. Only claude auto-routes: the rest stay explicit-only because
+        # their terms or their quota accounting are not provable in advance.
+        assert _row(rows, "antigravity")["routable"] == "explicit"
+        assert _row(rows, "codex")["routable"] == "explicit"
         assert _row(rows, "opencode")["routable"] == "blocked"
         assert _row(rows, "kiro")["routable"] == "blocked"
         assert _row(rows, "copilot")["routable"] == "metered"

--- a/tests/unit/test_backends/test_plan_quota_safety.py
+++ b/tests/unit/test_backends/test_plan_quota_safety.py
@@ -73,14 +73,19 @@ class TestDetectAuthMode:
         assert detect_auth_mode(get_adapter("opencode"), {"OPENAI_API_KEY": "sk-x"}) == AuthMode.UNKNOWN
 
     def test_other_adapters_remain_blocked_by_their_own_gates(self):
-        """This narrows to `claude`: the rest are blocked for unrelated reasons."""
+        """Every other adapter is either blocked or confined at dispatch.
+
+        grok, antigravity and codex are confined rather than blocked, which is
+        strictly better: the invariant holds and the backend stays usable.
+        test_plan_quota_adapters pins the confinement itself.
+        """
+        confined = {"grok", "antigravity", "codex"}
         for backend_id in ("codex", "grok", "kiro", "opencode", "antigravity"):
             adapter = get_adapter(backend_id)
             assert adapter is not None
-            if backend_id == "grok":
-                # Confined at dispatch rather than blocked; the argv strips the
-                # native tools. test_plan_quota_adapters pins that directly.
-                assert "--disallowed-tools" in " ".join(adapter.argv_builder("p.txt", None))
+            if backend_id in confined:
+                argv = " ".join(adapter.argv_builder("p.txt", None))
+                assert "--disallowed-tools" in argv or "--sandbox" in argv, backend_id
                 continue
             assert adapter.execution_block_reason, f"{backend_id} lost its execution block"
 
@@ -139,10 +144,15 @@ class TestSafetyGate:
         assert "native read tools" in d.reason
         assert "explicit read allowlist" in d.reason
 
-    def test_codex_native_tools_are_blocked(self):
+    def test_codex_is_safe_once_its_sandbox_confines_the_tools(self):
+        """Codex was gated on native tools; it now runs read-only and offline.
+
+        The gate existed to stop an untrusted prompt reaching live file and
+        shell tools. An OS sandbox satisfies that as well as a tool allowlist
+        does, so the refusal was pinning the mechanism rather than the property.
+        """
         d = evaluate_plan_quota_safety(get_adapter("codex"), env={})
-        assert not d.safe
-        assert "native read and shell tools" in d.reason
+        assert d.safe, d.reason
 
     def test_opencode_unknown_stored_auth_is_blocked(self):
         d = evaluate_plan_quota_safety(get_adapter("opencode"), env={})

--- a/tests/unit/test_backends/test_quota_headroom.py
+++ b/tests/unit/test_backends/test_quota_headroom.py
@@ -1,0 +1,86 @@
+"""Reading how much plan is left, without spending any of it.
+
+Deepr's own availability check dispatches a real request per backend, which
+spends quota to discover whether there is quota. That is the wrong trade when
+the answer is "almost none", and it is the reason this reads metadata instead.
+"""
+
+from deepr.backends.quota_headroom import (
+    PlanHeadroom,
+    exhausted,
+    order_by_headroom,
+    parse_snapshot,
+)
+
+_NOW = 1_000_000.0
+
+_SNAPSHOT = {
+    "providers": [
+        {
+            "provider": "claude",
+            "ok": True,
+            "plan": "max",
+            "windows": [
+                {"label": "5h", "used_percent": 95.0, "resets_at": _NOW + 900},
+                {"label": "weekly", "used_percent": 52.0, "resets_at": _NOW + 400000},
+            ],
+        },
+        {"provider": "codex", "ok": True, "windows": [{"label": "weekly", "used_percent": 4.0, "resets_at": _NOW}]},
+        {"provider": "grok", "ok": True, "windows": [{"label": "weekly", "used_percent": 88.0, "resets_at": _NOW}]},
+        {"provider": "dead", "ok": False, "windows": []},
+    ]
+}
+
+
+class TestParsing:
+    def test_the_tightest_window_is_the_one_that_binds(self):
+        """A five-hour cap at 95% matters more than a weekly one at 52%."""
+        plans = parse_snapshot(_SNAPSHOT, now=_NOW)
+        assert plans["claude"].used_percent == 95.0
+        assert plans["claude"].window_label == "5h"
+
+    def test_headroom_is_the_inverse_of_usage(self):
+        plans = parse_snapshot(_SNAPSHOT, now=_NOW)
+        assert plans["codex"].headroom == 0.96
+        assert plans["claude"].headroom < 0.1
+
+    def test_reset_time_is_relative_and_never_negative(self):
+        plans = parse_snapshot(_SNAPSHOT, now=_NOW)
+        assert plans["claude"].resets_in_s == 900
+        assert plans["codex"].resets_in_s == 0.0
+
+    def test_a_provider_reporting_not_ok_is_exhausted(self):
+        assert parse_snapshot(_SNAPSHOT, now=_NOW)["dead"].is_exhausted
+
+    def test_a_malformed_window_does_not_take_the_snapshot_down(self):
+        payload = {"providers": [{"provider": "x", "windows": [{"used_percent": "lots"}]}]}
+        assert parse_snapshot(payload, now=_NOW)["x"].used_percent == 0.0
+
+
+class TestOrdering:
+    def test_most_headroom_goes_first(self):
+        plans = parse_snapshot(_SNAPSHOT, now=_NOW)
+        assert order_by_headroom(["claude", "grok", "codex"], plans) == ["codex", "grok", "claude"]
+
+    def test_an_unreported_plan_sorts_in_the_middle(self):
+        """Neither preferred nor starved: absence is not evidence either way."""
+        plans = parse_snapshot(_SNAPSHOT, now=_NOW)
+        assert order_by_headroom(["claude", "unknown", "codex"], plans) == ["codex", "unknown", "claude"]
+
+    def test_no_snapshot_leaves_the_given_order_alone(self):
+        assert order_by_headroom(["a", "b"], {}) == ["a", "b"]
+
+
+class TestExhaustion:
+    def test_a_plan_at_its_cap_is_named(self):
+        plans = {"claude": PlanHeadroom(provider="claude", used_percent=98.0, window_label="5h")}
+        assert exhausted(["claude", "codex"], plans) == ["claude"]
+
+    def test_a_plan_with_room_is_not(self):
+        plans = parse_snapshot(_SNAPSHOT, now=_NOW)
+        assert exhausted(["codex", "grok"], plans) == []
+
+    def test_describe_says_which_window_and_when_it_resets(self):
+        plans = parse_snapshot(_SNAPSHOT, now=_NOW)
+        text = plans["claude"].describe()
+        assert "5h" in text and "95%" in text and "15m" in text

--- a/tests/unit/test_backends/test_waterfall.py
+++ b/tests/unit/test_backends/test_waterfall.py
@@ -177,11 +177,22 @@ class TestExplicitPlanQuota:
         choice = choose_plan_quota_backend("claude", env={"ANTHROPIC_API_KEY": "sk-x"})
         assert choice.plan_backend_id == "claude"
 
-    def test_native_tool_backend_is_refused(self):
+    def test_native_tool_backend_is_accepted_once_confined(self):
+        """codex was refused for its native tools; it now runs sandboxed.
+
+        The refusal protected against an untrusted prompt reaching live file
+        and shell tools. Once the argv runs read-only and offline with
+        escalation off, the property holds and the refusal was pinning the
+        mechanism. test_plan_quota_adapters pins the sandbox itself.
+        """
         choice = choose_plan_quota_backend("codex", env={})
+        assert choice.plan_backend_id == "codex", choice.reason
+
+    def test_unconfinable_backend_is_still_refused(self):
+        """kiro cannot confine its native read tools, so the gate still holds."""
+        choice = choose_plan_quota_backend("kiro", env={})
         assert choice.backend == BACKEND_UNAVAILABLE
         assert choice.plan_backend_id is None
-        assert "native read and shell tools" in choice.reason
 
     def test_unknown_backend_is_unavailable(self):
         choice = choose_plan_quota_backend("bogus", env={})

--- a/tests/unit/test_belief_revision.py
+++ b/tests/unit/test_belief_revision.py
@@ -353,7 +353,7 @@ class TestConflictResolution:
             trust_class="tertiary",
         )
 
-        retained, change = store.add_belief(candidate)
+        retained, _change = store.add_belief(candidate)
 
         # Weaker effective confidence cannot rewrite claim or raise raw conf;
         # provenance may still merge for multi-source accounting.

--- a/tests/unit/test_cli/test_capacity_command.py
+++ b/tests/unit/test_cli/test_capacity_command.py
@@ -144,8 +144,13 @@ class TestAdmitPlan:
         assert r.exit_code == 0, r.output
 
     def test_admit_choice_restricted_to_auto_routable(self):
-        # ToS-gray / metered backends cannot be admitted for auto-routing.
-        for backend in ("codex", "opencode", "kiro", "grok", "antigravity", "copilot"):
+        """Only backends provable non-metered and read-confined can auto-route.
+
+        codex, grok and antigravity left this list once their tools could be
+        stripped at dispatch, which is the property the refusal existed to
+        protect rather than the refusal itself.
+        """
+        for backend in ("opencode", "kiro", "copilot"):
             r = CliRunner().invoke(capacity, ["admit-plan", backend])
             assert r.exit_code != 0, backend
 
@@ -421,12 +426,12 @@ class TestProbeFleet:
     def test_explicit_fanout_refuses_blocked_adapter(self, monkeypatch, tmp_path):
         monkeypatch.setenv("DEEPR_CAPACITY_DATA_DIR", str(tmp_path))
         _clean_env(monkeypatch)
-        _stub_path(monkeypatch, "claude", "agy")
+        _stub_path(monkeypatch, "claude", "opencode")
         _stub_probe(monkeypatch, ok=True, reply="OK", latency_ms=7)
 
         r = CliRunner().invoke(
             capacity,
-            ["probe-fleet", "--backend", "claude", "--backend", "antigravity", "--json"],
+            ["probe-fleet", "--backend", "claude", "--backend", "opencode", "--json"],
         )
 
         assert r.exit_code == 1, r.output
@@ -435,8 +440,8 @@ class TestProbeFleet:
         assert payload["probed_count"] == 2
         assert payload["ok_count"] == 1
         assert payload["failed_count"] == 1
-        assert [result["backend"] for result in payload["results"]] == ["claude", "antigravity"]
-        assert "transcript side effects" in payload["results"][1]["error"]
+        assert [result["backend"] for result in payload["results"]] == ["claude", "opencode"]
+        assert "cannot be proven prepaid or local before dispatch" in payload["results"][1]["error"]
         events = load_quota_events(tmp_path / "quota_ledger.jsonl")
         assert [event.backend_id for event in events] == ["claude"]
         assert all(event.event_type == QuotaEventType.USAGE_OBSERVED for event in events)
@@ -454,27 +459,25 @@ class TestProbeFleet:
         assert payload["results"][0]["backend"] == "claude"
 
     def test_explicit_unconfined_experimental_backend_is_refused(self, monkeypatch):
-        """antigravity stays refused: its tools cannot be stripped at dispatch.
+        """kiro stays refused: its read tools cannot be confined at dispatch.
 
-        grok is deliberately absent from this case. It carries the same class
-        of native tools and is now confined in its argv instead of blocked, so
-        asserting a refusal here would pin the block rather than the property
-        the block exists to protect.
+        codex, grok and antigravity are deliberately absent. They carry the
+        same class of native tools and are now confined in their argv instead
+        of blocked, so asserting a refusal for them would pin the block rather
+        than the property the block exists to protect.
         """
         _clean_env(monkeypatch)
-        _stub_path(monkeypatch, "agy")
+        _stub_path(monkeypatch, "kiro-cli")
         _stub_probe(monkeypatch, ok=True, reply="OK")
 
-        r = CliRunner().invoke(capacity, ["probe-fleet", "--backend", "antigravity", "--json"])
+        r = CliRunner().invoke(capacity, ["probe-fleet", "--backend", "kiro", "--json"])
 
         assert r.exit_code == 1, r.output
         payload = json.loads(r.output)
         assert payload["ok_count"] == 0
         assert payload["failed_count"] == 1
-        assert [result["backend"] for result in payload["results"]] == ["antigravity"]
-        assert all(result["experimental"] for result in payload["results"])
-        assert "native tool permissions" in payload["results"][0]["error"]
-        assert "transcript side effects" in payload["results"][0]["error"]
+        assert [result["backend"] for result in payload["results"]] == ["kiro"]
+        assert "confined" in payload["results"][0]["error"]
 
     def test_explicit_metered_backend_is_blocked_by_default(self, monkeypatch):
         _clean_env(monkeypatch)
@@ -551,7 +554,7 @@ class TestValidateFleet:
 
         monkeypatch.setenv("DEEPR_CAPACITY_DATA_DIR", str(tmp_path))
         _clean_env(monkeypatch)
-        _stub_path(monkeypatch, "claude", "agy")
+        _stub_path(monkeypatch, "claude", "opencode")
         _stub_probe(monkeypatch, ok=True, reply="OK", latency_ms=7)
         calls: list[tuple[str | None, float]] = []
 
@@ -576,7 +579,7 @@ class TestValidateFleet:
                 "--backend",
                 "claude",
                 "--backend",
-                "antigravity",
+                "opencode",
                 "--expert",
                 "AI Agent Harnesses",
                 "--json",

--- a/tests/unit/test_cli/test_expert_consult_quality.py
+++ b/tests/unit/test_cli/test_expert_consult_quality.py
@@ -19,6 +19,7 @@ from deepr.core.contracts import Claim, ExpertManifest
 from deepr.experts.consult_quality import build_consult_quality_review
 from deepr.experts.consult_traces import build_consult_trace, build_consult_trace_candidates, record_consult_trace
 from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -26,7 +27,7 @@ def _profile() -> ExpertProfile:
         name="Consult Quality Expert",
         vector_store_id="vs-consult-quality",
         domain="consult quality",
-        knowledge_cutoff_date=datetime(2026, 6, 27, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
     )
     manifest = ExpertManifest(
         expert_name=profile.name,

--- a/tests/unit/test_cli/test_expert_maintenance.py
+++ b/tests/unit/test_cli/test_expert_maintenance.py
@@ -1717,14 +1717,14 @@ class TestPlanQuotaSync:
                 "claude",
                 "--check-grounding",
                 "--checker-plan",
-                "antigravity",
+                "kiro",
                 "-y",
                 "--json",
             ],
         )
 
         assert result.exit_code == 2, result.output
-        assert "Antigravity CLI (Google plan) execution is disabled" in result.output
+        assert "Kiro CLI execution is disabled" in result.output
         assert client_calls == []
 
     def test_plan_claude_runs_on_prepaid_and_records_source(self, monkeypatch):

--- a/tests/unit/test_cli/test_expert_memory_card.py
+++ b/tests/unit/test_cli/test_expert_memory_card.py
@@ -12,6 +12,7 @@ from deepr.cli.commands.semantic.expert_memory_card import expert_memory_card
 from deepr.cli.main import cli
 from deepr.core.contracts import Claim, ExpertManifest, Gap
 from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -19,7 +20,7 @@ def _profile() -> ExpertProfile:
         name="Memory Card Expert",
         vector_store_id="vs-memory-card",
         domain="agent memory",
-        knowledge_cutoff_date=datetime(2026, 6, 26, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, tzinfo=UTC),
     )
     manifest = ExpertManifest(

--- a/tests/unit/test_cli/test_expert_perspective_command.py
+++ b/tests/unit/test_cli/test_expert_perspective_command.py
@@ -59,7 +59,8 @@ def _stub_backend(monkeypatch, reply):
 
     class FakeBackend:
         cost_note = "$0 local"
-        capacity_source = "local:test"
+        capacity_source = "local:qwen2.5:14b"
+        model = "qwen2.5:14b"
 
     fake = FakeBackend()
     fake.completion = completion
@@ -154,6 +155,7 @@ class TestRefusalsBeforeSpending:
         class FakeBackend:
             cost_note = "$0"
             capacity_source = "plan:claude"
+            model = ""
             completion = staticmethod(refusing)
 
         monkeypatch.setattr(

--- a/tests/unit/test_cli/test_expert_perspective_command.py
+++ b/tests/unit/test_cli/test_expert_perspective_command.py
@@ -64,9 +64,7 @@ def _stub_backend(monkeypatch, reply):
 
     fake = FakeBackend()
     fake.completion = completion
-    monkeypatch.setattr(
-        "deepr.cli.commands.semantic.expert_perspective.build_study_backend", lambda **kwargs: fake
-    )
+    monkeypatch.setattr("deepr.cli.commands.semantic.expert_perspective.build_study_backend", lambda **kwargs: fake)
     return completion
 
 
@@ -112,9 +110,7 @@ class TestItNeverClaimsCoverage:
 
 
 class TestWhatItLends:
-    def test_the_prompt_carries_patterns_rather_than_question_matched_evidence(
-        self, profile, expert_home, monkeypatch
-    ):
+    def test_the_prompt_carries_patterns_rather_than_question_matched_evidence(self, profile, expert_home, monkeypatch):
         """Ranking against a foreign question surfaces shared vocabulary, which
         is the least interesting thing a frame has to offer."""
         _write_brief(expert_home, "Lender")

--- a/tests/unit/test_cli/test_expert_perspective_command.py
+++ b/tests/unit/test_cli/test_expert_perspective_command.py
@@ -1,0 +1,188 @@
+"""`deepr expert perspective`: lending a frame to a subject it knows nothing about.
+
+The property that matters: this mode must never look like coverage. It claims
+an analogy, says so in the first line of every rendering, and states where the
+analogy breaks. A reading that cannot do those things is worse than no reading.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from deepr.cli.commands.semantic.experts import expert
+
+
+@pytest.fixture
+def expert_home(tmp_path, monkeypatch):
+    home = tmp_path / "experts"
+    monkeypatch.setattr("deepr.cli.commands.semantic.expert_perspective.canonical_expert_dir", lambda n: home / n)
+    return home
+
+
+def _write_brief(home, name, *, orientation="I read this as a dependency problem.", settled=("A is settled",)):
+    directory = home / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "brief.json").write_text(
+        json.dumps(
+            {
+                "expert_name": name,
+                "orientation": orientation,
+                "positions": [],
+                "state": {"settled": list(settled), "live": ["B is contested"], "unknown": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return directory
+
+
+@pytest.fixture
+def profile(monkeypatch):
+    class FakeProfile:
+        name = "Lender"
+
+    class FakeStore:
+        def load(self, name):
+            return FakeProfile() if name == "Lender" else None
+
+    monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+    return FakeProfile
+
+
+def _stub_backend(monkeypatch, reply):
+    async def completion(prompt: str) -> str:
+        completion.prompt = prompt
+        return reply
+
+    class FakeBackend:
+        cost_note = "$0 local"
+        capacity_source = "local:test"
+
+    fake = FakeBackend()
+    fake.completion = completion
+    monkeypatch.setattr(
+        "deepr.cli.commands.semantic.expert_perspective.build_study_backend", lambda **kwargs: fake
+    )
+    return completion
+
+
+_GOOD_READING = json.dumps(
+    {
+        "observations": [
+            "In my subject meaning lives in the order of construction, so I would ask whether "
+            "your assembly order carries information nobody is reading."
+        ],
+        "where_it_breaks": ["My material is reversible and yours is not; a wrong step cannot be undone."],
+    }
+)
+
+
+class TestItNeverClaimsCoverage:
+    def test_every_rendering_says_analogy_in_its_opening(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Lender")
+        _stub_backend(monkeypatch, _GOOD_READING)
+
+        r = CliRunner().invoke(expert, ["perspective", "Lender", "how should I design a chair"])
+
+        assert r.exit_code == 0, r.output
+        assert "analogy, not evidence" in r.output
+
+    def test_where_it_breaks_is_carried_into_the_output(self, profile, expert_home, monkeypatch):
+        """An analogy with no stated limit is being offered as a fact."""
+        _write_brief(expert_home, "Lender")
+        _stub_backend(monkeypatch, _GOOD_READING)
+
+        r = CliRunner().invoke(expert, ["perspective", "Lender", "chairs"])
+
+        assert "cannot be undone" in r.output
+
+    def test_a_frame_that_does_not_reach_says_so_and_exits_zero(self, profile, expert_home, monkeypatch):
+        """A forced analogy is worse than none, so refusing is a real answer."""
+        _write_brief(expert_home, "Lender")
+        _stub_backend(monkeypatch, '{"observations": [], "where_it_breaks": []}')
+
+        r = CliRunner().invoke(expert, ["perspective", "Lender", "chairs"])
+
+        assert r.exit_code == 0
+        assert "does not reach this" in r.output
+
+
+class TestWhatItLends:
+    def test_the_prompt_carries_patterns_rather_than_question_matched_evidence(
+        self, profile, expert_home, monkeypatch
+    ):
+        """Ranking against a foreign question surfaces shared vocabulary, which
+        is the least interesting thing a frame has to offer."""
+        _write_brief(expert_home, "Lender")
+        completion = _stub_backend(monkeypatch, _GOOD_READING)
+
+        CliRunner().invoke(expert, ["perspective", "Lender", "how should I design a chair"])
+
+        assert "I read this as a dependency problem." in completion.prompt
+        assert "B is contested" in completion.prompt
+
+    def test_a_preferred_lens_reaches_the_prompt(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Lender")
+        completion = _stub_backend(monkeypatch, _GOOD_READING)
+
+        CliRunner().invoke(expert, ["perspective", "Lender", "chairs", "--lens", "read it as negative space"])
+
+        assert "read it as negative space" in completion.prompt
+
+
+class TestRefusalsBeforeSpending:
+    def test_unknown_expert_exits_two(self, profile, expert_home):
+        r = CliRunner().invoke(expert, ["perspective", "Nobody", "chairs"])
+        assert r.exit_code == 2
+        assert "Expert not found" in r.output
+
+    def test_an_unbriefed_expert_has_no_frame_to_lend(self, profile, expert_home, monkeypatch):
+        _stub_backend(monkeypatch, _GOOD_READING)
+        r = CliRunner().invoke(expert, ["perspective", "Lender", "chairs"])
+        assert r.exit_code == 2
+        assert "no frame to lend" in r.output
+
+    def test_a_capacity_refusal_is_named_rather_than_swallowed(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Lender")
+
+        async def refusing(prompt: str) -> str:
+            raise RuntimeError("plan did not prove that paid extra usage is disabled")
+
+        class FakeBackend:
+            cost_note = "$0"
+            capacity_source = "plan:claude"
+            completion = staticmethod(refusing)
+
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_perspective.build_study_backend", lambda **kwargs: FakeBackend()
+        )
+
+        r = CliRunner().invoke(expert, ["perspective", "Lender", "chairs"])
+
+        assert r.exit_code == 2
+        assert "paid extra usage is disabled" in r.output
+
+
+class TestOutput:
+    def test_json_mode_emits_the_reading(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Lender")
+        _stub_backend(monkeypatch, _GOOD_READING)
+
+        r = CliRunner().invoke(expert, ["perspective", "Lender", "chairs", "--json"])
+
+        assert r.exit_code == 0, r.output
+        payload = json.loads(r.output)
+        assert payload["where_it_breaks"]
+
+    def test_out_writes_the_rendered_reading(self, profile, expert_home, monkeypatch, tmp_path):
+        _write_brief(expert_home, "Lender")
+        _stub_backend(monkeypatch, _GOOD_READING)
+        target = tmp_path / "reading.md"
+
+        r = CliRunner().invoke(expert, ["perspective", "Lender", "chairs", "--out", str(target)])
+
+        assert r.exit_code == 0, r.output
+        assert "analogy, not evidence" in target.read_text(encoding="utf-8")

--- a/tests/unit/test_cli/test_expert_profile_command.py
+++ b/tests/unit/test_cli/test_expert_profile_command.py
@@ -19,10 +19,13 @@ from deepr.cli.commands.semantic.experts import expert
 
 @pytest.fixture
 def expert_home(tmp_path, monkeypatch):
+    from deepr.experts import paths
+
     home = tmp_path / "experts"
-    monkeypatch.setattr(
-        "deepr.cli.commands.semantic.expert_profile_card_cmd.canonical_expert_dir", lambda n: home / n
-    )
+    # Both: the layout helpers look the root up on `paths` at call time, while
+    # the command module still binds its own reference at import.
+    monkeypatch.setattr(paths, "canonical_expert_dir", lambda n: home / n)
+    monkeypatch.setattr("deepr.cli.commands.semantic.expert_profile_card_cmd.canonical_expert_dir", lambda n: home / n)
     return home
 
 
@@ -92,14 +95,14 @@ def _reply(standpoint="I read this as a dependency problem.", **extra):
 
 class TestItUnlocksThePerspectiveRung:
     def test_it_writes_the_file_expert_health_reads(self, profile, expert_home, monkeypatch):
-        """Nothing wrote profile_card.json, so the top of the ladder was unreachable."""
+        """Nothing wrote self.json, so the top of the ladder was unreachable."""
         _write_brief(expert_home, "Subject")
         _stub_backend(monkeypatch, _reply())
 
         r = CliRunner().invoke(expert, ["profile", "Subject"])
 
         assert r.exit_code == 0, r.output
-        written = json.loads((expert_home / "Subject" / "profile_card.json").read_text(encoding="utf-8"))
+        written = json.loads((expert_home / "Subject" / "self.json").read_text(encoding="utf-8"))
         assert written["standpoint"]
         assert written["has_standpoint"] is True
 
@@ -118,7 +121,7 @@ class TestTheShiftHistory:
         _write_brief(expert_home, "Subject")
         directory = expert_home / "Subject"
         directory.mkdir(parents=True, exist_ok=True)
-        (directory / "profile_card.json").write_text(
+        (directory / "self.json").write_text(
             json.dumps({"expert_name": "Subject", "standpoint": "I used to read it as a naming problem."}),
             encoding="utf-8",
         )
@@ -133,7 +136,7 @@ class TestTheShiftHistory:
         r = CliRunner().invoke(expert, ["profile", "Subject"])
 
         assert r.exit_code == 0, r.output
-        written = json.loads((directory / "profile_card.json").read_text(encoding="utf-8"))
+        written = json.loads((directory / "self.json").read_text(encoding="utf-8"))
         assert len(written["shifts"]) == 1
         assert written["shifts"][0]["because"].startswith("The failure lens")
         assert "changed its mind 1 time(s)" in r.output
@@ -142,7 +145,7 @@ class TestTheShiftHistory:
         """Append-only. Overwriting leaves the state a new expert is already in."""
         _write_brief(expert_home, "Subject")
         directory = expert_home / "Subject"
-        (directory / "profile_card.json").write_text(
+        (directory / "self.json").write_text(
             json.dumps(
                 {
                     "expert_name": "Subject",
@@ -163,26 +166,26 @@ class TestTheShiftHistory:
 
         CliRunner().invoke(expert, ["profile", "Subject"])
 
-        written = json.loads((directory / "profile_card.json").read_text(encoding="utf-8"))
+        written = json.loads((directory / "self.json").read_text(encoding="utf-8"))
         assert [s["was"] for s in written["shifts"]] == ["First reading.", "Second reading."]
 
     def test_an_unchanged_standpoint_records_no_shift(self, profile, expert_home, monkeypatch):
         """Inventing a change is worse than reporting none."""
         _write_brief(expert_home, "Subject")
         directory = expert_home / "Subject"
-        (directory / "profile_card.json").write_text(
+        (directory / "self.json").write_text(
             json.dumps({"expert_name": "Subject", "standpoint": "Same reading."}), encoding="utf-8"
         )
         _stub_backend(monkeypatch, _reply(standpoint="Same reading.", shift_from_prior="", shift_because=""))
 
         CliRunner().invoke(expert, ["profile", "Subject"])
 
-        assert json.loads((directory / "profile_card.json").read_text(encoding="utf-8"))["shifts"] == []
+        assert json.loads((directory / "self.json").read_text(encoding="utf-8"))["shifts"] == []
 
     def test_the_prior_standpoint_is_shown_to_the_model(self, profile, expert_home, monkeypatch):
         """It cannot report a change it was never shown."""
         _write_brief(expert_home, "Subject")
-        (expert_home / "Subject" / "profile_card.json").write_text(
+        (expert_home / "Subject" / "self.json").write_text(
             json.dumps({"expert_name": "Subject", "standpoint": "An earlier reading."}), encoding="utf-8"
         )
         completion = _stub_backend(monkeypatch, _reply())
@@ -196,7 +199,7 @@ class TestRefusalsBeforeWriting:
     def test_an_unusable_reply_does_not_destroy_the_shift_history(self, profile, expert_home, monkeypatch):
         """The history is the only unrecomputable thing in the directory."""
         _write_brief(expert_home, "Subject")
-        card = expert_home / "Subject" / "profile_card.json"
+        card = expert_home / "Subject" / "self.json"
         card.write_text(
             json.dumps(
                 {

--- a/tests/unit/test_cli/test_expert_profile_command.py
+++ b/tests/unit/test_cli/test_expert_profile_command.py
@@ -221,6 +221,25 @@ class TestRefusalsBeforeWriting:
         assert r.exit_code == 2
         assert "has not landed anywhere" in r.output
 
+    def test_a_brief_holding_no_positions_is_refused(self, profile, expert_home, monkeypatch):
+        """Measured: a timed-out synthesis wrote an empty brief, and profiling
+        against it produced a standpoint about the pipeline failing rather than
+        about the subject. The "did it return a standpoint" check cannot catch
+        that, because a description of the failure is a non-empty standpoint.
+        """
+        directory = expert_home / "Subject"
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "brief.json").write_text(
+            json.dumps({"expert_name": "Subject", "positions": [], "limitations": ["synthesis timed out"]}),
+            encoding="utf-8",
+        )
+        _stub_backend(monkeypatch, _reply())
+
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert r.exit_code == 2
+        assert "no positions" in r.output
+
     def test_a_capacity_refusal_is_named(self, profile, expert_home, monkeypatch):
         _write_brief(expert_home, "Subject")
 

--- a/tests/unit/test_cli/test_expert_profile_command.py
+++ b/tests/unit/test_cli/test_expert_profile_command.py
@@ -1,0 +1,242 @@
+"""`deepr expert profile`: the expert's own account of how it reads its subject.
+
+The behaviour worth guarding is the shift history. Every study recomputes the
+brief from the corpus, so a profile's record of changing its mind is the only
+thing in an expert's directory that cannot be regenerated. Losing it to a bad
+model reply, or dropping it on the operation that produces revisions, would be
+the worst failure available here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from deepr.cli.commands.semantic.experts import expert
+
+
+@pytest.fixture
+def expert_home(tmp_path, monkeypatch):
+    home = tmp_path / "experts"
+    monkeypatch.setattr(
+        "deepr.cli.commands.semantic.expert_profile_card_cmd.canonical_expert_dir", lambda n: home / n
+    )
+    return home
+
+
+def _write_brief(home, name):
+    directory = home / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "brief.json").write_text(
+        json.dumps(
+            {
+                "expert_name": name,
+                "orientation": "I read this as a dependency problem.",
+                "positions": [{"claim": "A", "would_change_my_mind": "B"}],
+                "state": {"settled": ["s"], "live": ["l"], "unknown": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return directory
+
+
+@pytest.fixture
+def profile(monkeypatch):
+    class FakeProfile:
+        name = "Subject"
+
+    class FakeStore:
+        def load(self, name):
+            return FakeProfile() if name == "Subject" else None
+
+    monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+    return FakeProfile
+
+
+def _stub_backend(monkeypatch, reply):
+    async def completion(prompt: str) -> str:
+        completion.prompt = prompt
+        return reply
+
+    class FakeBackend:
+        cost_note = "$0 local"
+        capacity_source = "local:test"
+
+    fake = FakeBackend()
+    fake.completion = completion
+    monkeypatch.setattr(
+        "deepr.cli.commands.semantic.expert_profile_card_cmd.build_study_backend", lambda **kwargs: fake
+    )
+    return completion
+
+
+def _reply(standpoint="I read this as a dependency problem.", **extra):
+    return json.dumps(
+        {
+            "chosen_name": "Ledger",
+            "standpoint": standpoint,
+            "what_the_subject_is_about": "what depends on what",
+            "preferred_lens": "mechanism",
+            "open_questions": ["whether retraction scales"],
+            "where_it_is_weak": ["no primary sources"],
+            "voice": "plain",
+            "glad_to_be_asked_about": ["dependency chains"],
+            **extra,
+        }
+    )
+
+
+class TestItUnlocksThePerspectiveRung:
+    def test_it_writes_the_file_expert_health_reads(self, profile, expert_home, monkeypatch):
+        """Nothing wrote profile_card.json, so the top of the ladder was unreachable."""
+        _write_brief(expert_home, "Subject")
+        _stub_backend(monkeypatch, _reply())
+
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert r.exit_code == 0, r.output
+        written = json.loads((expert_home / "Subject" / "profile_card.json").read_text(encoding="utf-8"))
+        assert written["standpoint"]
+        assert written["has_standpoint"] is True
+
+    def test_the_chosen_name_and_invitation_are_surfaced(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Subject")
+        _stub_backend(monkeypatch, _reply())
+
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert "Ledger" in r.output
+        assert "dependency chains" in r.output
+
+
+class TestTheShiftHistory:
+    def test_a_changed_standpoint_is_recorded_with_what_moved_it(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Subject")
+        directory = expert_home / "Subject"
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "profile_card.json").write_text(
+            json.dumps({"expert_name": "Subject", "standpoint": "I used to read it as a naming problem."}),
+            encoding="utf-8",
+        )
+        _stub_backend(
+            monkeypatch,
+            _reply(
+                shift_from_prior="I used to read it as a naming problem.",
+                shift_because="The failure lens found retraction, not naming, at the centre.",
+            ),
+        )
+
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert r.exit_code == 0, r.output
+        written = json.loads((directory / "profile_card.json").read_text(encoding="utf-8"))
+        assert len(written["shifts"]) == 1
+        assert written["shifts"][0]["because"].startswith("The failure lens")
+        assert "changed its mind 1 time(s)" in r.output
+
+    def test_earlier_shifts_survive_a_re_profile(self, profile, expert_home, monkeypatch):
+        """Append-only. Overwriting leaves the state a new expert is already in."""
+        _write_brief(expert_home, "Subject")
+        directory = expert_home / "Subject"
+        (directory / "profile_card.json").write_text(
+            json.dumps(
+                {
+                    "expert_name": "Subject",
+                    "standpoint": "Second reading.",
+                    "shifts": [{"at": "2026-01-01", "was": "First reading.", "now": "Second reading.", "because": "x"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        _stub_backend(
+            monkeypatch,
+            _reply(
+                standpoint="Third reading.",
+                shift_from_prior="Second reading.",
+                shift_because="New sources.",
+            ),
+        )
+
+        CliRunner().invoke(expert, ["profile", "Subject"])
+
+        written = json.loads((directory / "profile_card.json").read_text(encoding="utf-8"))
+        assert [s["was"] for s in written["shifts"]] == ["First reading.", "Second reading."]
+
+    def test_an_unchanged_standpoint_records_no_shift(self, profile, expert_home, monkeypatch):
+        """Inventing a change is worse than reporting none."""
+        _write_brief(expert_home, "Subject")
+        directory = expert_home / "Subject"
+        (directory / "profile_card.json").write_text(
+            json.dumps({"expert_name": "Subject", "standpoint": "Same reading."}), encoding="utf-8"
+        )
+        _stub_backend(monkeypatch, _reply(standpoint="Same reading.", shift_from_prior="", shift_because=""))
+
+        CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert json.loads((directory / "profile_card.json").read_text(encoding="utf-8"))["shifts"] == []
+
+    def test_the_prior_standpoint_is_shown_to_the_model(self, profile, expert_home, monkeypatch):
+        """It cannot report a change it was never shown."""
+        _write_brief(expert_home, "Subject")
+        (expert_home / "Subject" / "profile_card.json").write_text(
+            json.dumps({"expert_name": "Subject", "standpoint": "An earlier reading."}), encoding="utf-8"
+        )
+        completion = _stub_backend(monkeypatch, _reply())
+
+        CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert "An earlier reading." in completion.prompt
+
+
+class TestRefusalsBeforeWriting:
+    def test_an_unusable_reply_does_not_destroy_the_shift_history(self, profile, expert_home, monkeypatch):
+        """The history is the only unrecomputable thing in the directory."""
+        _write_brief(expert_home, "Subject")
+        card = expert_home / "Subject" / "profile_card.json"
+        card.write_text(
+            json.dumps(
+                {
+                    "expert_name": "Subject",
+                    "standpoint": "A real reading.",
+                    "shifts": [{"at": "2026-01-01", "was": "older", "now": "A real reading.", "because": "y"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        _stub_backend(monkeypatch, "the model wrote prose instead")
+
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert r.exit_code == 2
+        assert "left alone" in r.output
+        assert json.loads(card.read_text(encoding="utf-8"))["shifts"]
+
+    def test_an_unbriefed_expert_is_refused(self, profile, expert_home, monkeypatch):
+        _stub_backend(monkeypatch, _reply())
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+        assert r.exit_code == 2
+        assert "has not landed anywhere" in r.output
+
+    def test_a_capacity_refusal_is_named(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Subject")
+
+        async def refusing(prompt: str) -> str:
+            raise RuntimeError("plan did not prove that paid extra usage is disabled")
+
+        class FakeBackend:
+            cost_note = "$0"
+            capacity_source = "plan:claude"
+            completion = staticmethod(refusing)
+
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_profile_card_cmd.build_study_backend",
+            lambda **kwargs: FakeBackend(),
+        )
+
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert r.exit_code == 2
+        assert "paid extra usage is disabled" in r.output

--- a/tests/unit/test_cli/test_expert_profile_command.py
+++ b/tests/unit/test_cli/test_expert_profile_command.py
@@ -63,7 +63,8 @@ def _stub_backend(monkeypatch, reply):
 
     class FakeBackend:
         cost_note = "$0 local"
-        capacity_source = "local:test"
+        capacity_source = "local:qwen2.5:14b"
+        model = "qwen2.5:14b"
 
     fake = FakeBackend()
     fake.completion = completion
@@ -229,6 +230,7 @@ class TestRefusalsBeforeWriting:
         class FakeBackend:
             cost_note = "$0"
             capacity_source = "plan:claude"
+            model = ""
             completion = staticmethod(refusing)
 
         monkeypatch.setattr(

--- a/tests/unit/test_cli/test_expert_self_model.py
+++ b/tests/unit/test_cli/test_expert_self_model.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import shutil
-from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -24,6 +23,7 @@ from deepr.core.contracts import Claim, ExpertManifest, Gap
 from deepr.experts.beliefs import Belief
 from deepr.experts.profile import ExpertProfile
 from deepr.experts.profile_store import ExpertStore
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -31,7 +31,7 @@ def _profile() -> ExpertProfile:
         name="Agent Harness Expert",
         vector_store_id="vs-agent-harness",
         domain="agent harnesses",
-        knowledge_cutoff_date=datetime(2026, 6, 26, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         installed_skills=["consult-review"],
     )
     manifest = ExpertManifest(

--- a/tests/unit/test_cli/test_expert_semantic_recall.py
+++ b/tests/unit/test_cli/test_expert_semantic_recall.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -12,6 +11,7 @@ from deepr.cli.commands.semantic.expert_semantic_recall import expert_refresh_se
 from deepr.cli.main import cli
 from deepr.experts.beliefs import Belief, BeliefStore
 from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -19,7 +19,7 @@ def _profile() -> ExpertProfile:
         name="Recall CLI Expert",
         vector_store_id="vs-recall-cli",
         domain="ai infrastructure",
-        knowledge_cutoff_date=datetime(2026, 6, 29, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
     )
 
 

--- a/tests/unit/test_cli/test_expert_status_command.py
+++ b/tests/unit/test_cli/test_expert_status_command.py
@@ -63,7 +63,10 @@ class TestItSeparatesFailedFromDone:
 
     def test_a_real_artifact_reads_as_done(self, profile, expert_home):
         _build(expert_home)
-        stages = {s["stage"]: s for s in json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["stages"]}
+        stages = {
+            s["stage"]: s
+            for s in json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["stages"]
+        }
         assert stages["brief"]["status"] == "done"
 
     def test_the_human_view_warns_about_failed_stages(self, profile, expert_home):
@@ -110,7 +113,10 @@ class TestReadingArtifacts:
         d = _build(expert_home)
         (d / "brief.json").write_text("{not json", encoding="utf-8")
 
-        stages = {s["stage"]: s for s in json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["stages"]}
+        stages = {
+            s["stage"]: s
+            for s in json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["stages"]
+        }
         assert stages["profile"]["status"] == "blocked"
 
     def test_an_empty_expert_reports_acquire_as_the_next_step(self, profile, expert_home):

--- a/tests/unit/test_cli/test_expert_status_command.py
+++ b/tests/unit/test_cli/test_expert_status_command.py
@@ -1,0 +1,126 @@
+"""`deepr expert status`: where an expert is in the loop, and why.
+
+The state worth having is `failed` - the artifact exists and carries nothing.
+Every prior view could only ask "does the file exist", and a brief holding zero
+positions passes that. Profiling against one produced a standpoint about the
+pipeline failing rather than about the subject.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from deepr.cli.commands.semantic.experts import expert
+
+
+@pytest.fixture
+def expert_home(tmp_path, monkeypatch):
+    home = tmp_path / "experts"
+    monkeypatch.setattr("deepr.cli.commands.semantic.expert_status.canonical_expert_dir", lambda n: home / n)
+    return home
+
+
+@pytest.fixture
+def profile(monkeypatch):
+    class FakeProfile:
+        name = "Subject"
+
+    class FakeStore:
+        def load(self, name):
+            return FakeProfile() if name == "Subject" else None
+
+    monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+    return FakeProfile
+
+
+def _build(home, *, sources=3, findings=10, grounded=8, positions=1, standpoint="I read this as X."):
+    d = home / "Subject"
+    (d / "corpus").mkdir(parents=True, exist_ok=True)
+    (d / "corpus" / "index.jsonl").write_text("\n".join('{"x":1}' for _ in range(sources)), encoding="utf-8")
+    (d / "study.json").write_text(
+        json.dumps({"totals": {"findings": findings, "grounded_findings": grounded}}), encoding="utf-8"
+    )
+    (d / "brief.json").write_text(
+        json.dumps({"positions": [{"question": f"Q{i}"} for i in range(positions)]}), encoding="utf-8"
+    )
+    if standpoint:
+        (d / "profile_card.json").write_text(json.dumps({"standpoint": standpoint}), encoding="utf-8")
+    return d
+
+
+class TestItSeparatesFailedFromDone:
+    def test_an_artifact_that_carries_nothing_reads_as_failed(self, profile, expert_home):
+        """The exact case: a timed-out synthesis wrote a parseable, empty brief."""
+        _build(expert_home, positions=0)
+
+        r = CliRunner().invoke(expert, ["status", "Subject", "--json"])
+
+        stages = {s["stage"]: s for s in json.loads(r.output)["stages"]}
+        assert stages["brief"]["status"] == "failed"
+
+    def test_a_real_artifact_reads_as_done(self, profile, expert_home):
+        _build(expert_home)
+        stages = {s["stage"]: s for s in json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["stages"]}
+        assert stages["brief"]["status"] == "done"
+
+    def test_the_human_view_warns_about_failed_stages(self, profile, expert_home):
+        _build(expert_home, positions=0)
+        r = CliRunner().invoke(expert, ["status", "Subject"])
+        assert "carries nothing" in r.output
+
+
+class TestBlockedNamesTheFix:
+    def test_an_empty_brief_blocks_the_profile_and_says_why(self, profile, expert_home):
+        _build(expert_home, positions=0, standpoint="")
+
+        r = CliRunner().invoke(expert, ["status", "Subject"])
+
+        assert "holds no positions" in r.output
+        assert "expert brief" in r.output
+
+    def test_ungrounded_findings_block_the_brief(self, profile, expert_home):
+        _build(expert_home, grounded=0, positions=0, standpoint="")
+        r = CliRunner().invoke(expert, ["status", "Subject", "--json"])
+        stages = {s["stage"]: s for s in json.loads(r.output)["stages"]}
+        assert stages["brief"]["status"] == "blocked"
+
+
+class TestWhatToDoNext:
+    def test_a_failed_stage_outranks_a_ready_one(self, profile, expert_home):
+        """Building on a stage that produced nothing is how corruption spreads."""
+        _build(expert_home, positions=0, standpoint="")
+        assert json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["next"] == "brief"
+
+    def test_a_complete_expert_has_nothing_next(self, profile, expert_home):
+        d = _build(expert_home)
+        (d / "graph").mkdir(exist_ok=True)
+        (d / "graph" / "evidence.json").write_text(json.dumps({"stats": {"is_formed": True}}), encoding="utf-8")
+        (d / "practice.json").write_text(json.dumps({"stats": {"live_pursuits": 2}}), encoding="utf-8")
+        (d / "viva.json").write_text(json.dumps({"exchanges": [{"question": "Q"}]}), encoding="utf-8")
+
+        assert json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["next"] is None
+
+
+class TestReadingArtifacts:
+    def test_an_unparseable_artifact_is_treated_as_missing(self, profile, expert_home):
+        """Treating a corrupt file as present is how corruption travels."""
+        d = _build(expert_home)
+        (d / "brief.json").write_text("{not json", encoding="utf-8")
+
+        stages = {s["stage"]: s for s in json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["stages"]}
+        assert stages["profile"]["status"] == "blocked"
+
+    def test_an_empty_expert_reports_acquire_as_the_next_step(self, profile, expert_home):
+        (expert_home / "Subject").mkdir(parents=True, exist_ok=True)
+        assert json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["next"] == "acquire"
+
+    def test_it_costs_nothing_and_says_so(self, profile, expert_home):
+        _build(expert_home)
+        assert json.loads(CliRunner().invoke(expert, ["status", "Subject", "--json"]).output)["cost_usd"] == 0.0
+
+    def test_an_unknown_expert_exits_two(self, profile, expert_home):
+        r = CliRunner().invoke(expert, ["status", "Nobody"])
+        assert r.exit_code == 2

--- a/tests/unit/test_cli/test_expert_study_roundtrip.py
+++ b/tests/unit/test_cli/test_expert_study_roundtrip.py
@@ -21,11 +21,21 @@ from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
 @pytest.fixture
 def profile(tmp_path, monkeypatch):
     """An expert whose canonical directory is disposable."""
-    monkeypatch.setattr(
-        "deepr.cli.commands.semantic.expert_study.canonical_expert_dir",
-        lambda name: tmp_path,
-    )
+    from deepr.experts import paths
+
+    monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: tmp_path)
     return SimpleNamespace(name="Round Trip Expert")
+
+
+def _write(path, payload: str) -> None:
+    """Write where a command would, creating the directory a command would.
+
+    The canonical paths are nested now (`noticed/current.json`), so a test that
+    writes one has to make the directory the same way the production writers
+    do.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload, encoding="utf-8")
 
 
 def _study() -> StudyResult:
@@ -55,7 +65,7 @@ def _study() -> StudyResult:
 class TestStudyRoundTrip:
     def test_a_study_written_to_the_canonical_path_is_the_one_brief_loads(self, profile):
         path = canonical_study_path(profile.name)
-        path.write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+        _write(path, json.dumps(_study().to_dict()))
 
         loaded = _load_study_result(profile, None)
 
@@ -64,7 +74,7 @@ class TestStudyRoundTrip:
 
     def test_grounding_survives_the_round_trip(self, profile):
         """A finding that loses its anchors on reload would brief as unverified."""
-        canonical_study_path(profile.name).write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+        _write(canonical_study_path(profile.name), json.dumps(_study().to_dict()))
 
         finding = _load_study_result(profile, None).findings[0]
 
@@ -73,7 +83,7 @@ class TestStudyRoundTrip:
 
     def test_limitations_survive_the_round_trip(self, profile):
         """Limitations are what stop a partial study reading as a complete one."""
-        canonical_study_path(profile.name).write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+        _write(canonical_study_path(profile.name), json.dumps(_study().to_dict()))
 
         assert _load_study_result(profile, None).limitations == ["one source was skipped"]
 
@@ -86,6 +96,6 @@ class TestStudyRoundTrip:
 
     def test_explicit_path_overrides_the_canonical_one(self, profile, tmp_path):
         elsewhere = tmp_path / "other.json"
-        elsewhere.write_text(json.dumps(_study().to_dict()), encoding="utf-8")
+        _write(elsewhere, json.dumps(_study().to_dict()))
 
         assert _load_study_result(profile, str(elsewhere)).findings

--- a/tests/unit/test_cli/test_expert_viva_command.py
+++ b/tests/unit/test_cli/test_expert_viva_command.py
@@ -1,0 +1,230 @@
+"""`deepr expert viva`: examining an expert from the command line.
+
+What matters here is that the command refuses cleanly before spending anything
+when there is nothing to examine, and that a run producing no questions exits
+non-zero rather than writing a clean-looking empty transcript.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from deepr.cli.commands.semantic.experts import expert
+
+
+@pytest.fixture
+def expert_home(tmp_path, monkeypatch):
+    """Point the canonical expert directory at a temp dir."""
+    from deepr.experts import paths
+
+    home = tmp_path / "experts"
+    monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: home / name)
+    for module in ("deepr.cli.commands.semantic.expert_viva",):
+        monkeypatch.setattr(f"{module}.canonical_expert_dir", lambda name: home / name)
+    return home
+
+
+def _write_brief(home, name, *, orientation="I read this as a systems problem.", positions=1):
+    directory = home / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "brief.json").write_text(
+        json.dumps(
+            {
+                "expert_name": name,
+                "orientation": orientation,
+                "positions": [
+                    {
+                        "claim": f"Position {i}",
+                        "confidence": "moderate",
+                        "would_change_my_mind": "A counterexample from a primary source.",
+                    }
+                    for i in range(positions)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return directory
+
+
+@pytest.fixture
+def profile(monkeypatch):
+    """A loadable expert profile, so the command gets past name resolution."""
+
+    class FakeProfile:
+        name = "Candidate"
+
+    class FakeStore:
+        def load(self, name):
+            return FakeProfile() if name in {"Candidate", "Examiner One"} else None
+
+    monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+    return FakeProfile
+
+
+def _stub_backend(monkeypatch, replies):
+    """A $0 backend whose completion replays a script."""
+    from deepr.cli.commands.semantic import study_backend as backend_module
+
+    state = {"replies": list(replies), "prompts": []}
+
+    async def completion(prompt: str) -> str:
+        state["prompts"].append(prompt)
+        return state["replies"].pop(0) if state["replies"] else ""
+
+    class FakeBackend:
+        capacity_source = "local:test"
+        cost_note = "$0 local"
+
+    fake = FakeBackend()
+    fake.completion = completion
+    monkeypatch.setattr(
+        "deepr.cli.commands.semantic.expert_viva.build_study_backend",
+        lambda **kwargs: fake,
+    )
+    assert backend_module is not None
+    return state
+
+
+class TestRefusalsBeforeSpending:
+    def test_unknown_expert_exits_two(self, profile, expert_home):
+        r = CliRunner().invoke(expert, ["viva", "Nobody"])
+        assert r.exit_code == 2
+        assert "Expert not found" in r.output
+
+    def test_an_unbriefed_expert_is_refused_with_the_command_to_run(self, profile, expert_home, monkeypatch):
+        """Nothing to probe, so three model calls would produce a document saying so."""
+        called = _stub_backend(monkeypatch, [])
+        r = CliRunner().invoke(expert, ["viva", "Candidate"])
+        assert r.exit_code == 2
+        assert "has no brief" in r.output
+        assert "expert brief" in r.output
+        assert called["prompts"] == []
+
+    def test_an_examiner_without_an_orientation_is_skipped(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Candidate")
+        _write_brief(expert_home, "Examiner One", orientation="")
+        _stub_backend(monkeypatch, [])
+
+        r = CliRunner().invoke(expert, ["viva", "Candidate", "--examiner", "Examiner One"])
+
+        assert r.exit_code == 2
+        assert "holds no orientation of its own" in r.output
+        assert "no usable examiners" in r.output
+
+
+class TestAnExaminationThatRuns:
+    def test_it_writes_the_transcript_and_the_reading_queue(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Candidate")
+        _stub_backend(
+            monkeypatch,
+            [
+                '{"questions": [{"question": "Why this?", "probes": "reasoning"}]}',
+                "{}",
+                "{}",
+                '{"answers": [{"question": "Why this?", "answer": "Because X."}]}',
+                '{"judgements": [{"question": "Why this?", "verdict": "cannot_answer",'
+                ' "would_resolve_it": "The 2024 errata."}]}',
+                "{}",
+                "{}",
+            ],
+        )
+
+        r = CliRunner().invoke(expert, ["viva", "Candidate"])
+
+        assert r.exit_code == 0, r.output
+        written = json.loads((expert_home / "Candidate" / "viva.json").read_text(encoding="utf-8"))
+        assert written["reading_queue"] == ["The 2024 errata."]
+        assert "The 2024 errata." in r.output
+
+    def test_markdown_is_written_beside_the_json(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Candidate")
+        _stub_backend(
+            monkeypatch,
+            ['{"questions": [{"question": "Q"}]}', "{}", "{}", '{"answers": []}', "{}", "{}", "{}"],
+        )
+
+        r = CliRunner().invoke(expert, ["viva", "Candidate", "--markdown"])
+
+        assert r.exit_code == 0, r.output
+        assert (expert_home / "Candidate" / "viva.md").exists()
+
+    def test_a_panel_that_asked_nothing_exits_two(self, profile, expert_home, monkeypatch):
+        """A broken backend must not read as a clean examination."""
+        _write_brief(expert_home, "Candidate")
+        _stub_backend(monkeypatch, ["not json", "not json", "not json"])
+
+        r = CliRunner().invoke(expert, ["viva", "Candidate"])
+
+        assert r.exit_code == 2
+        assert "no examiner produced a question" in r.output
+
+    def test_a_capacity_refusal_is_named_rather_than_swallowed(self, profile, expert_home, monkeypatch):
+        """Measured live: the paid-overage guard refused and the run looked empty.
+
+        A quota refusal affects every call, so it is the whole story rather
+        than one flaky examiner. Reporting an empty panel without it sends
+        someone looking for a prompt bug that is not there.
+        """
+        _write_brief(expert_home, "Candidate")
+
+        async def refusing(prompt: str) -> str:
+            raise RuntimeError("plan did not prove that paid extra usage is disabled")
+
+        class FakeBackend:
+            capacity_source = "plan:claude"
+            cost_note = "$0 at the margin"
+            completion = staticmethod(refusing)
+
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_viva.build_study_backend", lambda **kwargs: FakeBackend()
+        )
+
+        r = CliRunner().invoke(expert, ["viva", "Candidate"])
+
+        assert r.exit_code == 2
+        assert "paid extra usage is disabled" in r.output
+
+    def test_a_failed_run_does_not_destroy_the_previous_transcript(self, profile, expert_home, monkeypatch):
+        """Measured live: a backend hiccup overwrote a good viva with an empty one.
+
+        An examination costs quota and several minutes. Losing one to a
+        transient failure on the next run is the worst possible trade, so the
+        refusal happens before anything is written.
+        """
+        _write_brief(expert_home, "Candidate")
+        existing = expert_home / "Candidate" / "viva.json"
+        existing.write_text('{"summary": "an earlier examination"}', encoding="utf-8")
+        _stub_backend(monkeypatch, ["not json", "not json", "not json"])
+
+        r = CliRunner().invoke(expert, ["viva", "Candidate"])
+
+        assert r.exit_code == 2
+        assert "left alone" in r.output
+        assert json.loads(existing.read_text(encoding="utf-8"))["summary"] == "an earlier examination"
+
+    def test_no_grade_appears_anywhere_in_the_output(self, profile, expert_home, monkeypatch):
+        """expert health is the letter-shaped question; this one is not."""
+        _write_brief(expert_home, "Candidate")
+        _stub_backend(
+            monkeypatch,
+            [
+                '{"questions": [{"question": "Q"}]}',
+                "{}",
+                "{}",
+                '{"answers": [{"question": "Q", "answer": "A"}]}',
+                '{"judgements": [{"question": "Q", "verdict": "answered"}]}',
+                "{}",
+                "{}",
+            ],
+        )
+
+        r = CliRunner().invoke(expert, ["viva", "Candidate", "--json"])
+
+        assert r.exit_code == 0, r.output
+        payload = json.loads(r.output)
+        assert "grade" not in payload
+        assert "score" not in payload

--- a/tests/unit/test_cli/test_expert_viva_command.py
+++ b/tests/unit/test_cli/test_expert_viva_command.py
@@ -76,7 +76,8 @@ def _stub_backend(monkeypatch, replies):
         return state["replies"].pop(0) if state["replies"] else ""
 
     class FakeBackend:
-        capacity_source = "local:test"
+        capacity_source = "local:qwen2.5:14b"
+        model = "qwen2.5:14b"
         cost_note = "$0 local"
 
     fake = FakeBackend()
@@ -176,6 +177,7 @@ class TestAnExaminationThatRuns:
 
         class FakeBackend:
             capacity_source = "plan:claude"
+            model = ""
             cost_note = "$0 at the margin"
             completion = staticmethod(refusing)
 

--- a/tests/unit/test_cli/test_expert_viva_command.py
+++ b/tests/unit/test_cli/test_expert_viva_command.py
@@ -21,9 +21,10 @@ def expert_home(tmp_path, monkeypatch):
     from deepr.experts import paths
 
     home = tmp_path / "experts"
+    # Patched on `paths` alone: every path helper resolves through
+    # `expert_layout`, which looks the root up on the module at call time
+    # rather than binding it at import.
     monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: home / name)
-    for module in ("deepr.cli.commands.semantic.expert_viva",):
-        monkeypatch.setattr(f"{module}.canonical_expert_dir", lambda name: home / name)
     return home
 
 
@@ -137,7 +138,7 @@ class TestAnExaminationThatRuns:
         r = CliRunner().invoke(expert, ["viva", "Candidate"])
 
         assert r.exit_code == 0, r.output
-        written = json.loads((expert_home / "Candidate" / "viva.json").read_text(encoding="utf-8"))
+        written = json.loads((expert_home / "Candidate" / "met" / "examination.json").read_text(encoding="utf-8"))
         assert written["reading_queue"] == ["The 2024 errata."]
         assert "The 2024 errata." in r.output
 
@@ -151,7 +152,7 @@ class TestAnExaminationThatRuns:
         r = CliRunner().invoke(expert, ["viva", "Candidate", "--markdown"])
 
         assert r.exit_code == 0, r.output
-        assert (expert_home / "Candidate" / "viva.md").exists()
+        assert (expert_home / "Candidate" / "met" / "examination.md").exists()
 
     def test_a_panel_that_asked_nothing_exits_two(self, profile, expert_home, monkeypatch):
         """A broken backend must not read as a clean examination."""
@@ -198,7 +199,8 @@ class TestAnExaminationThatRuns:
         refusal happens before anything is written.
         """
         _write_brief(expert_home, "Candidate")
-        existing = expert_home / "Candidate" / "viva.json"
+        existing = expert_home / "Candidate" / "met" / "examination.json"
+        existing.parent.mkdir(parents=True, exist_ok=True)
         existing.write_text('{"summary": "an earlier examination"}', encoding="utf-8")
         _stub_backend(monkeypatch, ["not json", "not json", "not json"])
 

--- a/tests/unit/test_cli/test_study_backend.py
+++ b/tests/unit/test_cli/test_study_backend.py
@@ -7,8 +7,8 @@ import pytest
 from deepr.cli.commands.semantic import study_backend
 from deepr.cli.commands.semantic.study_backend import (
     StudyBackendError,
-    build_study_backend,
     _preferred_plan_backends,
+    build_study_backend,
 )
 
 

--- a/tests/unit/test_experts/test_acquisition_plan.py
+++ b/tests/unit/test_experts/test_acquisition_plan.py
@@ -110,3 +110,26 @@ class TestSerialization:
     @pytest.mark.parametrize("arm", [ARM_DESCRIPTIVE, ARM_ADVERSARIAL, ARM_GENRE, ARM_PRIMARY])
     def test_every_query_states_why_it_is_in_the_plan(self, arm):
         assert all(q.rationale for q in plan_queries("X").by_arm(arm))
+
+
+class TestLongTopics:
+    """Found by using it: a sentence-length topic makes every query unusable."""
+
+    def test_a_long_topic_is_shortened_for_templating(self):
+        plan = plan_queries("How to keep AI agent produced software work from degrading into low quality output")
+        assert plan.search_key
+        assert len(plan.search_key.split()) <= 6
+        assert all(len(q.text) < 90 for q in plan.by_arm(ARM_ADVERSARIAL))
+
+    def test_the_shortening_is_reported_not_done_quietly(self):
+        plan = plan_queries("How to keep AI agent produced software work from degrading into low quality output")
+        assert any("too" in c and "template" in c for c in plan.concerns())
+
+    def test_a_short_topic_is_left_alone(self):
+        plan = plan_queries("AI generated code slop")
+        assert plan.search_key == plan.topic
+        assert not any("shortened" in c for c in plan.concerns())
+
+    def test_stopwords_do_not_consume_the_budget(self):
+        """Six content words, not six tokens of 'how to the of'."""
+        assert "slop" in plan_queries("how to deal with the problem of AI slop in code").search_key

--- a/tests/unit/test_experts/test_backend_pool_failover.py
+++ b/tests/unit/test_experts/test_backend_pool_failover.py
@@ -69,9 +69,7 @@ class TestAnExhaustedPlanIsRetired:
         assert pool.names == ["codex"]
 
     def test_retirement_is_reported_rather_than_silent(self):
-        pool = BackendPool(
-            backends=[_backend("grok", _dies("usage balance exhausted")), _backend("codex", _ok("ok"))]
-        )
+        pool = BackendPool(backends=[_backend("grok", _dies("usage balance exhausted")), _backend("codex", _ok("ok"))])
         asyncio.run(pool.complete("p"))
 
         assert any("grok" in note for note in pool.retired)

--- a/tests/unit/test_experts/test_backend_pool_failover.py
+++ b/tests/unit/test_experts/test_backend_pool_failover.py
@@ -1,0 +1,150 @@
+"""Spreading a run across prepaid plans, and moving on as each runs out.
+
+The failure this pins was watched repeatedly rather than imagined: a study or
+brief died on one plan's weekly cap while three other plans sat idle, and the
+run was restarted by hand against a different `--plan`.
+
+The distinction that makes the pool adaptive rather than merely redundant: a
+plan that is out of quota fails identically for every remaining call, so it is
+retired from rotation. A prompt that fails is one call, and gets one retry
+somewhere else.
+"""
+
+import asyncio
+
+import pytest
+
+from deepr.experts.backend_pool import BackendPool, PooledBackend
+
+
+def _backend(name: str, behaviour):
+    return PooledBackend(name=name, completion=behaviour)
+
+
+def _ok(text: str):
+    async def run(prompt: str) -> str:
+        return text
+
+    return run
+
+
+def _dies(message: str):
+    async def run(prompt: str) -> str:
+        raise RuntimeError(message)
+
+    return run
+
+
+def _dies_after(n: int, message: str, text: str = "ok"):
+    state = {"calls": 0}
+
+    async def run(prompt: str) -> str:
+        state["calls"] += 1
+        if state["calls"] > n:
+            raise RuntimeError(message)
+        return text
+
+    return run
+
+
+class TestAnExhaustedPlanIsRetired:
+    def test_it_moves_to_the_next_plan_rather_than_failing(self):
+        pool = BackendPool(
+            backends=[
+                _backend("grok", _dies("API error (status 402 Payment Required): usage balance exhausted")),
+                _backend("codex", _ok("from codex")),
+            ]
+        )
+        assert asyncio.run(pool.complete("p")) == "from codex"
+
+    def test_the_dead_plan_leaves_rotation_instead_of_being_re_poked(self):
+        """Round-robin used to hand it work every cycle and waste a call."""
+        grok = _backend("grok", _dies("quota exhausted"))
+        pool = BackendPool(backends=[grok, _backend("codex", _ok("ok"))])
+
+        for _ in range(4):
+            asyncio.run(pool.complete("p"))
+
+        assert grok.calls == 1, "an exhausted plan must be asked exactly once"
+        assert pool.names == ["codex"]
+
+    def test_retirement_is_reported_rather_than_silent(self):
+        pool = BackendPool(
+            backends=[_backend("grok", _dies("usage balance exhausted")), _backend("codex", _ok("ok"))]
+        )
+        asyncio.run(pool.complete("p"))
+
+        assert any("grok" in note for note in pool.retired)
+
+    def test_a_plan_that_dies_mid_run_is_retired_then(self):
+        """The real shape: it worked, then the weekly cap hit."""
+        grok = _backend("grok", _dies_after(1, "429 rate limit"))
+        pool = BackendPool(backends=[grok, _backend("codex", _ok("codex"))])
+
+        first = asyncio.run(pool.complete("p"))
+        second = asyncio.run(pool.complete("p"))
+        third = asyncio.run(pool.complete("p"))
+
+        assert first == "ok"
+        assert second == third == "codex"
+        assert pool.names == ["codex"]
+
+    def test_every_plan_running_out_raises_and_names_them_all(self):
+        pool = BackendPool(
+            backends=[_backend("grok", _dies("quota exhausted")), _backend("codex", _dies("quota exhausted"))]
+        )
+        with pytest.raises(Exception) as caught:
+            asyncio.run(pool.complete("p"))
+
+        assert "quota" in str(caught.value).lower()
+        assert pool.backends == []
+
+
+class TestAPromptFailureIsNotAPlanFailure:
+    def test_a_bad_prompt_retries_elsewhere_without_retiring_anything(self):
+        """A prompt that fails twice is usually the prompt."""
+        pool = BackendPool(
+            backends=[_backend("grok", _dies("no JSON object in response")), _backend("codex", _ok("recovered"))]
+        )
+        assert asyncio.run(pool.complete("p")) == "recovered"
+        assert pool.retired == []
+        assert len(pool.names) == 2
+
+    def test_it_gives_up_after_one_retry_rather_than_walking_the_pool(self):
+        pool = BackendPool(
+            backends=[
+                _backend("a", _dies("bad prompt")),
+                _backend("b", _dies("bad prompt")),
+                _backend("c", _ok("never reached")),
+            ]
+        )
+        with pytest.raises(RuntimeError):
+            asyncio.run(pool.complete("p"))
+
+        assert len(pool.names) == 3, "a prompt failure must not shrink the pool"
+
+
+class TestReporting:
+    def test_usage_shows_where_the_work_actually_went(self):
+        pool = BackendPool(backends=[_backend("grok", _ok("a")), _backend("codex", _ok("b"))])
+        asyncio.run(pool.complete("p"))
+        asyncio.run(pool.complete("p"))
+
+        usage = pool.usage()
+        assert usage["grok"]["calls"] == 1
+        assert usage["codex"]["calls"] == 1
+
+    def test_chunk_size_is_the_smallest_member_can_hold(self):
+        """A chunk sized for the largest would break on the tightest, and the
+        run cannot know which member serves any given call."""
+        pool = BackendPool(
+            backends=[
+                PooledBackend(name="a", completion=_ok("x"), chunk_chars=200_000),
+                PooledBackend(name="b", completion=_ok("x"), chunk_chars=14_000),
+            ]
+        )
+        assert pool.chunk_chars == 14_000
+
+    def test_an_empty_pool_says_so_rather_than_hanging(self):
+        with pytest.raises(RuntimeError, match="no plan-quota backend"):
+            asyncio.run(BackendPool().complete("p"))

--- a/tests/unit/test_experts/test_consult_context.py
+++ b/tests/unit/test_experts/test_consult_context.py
@@ -232,3 +232,36 @@ class TestBriefRoundTrip:
         path = tmp_path / "brief.json"
         path.write_text("{not json", encoding="utf-8")
         assert load_brief(path) is None
+
+
+class TestBriefedExpertWithoutBeliefs:
+    """acquire -> study -> brief never writes the claim ledger.
+
+    Consult gated its whole path on beliefs.json existing, so an expert with a
+    corpus, findings and positions all on disk answered "no stored belief
+    context is available". Observed live on a freshly built expert.
+    """
+
+    def test_a_brief_alone_produces_a_perspective(self, tmp_path, monkeypatch, brief):
+        import json
+
+        from deepr.experts import briefed_perspective as bp
+
+        (tmp_path / "brief.json").write_text(json.dumps(brief.to_dict()), encoding="utf-8")
+        monkeypatch.setattr(bp, "canonical_expert_dir", lambda name: tmp_path, raising=False)
+        monkeypatch.setattr("deepr.experts.paths.canonical_expert_dir", lambda name: tmp_path)
+
+        class _P:
+            def __init__(self, **kw):
+                self.__dict__.update(kw)
+
+        result = bp.briefed_perspective_without_beliefs("latency clusters", "E", "d", _P)
+
+        assert result is not None
+        assert result.context["source"] == "brief"
+
+    def test_no_brief_falls_through_rather_than_inventing(self, tmp_path, monkeypatch):
+        from deepr.experts import briefed_perspective as bp
+
+        monkeypatch.setattr("deepr.experts.paths.canonical_expert_dir", lambda name: tmp_path)
+        assert bp.briefed_perspective_without_beliefs("q", "E", "d", object) is None

--- a/tests/unit/test_experts/test_consult_quality.py
+++ b/tests/unit/test_experts/test_consult_quality.py
@@ -43,6 +43,7 @@ from deepr.experts.research_reservation_store import ResearchReservationStore
 from deepr.experts.semantic_model_gate import _mark_zero_dollar_client
 from deepr.observability.cost_ledger import CostLedger
 from deepr.services.metered_call import MeteredCallAccountingError
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -50,7 +51,7 @@ def _profile() -> ExpertProfile:
         name="Consult Quality Expert",
         vector_store_id="vs-consult-quality",
         domain="agentic consult quality",
-        knowledge_cutoff_date=datetime(2026, 6, 27, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
     )
     manifest = ExpertManifest(
         expert_name=profile.name,

--- a/tests/unit/test_experts/test_corpus_acquire.py
+++ b/tests/unit/test_experts/test_corpus_acquire.py
@@ -13,7 +13,6 @@ import pytest
 from deepr.experts.corpus_acquire import _as_source_text, acquire_sources
 from deepr.experts.corpus_store import CorpusStore, content_hash
 
-
 _BODY = "Retained pages must clear the nav-shell guard, so fixture bodies are realistic rather than a few words. " * 4
 
 

--- a/tests/unit/test_experts/test_corpus_search.py
+++ b/tests/unit/test_experts/test_corpus_search.py
@@ -186,3 +186,35 @@ class TestReporting:
     def test_arms_that_found_nothing_appears_in_the_payload(self):
         result = SearchResult(attempted_arms={"adversarial"})
         assert result.to_dict()["arms_that_found_nothing"] == ["adversarial"]
+
+
+class TestCoverageIsJudgedAgainstThePlan:
+    """The gate was hardcoded to 5 while ARMS held 6.
+
+    A plan containing all six arms could satisfy the gate with one arm never
+    run, and which arm got skipped was whatever the interleave left last.
+    Comparing against ``len(ARMS)`` instead would break the other way: many
+    plans carry no terminology queries at all, so the gate would never open
+    and every query would run - the request burst the early stop exists to
+    prevent.
+    """
+
+    def test_a_six_arm_plan_is_not_covered_by_five(self):
+        result = SearchResult(
+            planned_arms={"descriptive", "adversarial", "genre", "primary", "recency", "terminology"},
+            attempted_arms={"descriptive", "adversarial", "genre", "primary", "recency"},
+        )
+        assert not result.every_arm_tried
+
+    def test_a_five_arm_plan_is_covered_by_its_own_five(self):
+        arms = {"descriptive", "adversarial", "genre", "primary", "recency"}
+        assert SearchResult(planned_arms=arms, attempted_arms=set(arms)).every_arm_tried
+
+    def test_a_real_plan_can_reach_coverage_at_all(self):
+        """Guards the regression that would silence early stopping entirely."""
+        plan = plan_queries("widgets")
+        planned = {q.arm for q in plan.queries if q.arm}
+        assert SearchResult(planned_arms=planned, attempted_arms=planned).every_arm_tried
+
+    def test_a_hand_built_result_does_not_read_as_permanently_incomplete(self):
+        assert SearchResult(attempted_arms={"descriptive"}).every_arm_tried

--- a/tests/unit/test_experts/test_corpus_search.py
+++ b/tests/unit/test_experts/test_corpus_search.py
@@ -1,0 +1,140 @@
+"""Search carries the plan's questions to the network and nothing more.
+
+The discipline being tested is restraint: no ranking beyond the engine's, no
+relevance judgment, no filtering on content. Selection belongs to the plan
+upstream and the independence measurement downstream, and a search module that
+also judged quality would put three decisions in one place with no way to
+inspect any of them.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from deepr.experts.acquisition_plan import plan_queries
+from deepr.experts.corpus_search import (
+    SearchHit,
+    SearchResult,
+    parse_result_urls,
+    run_search_plan,
+    search_once,
+)
+
+_HTML = """
+<a href="https://duckduckgo.com/y.js?ad=1">ad</a>
+<a href="https://example.org/one">One</a>
+<a href="https://example.org/one">One again</a>
+<a href="https://other.test/two">Two</a>
+<a href="https://cdn.test/logo.png">image</a>
+"""
+
+
+def _client(pages):
+    """A stubbed HTTP client. Deepr's search is one POST; nothing else."""
+    calls = []
+
+    class _Stub:
+        async def post(self, url, data=None, headers=None):
+            calls.append(data["q"])
+            body = pages.get(data["q"], "")
+            if isinstance(body, Exception):
+                raise body
+            return SimpleNamespace(status_code=200, text=body)
+
+        async def aclose(self):
+            return None
+
+    stub = _Stub()
+    stub.calls = calls
+    return stub
+
+
+class TestParsing:
+    def test_engine_and_asset_links_are_not_candidates(self):
+        urls = parse_result_urls(_HTML, limit=10)
+        assert "https://example.org/one" in urls
+        assert not any("duckduckgo" in u or u.endswith(".png") for u in urls)
+
+    def test_order_is_the_engines_order(self):
+        """Deepr has no basis for a better ranking; inventing one hides a judgment."""
+        assert parse_result_urls(_HTML, limit=10) == ["https://example.org/one", "https://other.test/two"]
+
+    def test_duplicates_collapse(self):
+        assert parse_result_urls(_HTML, limit=10).count("https://example.org/one") == 1
+
+    def test_limit_is_respected(self):
+        assert len(parse_result_urls(_HTML, limit=1)) == 1
+
+    def test_empty_html_yields_nothing_rather_than_raising(self):
+        assert parse_result_urls("", limit=5) == []
+
+
+class TestSearchOnce:
+    @pytest.mark.asyncio
+    async def test_a_failing_query_returns_empty_rather_than_raising(self):
+        """One dead query must not abort a plan of thirty."""
+        client = _client({"q": RuntimeError("network down")})
+        assert await search_once("q", client=client) == []
+
+
+class TestRunPlan:
+    @pytest.mark.asyncio
+    async def test_every_query_in_the_plan_is_carried_to_the_network(self):
+        plan = plan_queries("widgets")
+        client = _client({})
+        await run_search_plan(plan, client=client)
+        assert len(client.calls) == len(plan.queries)
+
+    @pytest.mark.asyncio
+    async def test_hits_record_the_arm_that_surfaced_them(self):
+        plan = plan_queries("widgets")
+        client = _client({q.text: _HTML for q in plan.by_arm("adversarial")})
+
+        result = await run_search_plan(plan, client=client)
+
+        assert result.hits
+        assert {h.arm for h in result.hits} == {"adversarial"}
+
+    @pytest.mark.asyncio
+    async def test_a_url_seen_twice_is_retained_once(self):
+        plan = plan_queries("widgets")
+        client = _client({q.text: _HTML for q in plan.queries})
+
+        result = await run_search_plan(plan, client=client)
+
+        assert len(result.hits) == len({h.url for h in result.hits})
+
+    @pytest.mark.asyncio
+    async def test_an_arm_whose_results_were_all_duplicates_is_still_reported(self):
+        """Observed twice live: such an arm was neither found nor failed.
+
+        Derived from failures alone it is invisible, which is a check passing
+        because its subject is absent rather than sound.
+        """
+        plan = plan_queries("widgets")
+        client = _client({q.text: _HTML for q in plan.queries})
+
+        result = await run_search_plan(plan, client=client)
+
+        empty = result.arms_that_found_nothing()
+        assert "genre" in empty
+        assert "descriptive" not in empty
+
+    @pytest.mark.asyncio
+    async def test_the_url_ceiling_says_what_it_did_not_run(self):
+        plan = plan_queries("widgets")
+        client = _client({q.text: _HTML for q in plan.queries})
+
+        result = await run_search_plan(plan, max_urls=1, client=client)
+
+        assert any("unrun" in f for f in result.failures)
+
+
+class TestReporting:
+    def test_distinct_hosts_collapses_www(self):
+        result = SearchResult(hits=[SearchHit(url="https://www.a.org/x", query="q")])
+        assert result.distinct_hosts == {"a.org"}
+
+    def test_arms_that_found_nothing_appears_in_the_payload(self):
+        result = SearchResult(attempted_arms={"adversarial"})
+        assert result.to_dict()["arms_that_found_nothing"] == ["adversarial"]

--- a/tests/unit/test_experts/test_corpus_search.py
+++ b/tests/unit/test_experts/test_corpus_search.py
@@ -15,6 +15,7 @@ from deepr.experts.acquisition_plan import plan_queries
 from deepr.experts.corpus_search import (
     SearchHit,
     SearchResult,
+    interleave_by_arm,
     parse_result_urls,
     run_search_plan,
     search_once,
@@ -74,7 +75,7 @@ class TestSearchOnce:
     async def test_a_failing_query_returns_empty_rather_than_raising(self):
         """One dead query must not abort a plan of thirty."""
         client = _client({"q": RuntimeError("network down")})
-        assert await search_once("q", client=client) == []
+        assert await search_once("q", client=client, min_interval_s=0) == []
 
 
 class TestRunPlan:
@@ -82,7 +83,7 @@ class TestRunPlan:
     async def test_every_query_in_the_plan_is_carried_to_the_network(self):
         plan = plan_queries("widgets")
         client = _client({})
-        await run_search_plan(plan, client=client)
+        await run_search_plan(plan, client=client, min_interval_s=0)
         assert len(client.calls) == len(plan.queries)
 
     @pytest.mark.asyncio
@@ -90,7 +91,7 @@ class TestRunPlan:
         plan = plan_queries("widgets")
         client = _client({q.text: _HTML for q in plan.by_arm("adversarial")})
 
-        result = await run_search_plan(plan, client=client)
+        result = await run_search_plan(plan, client=client, min_interval_s=0)
 
         assert result.hits
         assert {h.arm for h in result.hits} == {"adversarial"}
@@ -100,7 +101,7 @@ class TestRunPlan:
         plan = plan_queries("widgets")
         client = _client({q.text: _HTML for q in plan.queries})
 
-        result = await run_search_plan(plan, client=client)
+        result = await run_search_plan(plan, client=client, min_interval_s=0)
 
         assert len(result.hits) == len({h.url for h in result.hits})
 
@@ -114,7 +115,7 @@ class TestRunPlan:
         plan = plan_queries("widgets")
         client = _client({q.text: _HTML for q in plan.queries})
 
-        result = await run_search_plan(plan, client=client)
+        result = await run_search_plan(plan, client=client, min_interval_s=0)
 
         empty = result.arms_that_found_nothing()
         assert "genre" in empty
@@ -125,9 +126,56 @@ class TestRunPlan:
         plan = plan_queries("widgets")
         client = _client({q.text: _HTML for q in plan.queries})
 
-        result = await run_search_plan(plan, max_urls=1, client=client)
+        result = await run_search_plan(plan, max_urls=1, client=client, min_interval_s=0)
 
-        assert any("unrun" in f for f in result.failures)
+        assert "ceiling" in result.stopped_early
+        assert result.unrun_queries > 0
+
+
+class TestEarlyStopping:
+    """Running every query put ~120 requests at one free endpoint in a burst.
+
+    Three builds came back rate-limited with zero results, which is
+    indistinguishable from a subject nobody has written about. The goal was
+    never to run every query; it was a corpus spanning enough publishers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_plan_stops_once_enough_hosts_are_found(self):
+        plan = plan_queries("widgets")
+        client = _client({q.text: _HTML for q in plan.queries})
+
+        result = await run_search_plan(plan, target_hosts=2, client=client, min_interval_s=0)
+
+        assert "distinct hosts" in result.stopped_early
+        assert len(client.calls) < len(plan.queries)
+
+    @pytest.mark.asyncio
+    async def test_it_will_not_stop_before_every_arm_has_run(self):
+        """Coverage reached in the descriptive arm is the popular half only."""
+        plan = plan_queries("widgets")
+        client = _client({q.text: _HTML for q in plan.queries})
+
+        result = await run_search_plan(plan, target_hosts=1, client=client, min_interval_s=0)
+
+        assert result.every_arm_tried
+        assert {"adversarial", "primary"} <= result.attempted_arms
+
+    @pytest.mark.asyncio
+    async def test_arms_are_interleaved_so_an_early_stop_is_unbiased(self):
+        plan = plan_queries("widgets")
+        arms = [q.arm for q in interleave_by_arm(list(plan.queries))]
+        assert len(set(arms[:4])) == 4, "the first queries must span arms, not repeat one"
+
+    @pytest.mark.asyncio
+    async def test_running_the_whole_plan_is_still_possible(self):
+        plan = plan_queries("widgets")
+        client = _client({})
+
+        result = await run_search_plan(plan, client=client, min_interval_s=0)
+
+        assert not result.stopped_early
+        assert len(client.calls) == len(plan.queries)
 
 
 class TestReporting:

--- a/tests/unit/test_experts/test_evidence_graph.py
+++ b/tests/unit/test_experts/test_evidence_graph.py
@@ -1,0 +1,231 @@
+"""The chain from a claim to a passage, stored as edges instead of recomputed.
+
+Every edge here is copied from a field that already existed - corpus_shas on a
+finding, supported_by on a position - so the graph is a change of storage, not
+a new claim. What it buys is the questions that were expensive across two flat
+files: which positions reach no source at all, which evidence nothing uses, and
+which passages the claims actually rest on.
+"""
+
+from types import SimpleNamespace
+
+from deepr.experts.evidence_graph import (
+    EDGE_ANCHORED_IN,
+    EDGE_RESTS_ON,
+    EvidenceGraph,
+    build_graph,
+    render_graph,
+)
+
+
+def _finding(finding_id, shas, *, grounded=True, title="", lens="failure"):
+    return SimpleNamespace(
+        finding_id=finding_id, corpus_shas=list(shas), is_grounded=grounded, title=title or finding_id, lens=lens
+    )
+
+
+def _study(findings, started_at="2026-08-01T00:00:00+00:00"):
+    return SimpleNamespace(findings=findings, started_at=started_at)
+
+
+def _position(question, supported_by, **attrs):
+    return SimpleNamespace(question=question, supported_by=list(supported_by), stance="", likelihood="", confidence="", **attrs)
+
+
+def _entry(sha, publisher="a.org", title=""):
+    """A CorpusStore entry, which names the hash `sha256`."""
+    return SimpleNamespace(
+        sha256=sha, publisher=publisher, origin_key=f"url:{publisher}", title=title, added_at="", fetched_at=""
+    )
+
+
+def _built(**overrides):
+    """A small, fully connected expert: one position, two findings, two sources."""
+    defaults = dict(
+        expert_name="E",
+        study=_study([_finding("failure-1", ["sha-a"]), _finding("failure-2", ["sha-b"])]),
+        brief=SimpleNamespace(positions=[_position("Does X hold?", ["failure-1", "failure-2"])]),
+        corpus_entries=[_entry("sha-a"), _entry("sha-b", "b.org")],
+        at="2026-08-09T00:00:00+00:00",
+    )
+    return build_graph(**{**defaults, **overrides})
+
+
+class TestTheChainIsCopiedNotInferred:
+    def test_findings_point_at_the_sources_their_anchors_were_found_in(self):
+        graph = _built()
+        anchored = [(e.source, e.target) for e in graph.edges if e.kind == EDGE_ANCHORED_IN]
+        assert ("failure-1", "sha-a") in anchored
+        assert ("failure-2", "sha-b") in anchored
+
+    def test_positions_point_at_the_findings_they_were_recorded_as_resting_on(self):
+        graph = _built()
+        rests = [(e.source, e.target) for e in graph.edges if e.kind == EDGE_RESTS_ON]
+        assert ("position-1", "failure-1") in rests
+
+    def test_an_anchor_naming_a_source_no_longer_retained_is_not_an_edge(self):
+        """A dangling edge would let a claim cite a passage nobody can open."""
+        graph = _built(
+            study=_study([_finding("failure-1", ["sha-a", "sha-deleted"])]),
+            corpus_entries=[_entry("sha-a")],
+        )
+        assert [e.target for e in graph.edges if e.kind == EDGE_ANCHORED_IN] == ["sha-a"]
+
+    def test_a_position_citing_a_finding_that_does_not_exist_is_not_an_edge(self):
+        graph = _built(brief=SimpleNamespace(positions=[_position("Q", ["failure-1", "invented-9"])]))
+        assert [e.target for e in graph.edges if e.kind == EDGE_RESTS_ON] == ["failure-1"]
+
+
+class TestTheIntegrityCheck:
+    def test_a_position_resting_on_ungrounded_findings_reaches_no_source(self):
+        """Not partially grounded. A bibliography citing empty pages."""
+        graph = _built(
+            study=_study([_finding("failure-1", [], grounded=False)]),
+            brief=SimpleNamespace(positions=[_position("Q", ["failure-1"])]),
+        )
+        assert not graph.reaches_a_source("position-1")
+        assert [p.id for p in graph.unsupported_positions] == ["position-1"]
+
+    def test_one_working_path_is_enough(self):
+        graph = _built(
+            study=_study([_finding("failure-1", []), _finding("failure-2", ["sha-b"])]),
+            brief=SimpleNamespace(positions=[_position("Q", ["failure-1", "failure-2"])]),
+            corpus_entries=[_entry("sha-b", "b.org")],
+        )
+        assert graph.reaches_a_source("position-1")
+        assert graph.unsupported_positions == []
+
+    def test_a_position_citing_nothing_reaches_no_source(self):
+        graph = _built(brief=SimpleNamespace(positions=[_position("Q", [])]))
+        assert graph.unsupported_positions
+
+
+class TestIsFormed:
+    def test_a_traversal_is_required_not_a_node_count(self):
+        """A study with no brief has nodes and no path between claim and passage."""
+        graph = _built(brief=SimpleNamespace(positions=[]))
+        assert graph.findings and graph.sources
+        assert not graph.is_formed
+
+    def test_a_complete_chain_is_formed(self):
+        assert _built().is_formed
+
+    def test_positions_that_all_dangle_are_not_formed(self):
+        graph = _built(
+            study=_study([_finding("failure-1", [], grounded=False)]),
+            brief=SimpleNamespace(positions=[_position("Q", ["failure-1"])]),
+        )
+        assert not graph.is_formed
+
+    def test_an_empty_expert_is_not_formed(self):
+        assert not build_graph(expert_name="E", study=None, brief=None).is_formed
+
+
+class TestWhatTheEdgesMakeVisible:
+    def test_evidence_no_position_uses_is_surfaced(self):
+        graph = _built(
+            study=_study([_finding("failure-1", ["sha-a"]), _finding("failure-9", ["sha-b"])]),
+            brief=SimpleNamespace(positions=[_position("Q", ["failure-1"])]),
+        )
+        assert [f.id for f in graph.unused_findings] == ["failure-9"]
+
+    def test_ungrounded_findings_are_not_reported_as_wasted_evidence(self):
+        """They are a different problem, and reporting them here buries it."""
+        graph = _built(
+            study=_study([_finding("failure-1", ["sha-a"]), _finding("failure-9", [], grounded=False)]),
+            brief=SimpleNamespace(positions=[_position("Q", ["failure-1"])]),
+        )
+        assert graph.unused_findings == []
+
+    def test_concentration_is_counted_per_claim_not_per_document(self):
+        """Thirty sources where every position routes through two of them."""
+        graph = _built(
+            study=_study([_finding("f1", ["sha-a"]), _finding("f2", ["sha-a"]), _finding("f3", ["sha-b"])]),
+            brief=SimpleNamespace(
+                positions=[_position("Q1", ["f1"]), _position("Q2", ["f2"]), _position("Q3", ["f3"])]
+            ),
+            corpus_entries=[_entry("sha-a", title="Load bearing"), _entry("sha-b", "b.org", title="Minor")],
+        )
+        assert graph.load_bearing_sources()[0] == ("Load bearing", 2)
+
+    def test_one_position_reaching_a_source_twice_counts_it_once(self):
+        graph = _built(
+            study=_study([_finding("f1", ["sha-a"]), _finding("f2", ["sha-a"])]),
+            brief=SimpleNamespace(positions=[_position("Q", ["f1", "f2"])]),
+            corpus_entries=[_entry("sha-a", title="Only")],
+        )
+        assert graph.load_bearing_sources() == [("Only", 1)]
+
+
+class TestTemporal:
+    def test_findings_carry_the_study_time_they_came_from(self):
+        graph = _built()
+        assert all(f.first_seen == "2026-08-01T00:00:00+00:00" for f in graph.findings)
+
+    def test_sources_prefer_their_own_retention_time_over_the_build_time(self):
+        entry = SimpleNamespace(
+            sha256="sha-a", publisher="a.org", origin_key="u", title="t", added_at="2026-01-01T00:00:00+00:00"
+        )
+        assert _built(corpus_entries=[entry]).sources[0].first_seen == "2026-01-01T00:00:00+00:00"
+
+
+class TestTheAttributeNameThatBrokeEverything:
+    """A CorpusStore entry names its hash `sha256`; findings say `corpus_shas`.
+
+    Reading `sha` produced source nodes with empty ids, dropped every
+    anchored_in edge as dangling, and reported a fully supported expert as
+    having no position that reaches a source. A wrong attribute name is
+    indistinguishable from real corruption in the output, which is what makes
+    it worth a test rather than a fix.
+    """
+
+    def test_the_store_s_own_attribute_name_is_read(self):
+        graph = _built(corpus_entries=[SimpleNamespace(sha256="sha-a", publisher="p", origin_key="u", title="t")])
+        assert [n.id for n in graph.sources] == ["sha-a"]
+        assert graph.is_formed
+
+    def test_an_entry_with_no_hash_at_all_is_skipped_rather_than_given_an_empty_id(self):
+        graph = _built(corpus_entries=[SimpleNamespace(publisher="p", origin_key="u", title="t")])
+        assert graph.sources == []
+
+
+class TestSerialization:
+    def test_the_graph_round_trips(self):
+        original = _built()
+        restored = EvidenceGraph.from_dict(original.to_dict())
+        assert restored.stats() == original.stats()
+        assert restored.is_formed
+
+    def test_node_attributes_survive_the_round_trip(self):
+        restored = EvidenceGraph.from_dict(_built().to_dict())
+        assert restored.findings[0].attrs["lens"] == "failure"
+
+    def test_junk_nodes_and_edges_are_dropped_rather_than_raising(self):
+        restored = EvidenceGraph.from_dict(
+            {"nodes": ["not a dict", {"kind": "source"}], "edges": ["nope", {"from": "a"}]}
+        )
+        assert restored.nodes == []
+        assert restored.edges == []
+
+    def test_the_stats_travel_with_the_payload(self):
+        assert _built().to_dict()["stats"]["is_formed"] is True
+
+
+class TestRender:
+    def test_an_unformed_graph_says_so_rather_than_reporting_counts(self):
+        text = render_graph(_built(brief=SimpleNamespace(positions=[])))
+        assert "pile of nodes" in text
+
+    def test_unsupported_positions_lead_the_document(self):
+        graph = _built(
+            study=_study([_finding("f1", [], grounded=False)]),
+            brief=SimpleNamespace(positions=[_position("Does X hold?", ["f1"])]),
+        )
+        text = render_graph(graph)
+        assert "Positions that reach no source" in text
+        assert "Does X hold?" in text
+
+    def test_a_clean_graph_reports_what_the_claims_rest_on(self):
+        text = render_graph(_built())
+        assert "What the claims actually rest on" in text
+        assert "reach no source" not in text

--- a/tests/unit/test_experts/test_evidence_graph.py
+++ b/tests/unit/test_experts/test_evidence_graph.py
@@ -61,7 +61,8 @@ class TestTheChainIsCopiedNotInferred:
     def test_positions_point_at_the_findings_they_were_recorded_as_resting_on(self):
         graph = _built()
         rests = [(e.source, e.target) for e in graph.edges if e.kind == EDGE_RESTS_ON]
-        assert ("position-1", "failure-1") in rests
+        assert graph.positions[0].id.startswith("position-")
+        assert (graph.positions[0].id, "failure-1") in rests
 
     def test_an_anchor_naming_a_source_no_longer_retained_is_not_an_edge(self):
         """A dangling edge would let a claim cite a passage nobody can open."""
@@ -76,6 +77,34 @@ class TestTheChainIsCopiedNotInferred:
         assert [e.target for e in graph.edges if e.kind == EDGE_RESTS_ON] == ["failure-1"]
 
 
+class TestAPositionKeepsItsIdentity:
+    """`position-{index}` made position-3 a different question every rebuild,
+    which is why nothing outside the graph file could ever refer to one."""
+
+    def test_the_same_question_keeps_the_same_id_across_rebuilds(self):
+        first = _built()
+        rebuilt = _built()
+        assert [p.id for p in first.positions] == [p.id for p in rebuilt.positions]
+
+    def test_reordering_the_brief_does_not_reassign_ids(self):
+        one = SimpleNamespace(positions=[_position("Q1", []), _position("Q2", [])])
+        two = SimpleNamespace(positions=[_position("Q2", []), _position("Q1", [])])
+
+        ids_one = {p.label: p.id for p in _built(brief=one).positions}
+        ids_two = {p.label: p.id for p in _built(brief=two).positions}
+
+        assert ids_one == ids_two
+
+    def test_a_different_question_gets_a_different_id(self):
+        graph = _built(brief=SimpleNamespace(positions=[_position("Q1", []), _position("Q2", [])]))
+        assert len({p.id for p in graph.positions}) == 2
+
+    def test_a_position_with_no_question_still_gets_an_id(self):
+        """Falls back to the positional form rather than colliding on empty."""
+        graph = _built(brief=SimpleNamespace(positions=[_position("", [])]))
+        assert graph.positions[0].id
+
+
 class TestTheIntegrityCheck:
     def test_a_position_resting_on_ungrounded_findings_reaches_no_source(self):
         """Not partially grounded. A bibliography citing empty pages."""
@@ -83,8 +112,8 @@ class TestTheIntegrityCheck:
             study=_study([_finding("failure-1", [], grounded=False)]),
             brief=SimpleNamespace(positions=[_position("Q", ["failure-1"])]),
         )
-        assert not graph.reaches_a_source("position-1")
-        assert [p.id for p in graph.unsupported_positions] == ["position-1"]
+        assert not graph.reaches_a_source(graph.positions[0].id)
+        assert graph.unsupported_positions == graph.positions
 
     def test_one_working_path_is_enough(self):
         graph = _built(
@@ -92,7 +121,7 @@ class TestTheIntegrityCheck:
             brief=SimpleNamespace(positions=[_position("Q", ["failure-1", "failure-2"])]),
             corpus_entries=[_entry("sha-b", "b.org")],
         )
-        assert graph.reaches_a_source("position-1")
+        assert graph.reaches_a_source(graph.positions[0].id)
         assert graph.unsupported_positions == []
 
     def test_a_position_citing_nothing_reaches_no_source(self):

--- a/tests/unit/test_experts/test_evidence_graph.py
+++ b/tests/unit/test_experts/test_evidence_graph.py
@@ -29,7 +29,9 @@ def _study(findings, started_at="2026-08-01T00:00:00+00:00"):
 
 
 def _position(question, supported_by, **attrs):
-    return SimpleNamespace(question=question, supported_by=list(supported_by), stance="", likelihood="", confidence="", **attrs)
+    return SimpleNamespace(
+        question=question, supported_by=list(supported_by), stance="", likelihood="", confidence="", **attrs
+    )
 
 
 def _entry(sha, publisher="a.org", title=""):

--- a/tests/unit/test_experts/test_expert_health.py
+++ b/tests/unit/test_experts/test_expert_health.py
@@ -1,0 +1,158 @@
+"""Grading a fleet, where certainty counts against you.
+
+The rule that shapes everything here: an expert holding no unresolved dissent,
+naming no open questions and admitting no weakness is not finished, it is
+closed. A full cup has no room. So openness is graded, and S requires all four
+of deep, current, holding a perspective, and still looking.
+"""
+
+import json
+
+import pytest
+
+from deepr.experts.expert_health import ExpertHealth, assess_expert, fleet_summary
+
+
+def _strong(**overrides) -> ExpertHealth:
+    """An expert with nothing structurally wrong with it."""
+    defaults = dict(
+        name="E",
+        sources=20,
+        effective_origins=12.0,
+        findings=90,
+        grounded_findings=88,
+        cross_source_findings=20,
+        positions=6,
+        falsifiable_positions=6,
+        positions_with_dissent=3,
+        standpoint="I read this as a systems problem.",
+        open_questions=4,
+        known_weaknesses=2,
+        age_days=2,
+    )
+    return ExpertHealth(**{**defaults, **overrides})
+
+
+class TestTheLadder:
+    def test_all_four_reaches_s(self):
+        assert _strong().grade == "S"
+
+    def test_a_closed_expert_cannot_reach_s(self):
+        """The full cup. Certainty is where learning stops, not where it ends."""
+        closed = _strong(positions_with_dissent=0, open_questions=0, known_weaknesses=0)
+        assert not closed.is_open
+        assert closed.grade == "B"
+
+    def test_no_perspective_caps_below_s(self):
+        """Positions without a reading is a well-organized index."""
+        assert _strong(standpoint="").grade == "A"
+
+    def test_open_but_not_hungry_caps_below_s(self):
+        """Leaving a gap unstated is not the same as going after it."""
+        assert _strong(known_weaknesses=0).grade == "A"
+
+    def test_stale_drops_further(self):
+        assert _strong(age_days=400).grade == "B"
+
+    def test_deep_but_not_current_is_a_not_s(self):
+        assert _strong(age_days=60).grade == "A"
+
+
+class TestCapsThatIgnoreDepth:
+    def test_no_brief_caps_at_c_however_large_the_corpus(self):
+        """An expert that has not landed anywhere is a search index."""
+        assert _strong(positions=0, falsifiable_positions=0).grade == "C"
+
+    def test_never_studied_is_c(self):
+        assert _strong(findings=0, grounded_findings=0, positions=0).grade == "C"
+
+    def test_claims_without_a_corpus_is_d(self):
+        """Nothing can be re-read or checked, whatever the claim count says."""
+        health = ExpertHealth(name="E", beliefs=150)
+        assert health.grade == "D"
+        assert "no retained corpus" in health.next_action
+
+    def test_nothing_at_all_is_f(self):
+        assert ExpertHealth(name="E").grade == "F"
+
+
+class TestDepthIsOrigins:
+    def test_many_documents_from_one_publisher_do_not_count_as_depth(self):
+        thin = _strong(sources=30, effective_origins=1.0)
+        assert thin.grade == "B"
+        assert "one publisher agreeing with itself" in thin.next_action
+
+    def test_unverifiable_findings_block_the_climb(self):
+        shaky = _strong(grounded_findings=10)
+        assert shaky.grade == "B"
+        assert "verifiable" in shaky.next_action
+
+
+class TestNextAction:
+    @pytest.mark.parametrize(
+        ("health", "expected"),
+        [
+            (ExpertHealth(name="E"), "Empty"),
+            (_strong(findings=0, grounded_findings=0, positions=0), "never read"),
+            (_strong(positions=0, falsifiable_positions=0), "never briefed"),
+            (_strong(falsifiable_positions=4), "would overturn them"),
+            (_strong(standpoint=""), "no reading of its own"),
+            (_strong(open_questions=0), "no open questions"),
+            (_strong(known_weaknesses=0), "nothing it is weak on"),
+            (_strong(age_days=90), "Re-acquire to reach S"),
+            (_strong(), "S tier"),
+        ],
+    )
+    def test_every_grade_comes_with_something_to_do(self, health, expected):
+        """A letter nobody can act on is not triage."""
+        assert expected in health.next_action
+
+    def test_only_one_action_is_offered(self):
+        """Five things to do is the same as none."""
+        assert "\n" not in _strong(sources=0, beliefs=5).next_action
+
+
+class TestAssessFromDisk:
+    def test_a_bare_directory_grades_f_rather_than_raising(self, tmp_path):
+        assert assess_expert("E", tmp_path).grade == "F"
+
+    def test_study_and_brief_are_read_together(self, tmp_path):
+        (tmp_path / "study.json").write_text(
+            json.dumps(
+                {
+                    "totals": {"findings": 40, "grounded_findings": 39, "cross_source_findings": 8},
+                    "independence": {"source_count": 12, "effective_source_count": 9.0},
+                    "started_at": "2026-08-07T00:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "brief.json").write_text(
+            json.dumps(
+                {
+                    "positions": [{"is_falsifiable": True, "unresolved_dissent": "one source disputes it"}],
+                    "state": {"live": ["a"], "unknown": ["b"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        health = assess_expert("E", tmp_path)
+
+        assert health.sources == 12
+        assert health.effective_origins == 9.0
+        assert health.positions_with_dissent == 1
+        assert health.is_open
+
+    def test_a_corrupt_artifact_does_not_take_the_fleet_down(self, tmp_path):
+        (tmp_path / "study.json").write_text("{not json", encoding="utf-8")
+        assert assess_expert("E", tmp_path).grade == "F"
+
+
+class TestFleetSummary:
+    def test_closed_experts_are_counted_separately(self):
+        fleet = [_strong(), _strong(positions_with_dissent=0, open_questions=0, known_weaknesses=0)]
+        summary = fleet_summary(fleet)
+        assert summary["closed"] == 1
+        assert summary["s_tier"] == 1
+        assert summary["consultable"] == 2

--- a/tests/unit/test_experts/test_expert_health.py
+++ b/tests/unit/test_experts/test_expert_health.py
@@ -181,6 +181,71 @@ class TestAssessFromDisk:
         assert assess_expert("E", tmp_path).grade == "F"
 
 
+class TestConsultRecencyComesFromRealTraces:
+    """The shape was guessed wrong once and silently graded everything A.
+
+    A consult trace nests under `input` and `output`. Reading a flat
+    `experts_consulted` found nothing, so every expert looked never-consulted
+    and the top of the ladder was unreachable for a second reason.
+    """
+
+    def _write(self, path, records):
+        path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+    def test_both_requested_and_consulted_names_are_read(self, tmp_path, monkeypatch):
+        from datetime import UTC, datetime
+
+        from deepr.experts import expert_health
+
+        traces = [
+            {
+                "recorded_at": "2026-08-01T00:00:00+00:00",
+                "input": {"requested_experts": ["Asked For"]},
+                "output": {"experts_consulted": ["Actually Spoke"]},
+            }
+        ]
+        monkeypatch.setattr(expert_health, "_load_traces_for_recency", lambda limit: traces, raising=False)
+        monkeypatch.setattr(
+            "deepr.experts.consult_traces.load_consult_traces", lambda limit=500: traces, raising=False
+        )
+
+        seen = expert_health.last_consulted_days(now=datetime(2026, 8, 6, tzinfo=UTC))
+
+        assert seen["Asked For"] == 5
+        assert seen["Actually Spoke"] == 5
+
+    def test_a_failed_consult_still_counts_as_being_used(self, tmp_path, monkeypatch):
+        """The question is whether anyone wants this expert, not whether it worked."""
+        from datetime import UTC, datetime
+
+        from deepr.experts import expert_health
+
+        traces = [
+            {
+                "recorded_at": "2026-08-05T00:00:00+00:00",
+                "input": {"requested_experts": ["Wanted"]},
+                "output": {},
+                "status": "failed",
+            }
+        ]
+        monkeypatch.setattr(
+            "deepr.experts.consult_traces.load_consult_traces", lambda limit=500: traces, raising=False
+        )
+
+        assert expert_health.last_consulted_days(now=datetime(2026, 8, 6, tzinfo=UTC))["Wanted"] == 1
+
+    def test_an_unreadable_trace_store_grades_everyone_never_consulted(self, monkeypatch):
+        """Being wrong toward 'no evidence of use' is the safe direction."""
+        from deepr.experts import expert_health
+
+        def boom(limit=500):
+            raise OSError("trace store is gone")
+
+        monkeypatch.setattr("deepr.experts.consult_traces.load_consult_traces", boom, raising=False)
+
+        assert expert_health.last_consulted_days() == {}
+
+
 class TestFleetSummary:
     def test_closed_experts_are_counted_separately(self):
         fleet = [_strong(), _strong(positions_with_dissent=0, open_questions=0, known_weaknesses=0)]

--- a/tests/unit/test_experts/test_expert_health.py
+++ b/tests/unit/test_experts/test_expert_health.py
@@ -18,7 +18,9 @@ def _strong(**overrides) -> ExpertHealth:
     defaults = dict(
         name="E",
         sources=20,
-        effective_origins=12.0,
+        origin_count=12,
+        dominant_share=0.2,
+        effective_origins=10.5,
         findings=90,
         grounded_findings=88,
         cross_source_findings=20,
@@ -77,10 +79,26 @@ class TestCapsThatIgnoreDepth:
 
 
 class TestDepthIsOrigins:
-    def test_many_documents_from_one_publisher_do_not_count_as_depth(self):
-        thin = _strong(sources=30, effective_origins=1.0)
+    def test_one_publisher_is_not_depth_however_many_documents(self):
+        thin = _strong(sources=30, origin_count=1, dominant_share=1.0, effective_origins=1.0)
         assert thin.grade == "B"
         assert "one publisher agreeing with itself" in thin.next_action
+
+    def test_reading_more_of_the_best_source_does_not_lower_the_grade(self):
+        """exp(H) fell when an expert read more of its most authoritative source.
+
+        Five publishers with one document each scored 5.0; the same five with
+        twenty from the best scored 1.98 and were told to acquire elsewhere.
+        The grade-optimal move was deleting evidence.
+        """
+        spread = _strong(sources=5, origin_count=5, dominant_share=0.2, effective_origins=5.0)
+        deeper = _strong(sources=24, origin_count=5, dominant_share=0.4, effective_origins=1.98)
+        assert deeper.grade == spread.grade == "S"
+
+    def test_capture_is_caught_by_share_not_entropy(self):
+        captured = _strong(sources=24, origin_count=5, dominant_share=0.83, effective_origins=1.98)
+        assert captured.is_captured
+        assert captured.grade == "B"
 
     def test_unverifiable_findings_block_the_climb(self):
         shaky = _strong(grounded_findings=10)
@@ -156,3 +174,58 @@ class TestFleetSummary:
         assert summary["closed"] == 1
         assert summary["s_tier"] == 1
         assert summary["consultable"] == 2
+
+
+class TestOpennessIsJudgedAgainstTheSubject:
+    """Certainty is correct in some subjects, and the rule was domain-blind.
+
+    Expert intuition is valid where the environment is regular and feedback
+    exists; on a frozen specification there is no live dissent and an expert
+    manufacturing some is worse than one reporting none. Measured expert
+    organizations also err toward under-confidence, worst on the hardest
+    questions, so a uniform penalty on certainty pushes the wrong way.
+    """
+
+    def test_a_settled_subject_is_not_penalized_for_having_no_dissent(self):
+        settled = _strong(contention_findings=0, positions_with_dissent=0)
+        assert not settled.subject_is_contested
+        assert settled.is_open
+        assert settled.grade == "S"
+
+    def test_a_brief_that_dropped_real_contention_is_closed(self):
+        """The lens found it and the brief carried none of it. That is averaging."""
+        dropped = _strong(contention_findings=15, positions_with_dissent=0)
+        assert dropped.dropped_the_dissent
+        assert not dropped.is_open
+        assert dropped.grade == "B"
+        assert "carried none of them" in dropped.next_action
+
+    def test_carrying_the_dissent_forward_clears_it(self):
+        kept = _strong(contention_findings=15, positions_with_dissent=4)
+        assert not kept.dropped_the_dissent
+        assert kept.grade == "S"
+
+    def test_declared_openness_alone_cannot_rescue_a_dropped_dissent(self):
+        """Self-report is the weakest channel; it must not override the check."""
+        loud = _strong(contention_findings=15, positions_with_dissent=0, open_questions=9, known_weaknesses=9)
+        assert not loud.is_open
+        assert loud.grade == "B"
+
+    def test_contention_findings_are_read_from_the_study(self, tmp_path):
+        import json as _json
+
+        (tmp_path / "study.json").write_text(
+            _json.dumps(
+                {
+                    "totals": {"findings": 40, "grounded_findings": 39, "cross_source_findings": 8},
+                    "independence": {"source_count": 12, "origin_count": 9, "dominant_share": 0.2},
+                    "outcomes": [
+                        {"lens": "contention", "finding_count": 6},
+                        {"lens": "failure", "finding_count": 34},
+                    ],
+                    "started_at": "2026-08-07T00:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert assess_expert("E", tmp_path).contention_findings == 6

--- a/tests/unit/test_experts/test_expert_health.py
+++ b/tests/unit/test_experts/test_expert_health.py
@@ -1,9 +1,12 @@
-"""Grading a fleet, where certainty counts against you.
+"""Grading a fleet as a progression, one thing per rung.
 
-The rule that shapes everything here: an expert holding no unresolved dissent,
-naming no open questions and admitting no weakness is not finished, it is
-closed. A full cup has no room. So openness is graded, and S requires all four
-of deep, current, holding a perspective, and still looking.
+F nothing, D claims without a corpus, C researched but holding no view, B
+consultable with something structurally wrong, A well researched with a
+perspective, S all of A plus current plus actually in use.
+
+The only difference between A and S is liveness, and that is deliberate: an
+expert nobody has asked anything in six months is not being kept honest by
+anything, however good its corpus looks.
 """
 
 import json
@@ -31,33 +34,39 @@ def _strong(**overrides) -> ExpertHealth:
         open_questions=4,
         known_weaknesses=2,
         age_days=2,
+        consulted_days_ago=3,
     )
     return ExpertHealth(**{**defaults, **overrides})
 
 
 class TestTheLadder:
-    def test_all_four_reaches_s(self):
+    def test_well_researched_current_and_in_use_is_s(self):
         assert _strong().grade == "S"
 
-    def test_a_closed_expert_cannot_reach_s(self):
-        """The full cup. Certainty is where learning stops, not where it ends."""
-        closed = _strong(positions_with_dissent=0, open_questions=0, known_weaknesses=0)
-        assert not closed.is_open
+    def test_never_consulted_is_the_difference_between_a_and_s(self):
+        """A good expert nothing has ever asked is not being kept honest."""
+        unused = _strong(consulted_days_ago=-1)
+        assert not unused.is_in_use
+        assert unused.grade == "A"
+
+    def test_consulted_long_ago_is_also_only_a(self):
+        assert _strong(consulted_days_ago=200).grade == "A"
+
+    def test_not_current_is_a_however_much_it_is_used(self):
+        assert _strong(age_days=60).grade == "A"
+        assert _strong(age_days=400).grade == "A"
+
+    def test_no_perspective_is_b_not_a(self):
+        """Positions without a reading is a well-organized index, not an expert."""
+        assert _strong(standpoint="").grade == "B"
+
+    def test_a_closed_expert_that_dropped_real_dissent_is_b(self):
+        closed = _strong(contention_findings=12, positions_with_dissent=0)
         assert closed.grade == "B"
 
-    def test_no_perspective_caps_below_s(self):
-        """Positions without a reading is a well-organized index."""
-        assert _strong(standpoint="").grade == "A"
-
-    def test_open_but_not_hungry_caps_below_s(self):
-        """Leaving a gap unstated is not the same as going after it."""
-        assert _strong(known_weaknesses=0).grade == "A"
-
-    def test_stale_drops_further(self):
-        assert _strong(age_days=400).grade == "B"
-
-    def test_deep_but_not_current_is_a_not_s(self):
-        assert _strong(age_days=60).grade == "A"
+    def test_naming_no_weakness_no_longer_blocks_the_top(self):
+        """Self-reported hunger was the weakest signal here and gated the most."""
+        assert _strong(known_weaknesses=0, open_questions=0).grade == "S"
 
 
 class TestCapsThatIgnoreDepth:
@@ -95,6 +104,9 @@ class TestDepthIsOrigins:
         deeper = _strong(sources=24, origin_count=5, dominant_share=0.4, effective_origins=1.98)
         assert deeper.grade == spread.grade == "S"
 
+    def test_too_few_publishers_is_b_however_current_and_used(self):
+        assert _strong(origin_count=2).grade == "B"
+
     def test_capture_is_caught_by_share_not_entropy(self):
         captured = _strong(sources=24, origin_count=5, dominant_share=0.83, effective_origins=1.98)
         assert captured.is_captured
@@ -118,6 +130,8 @@ class TestNextAction:
             (_strong(open_questions=0), "no open questions"),
             (_strong(known_weaknesses=0), "nothing it is weak on"),
             (_strong(age_days=90), "Re-acquire to reach S"),
+            (_strong(consulted_days_ago=-1), "nobody has consulted it ever"),
+            (_strong(consulted_days_ago=120), "in 120 days"),
             (_strong(), "S tier"),
         ],
     )
@@ -172,8 +186,14 @@ class TestFleetSummary:
         fleet = [_strong(), _strong(positions_with_dissent=0, open_questions=0, known_weaknesses=0)]
         summary = fleet_summary(fleet)
         assert summary["closed"] == 1
-        assert summary["s_tier"] == 1
+        assert summary["s_tier"] == 2
         assert summary["consultable"] == 2
+
+    def test_good_experts_nobody_uses_are_counted(self):
+        """The triage question this answers: what did we build and abandon."""
+        summary = fleet_summary([_strong(), _strong(consulted_days_ago=-1)])
+        assert summary["unused"] == 1
+        assert summary["s_tier"] == 1
 
 
 class TestOpennessIsJudgedAgainstTheSubject:
@@ -191,6 +211,11 @@ class TestOpennessIsJudgedAgainstTheSubject:
         assert not settled.subject_is_contested
         assert settled.is_open
         assert settled.grade == "S"
+
+    def test_a_settled_subject_that_declares_nothing_is_still_fine(self):
+        """Manufactured doubt on a frozen spec would be worse than none."""
+        quiet = _strong(contention_findings=0, positions_with_dissent=0, open_questions=0, known_weaknesses=0)
+        assert quiet.grade == "S"
 
     def test_a_brief_that_dropped_real_contention_is_closed(self):
         """The lens found it and the brief carried none of it. That is averaging."""

--- a/tests/unit/test_experts/test_expert_health.py
+++ b/tests/unit/test_experts/test_expert_health.py
@@ -146,9 +146,7 @@ class TestTheGraphGate:
 
     def test_it_is_read_from_the_evidence_graph_on_disk(self, tmp_path):
         (tmp_path / "graph").mkdir()
-        (tmp_path / "graph" / "evidence.json").write_text(
-            json.dumps({"stats": {"is_formed": True}}), encoding="utf-8"
-        )
+        (tmp_path / "graph" / "evidence.json").write_text(json.dumps({"stats": {"is_formed": True}}), encoding="utf-8")
         assert assess_expert("E", tmp_path).graph_is_formed
 
     def test_a_missing_graph_reads_as_not_formed_rather_than_raising(self, tmp_path):
@@ -291,9 +289,7 @@ class TestConsultRecencyComesFromRealTraces:
             }
         ]
         monkeypatch.setattr(expert_health, "_load_traces_for_recency", lambda limit: traces, raising=False)
-        monkeypatch.setattr(
-            "deepr.experts.consult_traces.load_consult_traces", lambda limit=500: traces, raising=False
-        )
+        monkeypatch.setattr("deepr.experts.consult_traces.load_consult_traces", lambda limit=500: traces, raising=False)
 
         seen = expert_health.last_consulted_days(now=datetime(2026, 8, 6, tzinfo=UTC))
 
@@ -314,9 +310,7 @@ class TestConsultRecencyComesFromRealTraces:
                 "status": "failed",
             }
         ]
-        monkeypatch.setattr(
-            "deepr.experts.consult_traces.load_consult_traces", lambda limit=500: traces, raising=False
-        )
+        monkeypatch.setattr("deepr.experts.consult_traces.load_consult_traces", lambda limit=500: traces, raising=False)
 
         assert expert_health.last_consulted_days(now=datetime(2026, 8, 6, tzinfo=UTC))["Wanted"] == 1
 

--- a/tests/unit/test_experts/test_expert_health.py
+++ b/tests/unit/test_experts/test_expert_health.py
@@ -1,12 +1,15 @@
 """Grading a fleet as a progression, one thing per rung.
 
-F nothing, D claims without a corpus, C researched but holding no view, B
-consultable with something structurally wrong, A well researched with a
-perspective, S all of A plus current plus actually in use.
+Five gates hold an expert at B: a thin or captured corpus, findings that reach
+no passage, a small or unrecorded model doing the reading, no standpoint of its
+own, and - separating A from S - staleness or disuse.
 
-The only difference between A and S is liveness, and that is deliberate: an
-expert nobody has asked anything in six months is not being kept honest by
-anything, however good its corpus looks.
+What is deliberately *not* a gate matters as much. Cross-source counts,
+contention carried forward, declared open questions and named weaknesses were
+all inferences about quality from a structural proxy, and every one of them is
+satisfied by a shallow reading as easily as a deep one. Which model did the
+reading predicts more than all of them together and is a fact rather than an
+inference.
 """
 
 import json
@@ -35,6 +38,8 @@ def _strong(**overrides) -> ExpertHealth:
         known_weaknesses=2,
         age_days=2,
         consulted_days_ago=3,
+        graph_is_formed=True,
+        model_tier="frontier",
     )
     return ExpertHealth(**{**defaults, **overrides})
 
@@ -60,13 +65,94 @@ class TestTheLadder:
         """Positions without a reading is a well-organized index, not an expert."""
         assert _strong(standpoint="").grade == "B"
 
-    def test_a_closed_expert_that_dropped_real_dissent_is_b(self):
+    def test_dropped_dissent_is_now_a_warning_rather_than_a_gate(self):
+        """Kept as a signal, demoted from the ladder.
+
+        It is an inference about quality from a structural proxy, and a
+        shallow reading satisfies it as easily as a deep one. The next action
+        still says so; the letter no longer does.
+        """
         closed = _strong(contention_findings=12, positions_with_dissent=0)
-        assert closed.grade == "B"
+        assert closed.dropped_the_dissent
+        assert closed.grade == "S"
 
     def test_naming_no_weakness_no_longer_blocks_the_top(self):
         """Self-reported hunger was the weakest signal here and gated the most."""
         assert _strong(known_weaknesses=0, open_questions=0).grade == "S"
+
+
+class TestTheModelThatDidTheReading:
+    """Weighted heavily, because it is a fact rather than an inference.
+
+    A small model and a frontier model reading the same corpus through the
+    same lenses produce different experts, and nothing downstream recovers the
+    difference: a shallow finding is grounded, traceable and cross-source
+    exactly as easily as a deep one.
+    """
+
+    def test_a_small_model_holds_an_otherwise_perfect_expert_at_b(self):
+        assert _strong(model_tier="small").grade == "B"
+
+    def test_an_unrecorded_model_does_not_pass_either(self):
+        """Absence of evidence must not read as evidence of quality."""
+        assert _strong(model_tier="unknown").grade == "B"
+
+    def test_mid_tier_is_enough(self):
+        assert _strong(model_tier="mid").grade == "S"
+
+    def test_the_next_action_names_the_tier_and_says_what_to_do(self):
+        action = _strong(model_tier="small").next_action
+        assert "small model" in action
+        assert "plan backend" in action
+
+    def test_a_study_predating_the_stamp_is_classified_from_capacity_source(self, tmp_path):
+        """The whole existing fleet is rankable without re-studying anything.
+
+        capacity_source has always recorded which backend ran, and the tier is
+        derived from exactly that. Requiring the newer stamp would have burned
+        hours of quota to recover information already on disk.
+        """
+        (tmp_path / "study.json").write_text(
+            json.dumps({"capacity_source": "plan:grok", "totals": {"findings": 1}}), encoding="utf-8"
+        )
+        assert assess_expert("E", tmp_path).model_tier == "frontier"
+
+    def test_the_newer_stamp_wins_where_both_are_present(self, tmp_path):
+        (tmp_path / "study.json").write_text(
+            json.dumps(
+                {
+                    "capacity_source": "plan:grok",
+                    "model_provenance": {"capacity_source": "local:qwen2.5:7b", "tier": "small"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert assess_expert("E", tmp_path).model_tier == "small"
+
+
+class TestTheGraphGate:
+    """Structural, and stronger than the ratio beside it.
+
+    grounded_ratio averages - half the findings anchoring nowhere still scores
+    0.5 and reads as middling. This asks whether any claim connects to a
+    passage at all.
+    """
+
+    def test_an_expert_whose_claims_reach_no_passage_is_held_at_b(self):
+        assert _strong(graph_is_formed=False).grade == "B"
+
+    def test_the_next_action_points_at_the_command_that_shows_the_break(self):
+        assert "expert graph" in _strong(graph_is_formed=False).next_action
+
+    def test_it_is_read_from_the_evidence_graph_on_disk(self, tmp_path):
+        (tmp_path / "graph").mkdir()
+        (tmp_path / "graph" / "evidence.json").write_text(
+            json.dumps({"stats": {"is_formed": True}}), encoding="utf-8"
+        )
+        assert assess_expert("E", tmp_path).graph_is_formed
+
+    def test_a_missing_graph_reads_as_not_formed_rather_than_raising(self, tmp_path):
+        assert not assess_expert("E", tmp_path).graph_is_formed
 
 
 class TestCapsThatIgnoreDepth:
@@ -282,12 +368,15 @@ class TestOpennessIsJudgedAgainstTheSubject:
         quiet = _strong(contention_findings=0, positions_with_dissent=0, open_questions=0, known_weaknesses=0)
         assert quiet.grade == "S"
 
-    def test_a_brief_that_dropped_real_contention_is_closed(self):
-        """The lens found it and the brief carried none of it. That is averaging."""
+    def test_a_brief_that_dropped_real_contention_is_still_reported(self):
+        """The lens found it and the brief carried none of it. That is averaging.
+
+        Still detected and still the next action; no longer a gate on the
+        letter, because it is a proxy rather than a fact.
+        """
         dropped = _strong(contention_findings=15, positions_with_dissent=0)
         assert dropped.dropped_the_dissent
         assert not dropped.is_open
-        assert dropped.grade == "B"
         assert "carried none of them" in dropped.next_action
 
     def test_carrying_the_dissent_forward_clears_it(self):
@@ -299,7 +388,6 @@ class TestOpennessIsJudgedAgainstTheSubject:
         """Self-report is the weakest channel; it must not override the check."""
         loud = _strong(contention_findings=15, positions_with_dissent=0, open_questions=9, known_weaknesses=9)
         assert not loud.is_open
-        assert loud.grade == "B"
 
     def test_contention_findings_are_read_from_the_study(self, tmp_path):
         import json as _json

--- a/tests/unit/test_experts/test_expert_layout.py
+++ b/tests/unit/test_experts/test_expert_layout.py
@@ -1,0 +1,180 @@
+"""The layout has to be readable mid-migration, or the fleet moves as one.
+
+The whole reason reads fall back to the old path is that 57 experts cannot be
+moved atomically, and a reader that only knows the new layout would report an
+established expert as empty. These tests hold that property, and the two that
+protect against data loss: never overwrite, and never delete a directory that
+has something in it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deepr.experts import expert_layout
+from deepr.experts.expert_layout import MOVES, is_migrated, part_in, resolve_relative
+from deepr.experts.expert_migration import migrate_all, migrate_expert
+
+
+@pytest.fixture
+def expert_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "flooding"
+    directory.mkdir()
+    return directory
+
+
+class TestReadingDuringMigration:
+    def test_an_unmigrated_expert_is_still_readable(self, expert_dir: Path) -> None:
+        (expert_dir / "brief.json").write_text('{"positions": []}', encoding="utf-8")
+        assert part_in(expert_dir, "hold_current").name == "brief.json"
+
+    def test_a_migrated_expert_reads_the_new_path(self, expert_dir: Path) -> None:
+        (expert_dir / "hold").mkdir()
+        (expert_dir / "hold" / "current.json").write_text("{}", encoding="utf-8")
+        assert part_in(expert_dir, "hold_current").parent.name == "hold"
+
+    def test_the_new_path_wins_when_both_exist(self, expert_dir: Path) -> None:
+        """Otherwise a stale leftover would shadow the current file."""
+        (expert_dir / "brief.json").write_text("{}", encoding="utf-8")
+        (expert_dir / "hold").mkdir()
+        (expert_dir / "hold" / "current.json").write_text("{}", encoding="utf-8")
+        assert part_in(expert_dir, "hold_current").parent.name == "hold"
+
+    def test_an_absent_part_resolves_to_the_new_path_for_writing(self, expert_dir: Path) -> None:
+        """A writer must never be handed the old location."""
+        assert part_in(expert_dir, "hold_current") == expert_dir / "hold" / "current.json"
+
+    def test_an_unknown_part_is_a_typo_not_a_silent_miss(self, expert_dir: Path) -> None:
+        with pytest.raises(KeyError):
+            part_in(expert_dir, "positions")
+
+    def test_the_expert_root_is_looked_up_late(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patching the root has to take effect, or tests hit the real fleet."""
+        monkeypatch.setattr(expert_layout._paths, "canonical_expert_dir", lambda name: tmp_path / name)
+        assert expert_layout.hold_current_path("x") == tmp_path / "x" / "hold" / "current.json"
+
+
+class TestResolvingByPath:
+    def test_a_path_that_moved_falls_back(self, expert_dir: Path) -> None:
+        (expert_dir / "study.json").write_text("{}", encoding="utf-8")
+        assert resolve_relative(expert_dir, "noticed/current.json").name == "study.json"
+
+    def test_a_path_that_never_moved_resolves_to_itself(self, expert_dir: Path) -> None:
+        assert resolve_relative(expert_dir, "corpus/index.jsonl") == expert_dir / "corpus" / "index.jsonl"
+
+
+class TestMigrating:
+    def test_content_survives_the_move(self, expert_dir: Path) -> None:
+        (expert_dir / "brief.json").write_text('{"positions": [{"question": "Q"}]}', encoding="utf-8")
+        migrate_expert(expert_dir)
+        moved = json.loads((expert_dir / "hold" / "current.json").read_text(encoding="utf-8"))
+        assert moved["positions"] == [{"question": "Q"}]
+        assert not (expert_dir / "brief.json").exists()
+
+    def test_every_declared_move_is_handled(self, expert_dir: Path) -> None:
+        """Guards against a part being added to the table and never migrated."""
+        for old, _ in MOVES:
+            source = expert_dir / old
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text("{}", encoding="utf-8")
+        result = migrate_expert(expert_dir)
+        assert len(result.moved) == len(MOVES)
+        for old, new in MOVES:
+            assert (expert_dir / new).exists()
+            assert not (expert_dir / old).exists()
+
+    def test_running_twice_changes_nothing_the_second_time(self, expert_dir: Path) -> None:
+        (expert_dir / "brief.json").write_text("{}", encoding="utf-8")
+        migrate_expert(expert_dir)
+        assert not migrate_expert(expert_dir).changed
+
+    def test_a_dry_run_touches_nothing(self, expert_dir: Path) -> None:
+        (expert_dir / "brief.json").write_text("{}", encoding="utf-8")
+        result = migrate_expert(expert_dir, dry_run=True)
+        assert result.moved == [("brief.json", "hold/current.json")]
+        assert (expert_dir / "brief.json").exists()
+        assert not (expert_dir / "hold").exists()
+
+    def test_a_conflict_keeps_both_and_reports(self, expert_dir: Path) -> None:
+        """Picking a winner silently is how the wrong file gets kept."""
+        (expert_dir / "brief.json").write_text('{"who": "old"}', encoding="utf-8")
+        (expert_dir / "hold").mkdir()
+        (expert_dir / "hold" / "current.json").write_text('{"who": "new"}', encoding="utf-8")
+        result = migrate_expert(expert_dir)
+        assert result.conflicts == [("brief.json", "hold/current.json")]
+        assert (expert_dir / "brief.json").exists()
+        assert result.needs_attention
+
+    def test_is_migrated_tracks_the_move(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(expert_layout._paths, "canonical_expert_dir", lambda name: tmp_path / name)
+        directory = tmp_path / "flooding"
+        directory.mkdir()
+        (directory / "brief.json").write_text("{}", encoding="utf-8")
+        assert not is_migrated("flooding")
+        migrate_expert(directory)
+        assert is_migrated("flooding")
+
+
+class TestNotLosingData:
+    def test_empty_v1_directories_are_removed(self, expert_dir: Path) -> None:
+        (expert_dir / "conversations").mkdir()
+        result = migrate_expert(expert_dir)
+        assert "conversations" in result.removed_dead_dirs
+        assert not (expert_dir / "conversations").exists()
+
+    def test_a_v1_directory_with_content_is_left_alone(self, expert_dir: Path) -> None:
+        (expert_dir / "conversations").mkdir()
+        (expert_dir / "conversations" / "log.json").write_text("{}", encoding="utf-8")
+        result = migrate_expert(expert_dir)
+        assert result.kept_nonempty_dead_dirs == ["conversations"]
+        assert (expert_dir / "conversations" / "log.json").exists()
+
+    def test_live_v1_storage_is_not_touched_at_all(self, expert_dir: Path) -> None:
+        """`beliefs/` and `knowledge/` hold ~4MB across the real fleet.
+
+        They were on the dead list until a dry run showed 38 and 35 experts
+        with content in them. They are live storage, so the migration neither
+        removes them nor reports them as needing attention.
+        """
+        for live in ("beliefs", "knowledge"):
+            (expert_dir / live).mkdir()
+            (expert_dir / live / "data.json").write_text("{}", encoding="utf-8")
+        result = migrate_expert(expert_dir)
+        assert result.kept_nonempty_dead_dirs == []
+        assert not result.needs_attention
+        for live in ("beliefs", "knowledge"):
+            assert (expert_dir / live / "data.json").exists()
+
+    def test_the_evidence_graph_keeps_its_directory(self, expert_dir: Path) -> None:
+        """`graph/` only goes away when the perspective was all that was in it."""
+        graph = expert_dir / "graph"
+        graph.mkdir()
+        (graph / "evidence.json").write_text("{}", encoding="utf-8")
+        (graph / "perspective.json").write_text("{}", encoding="utf-8")
+        migrate_expert(expert_dir)
+        assert (graph / "evidence.json").exists()
+        assert (expert_dir / "became" / "perspective.json").exists()
+
+    def test_the_corpus_does_not_move(self, expert_dir: Path) -> None:
+        corpus = expert_dir / "corpus"
+        corpus.mkdir()
+        (corpus / "index.jsonl").write_text("{}\n", encoding="utf-8")
+        migrate_expert(expert_dir)
+        assert (corpus / "index.jsonl").exists()
+
+
+class TestMigratingAFleet:
+    def test_every_expert_is_visited_in_a_stable_order(self, tmp_path: Path) -> None:
+        for name in ("cairn", "aster", "marlow"):
+            directory = tmp_path / name
+            directory.mkdir()
+            (directory / "brief.json").write_text("{}", encoding="utf-8")
+        results = migrate_all(tmp_path)
+        assert [r.expert_name for r in results] == ["aster", "cairn", "marlow"]
+        assert all(r.changed for r in results)
+
+    def test_a_missing_root_is_not_an_error(self, tmp_path: Path) -> None:
+        assert migrate_all(tmp_path / "nope") == []

--- a/tests/unit/test_experts/test_expert_profile_card.py
+++ b/tests/unit/test_experts/test_expert_profile_card.py
@@ -1,0 +1,113 @@
+"""The expert's own account of itself, and the name it answers to.
+
+The naming instruction has one job and originally failed it. Told to pick
+something "that fits the subject", four experts named themselves after terms
+from their own fields - Green Tax, In-Domain Mirage, Hard Skip, The Missing
+Ledger. Those are things an expert would write *about*. An economist is not
+called "Marginal Utility".
+"""
+
+from deepr.experts.expert_profile_card import (
+    ExpertProfile,
+    PerspectiveShift,
+    build_profile_prompt,
+    parse_profile,
+)
+
+AT = "2026-08-09T00:00:00+00:00"
+
+
+class TestItAsksForANameNotAThesis:
+    def test_the_distinction_is_stated_first(self):
+        prompt = build_profile_prompt("E", material="M")
+        assert "a name for yourself. Not a label for your argument" in prompt
+
+    def test_the_failure_mode_is_named_with_its_own_bad_output(self):
+        """Showing the actual mistake beats describing it abstractly."""
+        prompt = build_profile_prompt("E", material="M")
+        assert "Green Tax" in prompt
+        assert "In-Domain Mirage" in prompt
+
+    def test_it_asks_for_temperament_rather_than_subject_fit(self):
+        prompt = build_profile_prompt("E", material="M")
+        assert "temperament" in prompt
+        assert "a name, not a topic" in prompt
+
+    def test_it_does_not_demand_a_human_first_name(self):
+        """An entity may be called something other than Dave."""
+        assert "does not have to be a human first name" in build_profile_prompt("E", material="M")
+
+
+class TestThePriorStandpointIsShown:
+    def test_a_prior_reading_reaches_the_prompt(self):
+        """It cannot report a change it was never shown."""
+        prior = ExpertProfile(expert_name="E", standpoint="An earlier reading.")
+        assert "An earlier reading." in build_profile_prompt("E", material="M", prior=prior)
+
+    def test_no_prior_shows_no_earlier_reading(self):
+        assert "Your prior standpoint, from an earlier reading" not in build_profile_prompt("E", material="M")
+
+    def test_a_prior_with_no_standpoint_is_not_shown_as_one(self):
+        prior = ExpertProfile(expert_name="E", standpoint="")
+        prompt = build_profile_prompt("E", material="M", prior=prior)
+        assert "Your prior standpoint, from an earlier reading" not in prompt
+
+
+class TestParsingCarriesHistoryForward:
+    def test_a_reported_change_becomes_a_shift(self):
+        prior = ExpertProfile(expert_name="E", standpoint="I read it as naming.")
+        profile = parse_profile(
+            {
+                "chosen_name": "Ledger",
+                "standpoint": "I read it as retraction.",
+                "shift_from_prior": "I read it as naming.",
+                "shift_because": "the failure lens moved it",
+            },
+            expert_name="E",
+            at=AT,
+            prior=prior,
+        )
+
+        assert len(profile.shifts) == 1
+        assert profile.shifts[0].because == "the failure lens moved it"
+
+    def test_earlier_shifts_survive(self):
+        """Append-only. Overwriting leaves the state a new expert is in."""
+        prior = ExpertProfile(expert_name="E", standpoint="second")
+        prior.shifts = [PerspectiveShift(at="2026-01-01", was="first", now="second", because="x")]
+
+        profile = parse_profile(
+            {"standpoint": "third", "shift_from_prior": "second", "shift_because": "y"},
+            expert_name="E",
+            at=AT,
+            prior=prior,
+        )
+
+        assert [s.was for s in profile.shifts] == ["first", "second"]
+
+    def test_no_prior_means_no_shift_however_much_it_claims(self):
+        """A first profile cannot have changed from anything."""
+        profile = parse_profile(
+            {"standpoint": "now", "shift_from_prior": "invented", "shift_because": "invented"},
+            expert_name="E",
+            at=AT,
+            prior=None,
+        )
+        assert profile.shifts == []
+
+    def test_an_unchanged_standpoint_records_nothing(self):
+        prior = ExpertProfile(expert_name="E", standpoint="same")
+        profile = parse_profile(
+            {"standpoint": "same", "shift_from_prior": "same", "shift_because": "y"},
+            expert_name="E",
+            at=AT,
+            prior=prior,
+        )
+        assert profile.shifts == []
+
+    def test_the_corpus_state_is_stamped_on_the_profile(self):
+        profile = parse_profile(
+            {"standpoint": "s"}, expert_name="E", at=AT, corpus_fingerprint="abc123", sources_read=12
+        )
+        assert profile.corpus_fingerprint == "abc123"
+        assert profile.sources_read == 12

--- a/tests/unit/test_experts/test_expert_profile_card.py
+++ b/tests/unit/test_experts/test_expert_profile_card.py
@@ -111,3 +111,19 @@ class TestParsingCarriesHistoryForward:
         )
         assert profile.corpus_fingerprint == "abc123"
         assert profile.sources_read == 12
+
+
+class TestTheFaceItChose:
+    """Appearance is identity, so it has to survive a round trip like the name."""
+
+    def test_it_survives_a_round_trip(self) -> None:
+        profile = ExpertProfile.from_dict({"expert_name": "x", "appearance": "A surveyor at dusk."})
+        assert ExpertProfile.from_dict(profile.to_dict()).appearance == "A surveyor at dusk."
+
+    def test_a_profile_written_before_the_field_existed_still_loads(self) -> None:
+        assert ExpertProfile.from_dict({"expert_name": "x", "standpoint": "s"}).appearance == ""
+
+    def test_the_prompt_asks_for_it(self) -> None:
+        prompt = build_profile_prompt("flooding", material="...")
+        assert '"appearance"' in prompt
+        assert "not illustrate your topic" in prompt or "rather than\n  illustrate your topic" in prompt

--- a/tests/unit/test_experts/test_expert_semantic_recall.py
+++ b/tests/unit/test_experts/test_expert_semantic_recall.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-from datetime import UTC, datetime
 
 import pytest
 
@@ -14,6 +13,7 @@ from deepr.experts.expert_semantic_recall import (
     coerce_query_embedding,
 )
 from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -21,7 +21,7 @@ def _profile() -> ExpertProfile:
         name="Recall Surface Expert",
         vector_store_id="vs-recall-surface",
         domain="ai infrastructure",
-        knowledge_cutoff_date=datetime(2026, 6, 29, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
     )
 
 

--- a/tests/unit/test_experts/test_expert_time_helpers.py
+++ b/tests/unit/test_experts/test_expert_time_helpers.py
@@ -1,0 +1,60 @@
+"""The cutoff helpers must name a freshness band, not a calendar date.
+
+Sixteen tests hardcoded `datetime(2026, 6, 26)`, which read as `fresh` when
+they were written and passed for weeks. At 45 days of real elapsed time it
+crossed into `aging`, the self model started emitting an extra proposal, and
+four tests that index into `proposals[0]` began asserting against a different
+proposal. Nothing in the suite had changed.
+
+These tests hold the property that made that possible impossible: the band a
+helper produces is the same on any day it runs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import recent_cutoff, stale_cutoff
+
+_DOMAINS = ("consult reliability", "ai research", "medicine", "law")
+
+
+def _status(cutoff: datetime, domain: str) -> str:
+    profile = ExpertProfile(name="Probe", vector_store_id="vs-probe", domain=domain, knowledge_cutoff_date=cutoff)
+    return str(profile.get_freshness_status().get("status") or "")
+
+
+class TestTheBandDoesNotDriftWithTheCalendar:
+    @pytest.mark.parametrize("domain", _DOMAINS)
+    def test_recent_reads_as_fresh_in_every_domain(self, domain: str) -> None:
+        """Velocity differs by domain, so one age has to be safe for all."""
+        assert _status(recent_cutoff(), domain) == "fresh"
+
+    @pytest.mark.parametrize("domain", _DOMAINS)
+    def test_stale_is_never_fresh_in_any_domain(self, domain: str) -> None:
+        assert _status(stale_cutoff(), domain) != "fresh"
+
+    def test_the_age_it_produces_is_constant(self) -> None:
+        """The property that makes expiry impossible.
+
+        Freshness is a function of `now - cutoff`. A hardcoded date makes that
+        difference grow every day; a relative one keeps it fixed, so the band
+        is whatever it was on the day the test was written, forever. Asserting
+        the age directly is the honest form of "this will not expire" - the
+        alternative is re-deriving `now - (now - k) == k`, which is arithmetic
+        rather than a test.
+        """
+        age = datetime.now(UTC) - recent_cutoff()
+        assert timedelta(days=3) <= age <= timedelta(days=4)
+
+    def test_a_fixed_date_is_what_this_replaces(self) -> None:
+        """The regression itself: a hardcoded date drifts out of its band.
+
+        Asserted rather than described, so the reason these helpers exist
+        cannot quietly stop being true.
+        """
+        fixed = datetime(2026, 6, 26, tzinfo=UTC)
+        assert _status(fixed, "consult reliability") != _status(recent_cutoff(), "consult reliability")

--- a/tests/unit/test_experts/test_memory_card.py
+++ b/tests/unit/test_experts/test_memory_card.py
@@ -15,6 +15,7 @@ from deepr.experts.memory_card import (
 )
 from deepr.experts.metacognition import MetaCognitionTracker
 from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -23,7 +24,7 @@ def _profile() -> ExpertProfile:
         vector_store_id="vs-memory-card",
         domain="agent memory",
         description="Durable expert memory",
-        knowledge_cutoff_date=datetime(2026, 6, 26, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, tzinfo=UTC),
         installed_skills=["consult-review"],
     )

--- a/tests/unit/test_experts/test_model_provenance.py
+++ b/tests/unit/test_experts/test_model_provenance.py
@@ -1,0 +1,95 @@
+"""Which model read the corpus, and how coarse the answer honestly is.
+
+The point of this record: a 14B model and a frontier model reading the same
+corpus produce different experts, and no downstream statistic recovers the
+difference - a shallow finding is grounded, traceable and cross-source just as
+easily as a deep one. Unlike every other signal in expert_health, this one is a
+fact about a subprocess rather than an inference about quality from structure.
+"""
+
+from deepr.experts.model_provenance import (
+    TIER_FRONTIER,
+    TIER_MID,
+    TIER_SMALL,
+    TIER_UNKNOWN,
+    ModelProvenance,
+    at_least,
+    classify_tier,
+    record,
+    weakest,
+)
+
+
+class TestPlanBackends:
+    def test_a_vendor_agent_cli_is_frontier_class(self):
+        """The claim is about the family, not the exact checkpoint."""
+        for backend in ("claude", "codex", "grok", "antigravity"):
+            assert classify_tier(f"plan:{backend}") == TIER_FRONTIER, backend
+
+    def test_an_unrecognised_plan_is_unknown_rather_than_assumed_good(self):
+        assert classify_tier("plan:somethingnew") == TIER_UNKNOWN
+
+
+class TestLocalModels:
+    def test_size_comes_from_the_tag_because_that_is_where_it_is_stated(self):
+        assert classify_tier("local:qwen2.5:14b") == TIER_SMALL
+        assert classify_tier("local:mistral-small3.2:24b") == TIER_MID
+        assert classify_tier("local:llama-3.3-70b-instruct") == TIER_FRONTIER
+
+    def test_a_tag_with_no_parameter_count_is_unknown_not_guessed(self):
+        """mistral-small and mistral-large are the same string to a guess."""
+        assert classify_tier("local:mistral-small") == TIER_UNKNOWN
+        assert classify_tier("local:gemma") == TIER_UNKNOWN
+
+    def test_decimal_parameter_counts_parse(self):
+        assert classify_tier("local:phi-3.5:3.8b") == TIER_SMALL
+
+    def test_the_boundary_sizes_land_where_documented(self):
+        assert classify_tier("local:x:20b") == TIER_MID
+        assert classify_tier("local:x:19b") == TIER_SMALL
+        assert classify_tier("local:x:65b") == TIER_FRONTIER
+
+
+class TestTheWeakestLinkWins:
+    def test_an_expert_is_ranked_by_the_worst_reading_in_its_chain(self):
+        """A frontier brief over 7B findings inherits the 7B blind spots.
+
+        The brief can only rank and reconcile what it was handed; it cannot
+        recover a comparison that was never found.
+        """
+        chain = [record("plan:claude"), record("local:qwen2.5:7b"), record("plan:grok")]
+        assert weakest(chain).tier == TIER_SMALL
+
+    def test_artifacts_that_were_never_stamped_do_not_drag_the_rank_down(self):
+        """An older artifact predating this record is absent, not bad."""
+        chain = [record("plan:claude"), ModelProvenance()]
+        assert weakest(chain).tier == TIER_FRONTIER
+
+    def test_an_entirely_unstamped_expert_reports_unknown(self):
+        assert weakest([ModelProvenance(), ModelProvenance()]).tier == TIER_UNKNOWN
+
+    def test_an_empty_chain_is_unknown_rather_than_an_error(self):
+        assert weakest([]).tier == TIER_UNKNOWN
+
+
+class TestAtLeast:
+    def test_unknown_never_satisfies_a_floor(self):
+        """Absence of evidence must not read as evidence of quality."""
+        assert not at_least(TIER_UNKNOWN, TIER_SMALL)
+        assert not at_least(TIER_UNKNOWN, TIER_FRONTIER)
+
+    def test_a_higher_tier_satisfies_a_lower_floor(self):
+        assert at_least(TIER_FRONTIER, TIER_MID)
+        assert at_least(TIER_MID, TIER_MID)
+        assert not at_least(TIER_SMALL, TIER_MID)
+
+
+class TestSerialization:
+    def test_the_stamp_round_trips(self):
+        original = record("local:qwen2.5:14b", "qwen2.5:14b")
+        restored = ModelProvenance.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_a_corrupt_stamp_reads_as_unknown_rather_than_raising(self):
+        assert ModelProvenance.from_dict("not a dict").tier == TIER_UNKNOWN
+        assert ModelProvenance.from_dict({"tier": "amazing"}).tier == TIER_UNKNOWN

--- a/tests/unit/test_experts/test_monitor_promotion.py
+++ b/tests/unit/test_experts/test_monitor_promotion.py
@@ -22,6 +22,7 @@ from deepr.experts.monitor_promotion import (
     promote_monitor_proposal,
 )
 from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile() -> ExpertProfile:
@@ -29,7 +30,7 @@ def _profile() -> ExpertProfile:
         name="Monitor Promotion Expert",
         vector_store_id="vs-monitor-promotion",
         domain="consult reliability",
-        knowledge_cutoff_date=datetime(2026, 6, 26, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
     )
     manifest = ExpertManifest(
         expert_name=profile.name,

--- a/tests/unit/test_experts/test_next_actions.py
+++ b/tests/unit/test_experts/test_next_actions.py
@@ -14,6 +14,7 @@ from deepr.experts.next_actions import (
     build_expert_next_actions,
 )
 from deepr.experts.profile import ExpertProfile
+from tests.expert_time_helpers import stale_cutoff as _stale_cutoff
 
 
 def _profile(**overrides):
@@ -110,7 +111,7 @@ def test_missing_blueprint_is_the_first_foundation_action():
 
 
 def test_failed_loop_and_stale_state_prioritize_recovery_before_gap_fill():
-    profile = _profile(knowledge_cutoff_date=datetime(2020, 1, 1, tzinfo=UTC))
+    profile = _profile(knowledge_cutoff_date=_stale_cutoff())
     manifest = ExpertManifest(
         expert_name=profile.name,
         domain=profile.domain,

--- a/tests/unit/test_experts/test_notebook.py
+++ b/tests/unit/test_experts/test_notebook.py
@@ -1,6 +1,5 @@
 """Notebook render: readable, honest about gaps, byte-stable."""
 
-
 from deepr.experts.corpus_store import CorpusStore
 from deepr.experts.notebook import NOTEBOOK_MARKER, build_notebook
 from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult

--- a/tests/unit/test_experts/test_notebook.py
+++ b/tests/unit/test_experts/test_notebook.py
@@ -1,6 +1,5 @@
 """Notebook render: readable, honest about gaps, byte-stable."""
 
-import pytest
 
 from deepr.experts.corpus_store import CorpusStore
 from deepr.experts.notebook import NOTEBOOK_MARKER, build_notebook
@@ -116,7 +115,7 @@ class TestHonesty:
 class TestCoverage:
     def test_coverage_section_reports_what_was_skipped(self, tmp_path):
         store = CorpusStore("Notebook Expert", storage_dir=tmp_path / "corpus")
-        a, _ = store.add("alpha body text", origin_key="url:a.org", publisher="a.org")
+        _a, _ = store.add("alpha body text", origin_key="url:a.org", publisher="a.org")
         store.add("beta body text", origin_key="url:b.org", publisher="b.org")
 
         result = _result([_finding()])

--- a/tests/unit/test_experts/test_parent_budget_transaction.py
+++ b/tests/unit/test_experts/test_parent_budget_transaction.py
@@ -11,8 +11,8 @@ from deepr.experts.metered_mutation_gate import (
     require_metered_expert_mutation,
 )
 from deepr.experts.parent_budget_transaction import (
-    ChildCallState,
     GATED_METERED_LIFECYCLE_SURFACES,
+    ChildCallState,
     ParentBudgetError,
     ParentBudgetState,
     open_parent_budget_transaction,

--- a/tests/unit/test_experts/test_perspective_graph.py
+++ b/tests/unit/test_experts/test_perspective_graph.py
@@ -114,9 +114,7 @@ class TestWhatAFactModelWouldDiscard:
     def test_conduct_is_kept_even_though_it_has_no_truth_value(self):
         """'I refuse to average live contentions' is not a claim about the world."""
         graph = _built()
-        assert [c.text for c in graph.commitments] == [
-            "I refuse to average live contentions into false consensus."
-        ]
+        assert [c.text for c in graph.commitments] == ["I refuse to average live contentions into false consensus."]
         assert any(e.kind == EDGE_HOLDS for e in graph.edges)
 
     def test_its_own_agenda_is_kept_separately_from_corpus_gaps(self):

--- a/tests/unit/test_experts/test_perspective_graph.py
+++ b/tests/unit/test_experts/test_perspective_graph.py
@@ -1,0 +1,186 @@
+"""The biography of a viewpoint, not a store of what is true.
+
+The distinction under test throughout: this graph's nodes are moments of coming
+to see something and its edges are what changed what. An expert with two
+hundred well-anchored positions and no recorded shifts has never been moved by
+anything it read, which is the state a brand-new expert is already in.
+"""
+
+from itertools import pairwise
+from types import SimpleNamespace
+
+from deepr.experts.perspective_graph import (
+    EDGE_BECAME,
+    EDGE_HOLDS,
+    EDGE_MOVED_BY,
+    EDGE_PURSUING,
+    EDGE_THROUGH,
+    NODE_SHIFT,
+    NODE_STANDPOINT,
+    PerspectiveGraph,
+    build_perspective_graph,
+    render_perspective,
+)
+
+
+def _shift(was, now, because="new sources", at="2026-03-01T00:00:00+00:00", fingerprint=""):
+    return SimpleNamespace(was=was, now=now, because=because, at=at, corpus_fingerprint=fingerprint)
+
+
+def _profile(**overrides):
+    defaults = dict(
+        chosen_name="Hard Skip",
+        standpoint="I read this as an operational discipline first.",
+        voice="I refuse to average live contentions into false consensus.",
+        open_questions=["how much scaffolding dissolves when the model improves"],
+        shifts=[],
+    )
+    return SimpleNamespace(**{**defaults, **overrides})
+
+
+def _built(**overrides):
+    defaults = dict(expert_name="Agentic Harness Design", profile=_profile(), viva=None, at="2026-08-09T00:00:00+00:00")
+    return build_perspective_graph(**{**defaults, **overrides})
+
+
+class TestTheSpineIsTheShiftChain:
+    def test_a_shift_links_the_old_reading_to_the_new_one(self):
+        graph = _built(profile=_profile(shifts=[_shift("I read it as a naming problem.", "I read it as retraction.")]))
+
+        assert [n.text for n in graph.standpoints][:2] == [
+            "I read it as a naming problem.",
+            "I read it as retraction.",
+        ]
+        assert any(e.kind == EDGE_BECAME for e in graph.edges)
+
+    def test_the_change_records_what_caused_it(self):
+        graph = _built(
+            profile=_profile(shifts=[_shift("was", "now", because="the failure lens put retraction at the centre")])
+        )
+        assert [s.text for s in graph.shifts] == ["the failure lens put retraction at the centre"]
+        assert any(e.kind == EDGE_THROUGH for e in graph.edges)
+
+    def test_a_corpus_state_becomes_the_encounter_that_moved_it(self):
+        graph = _built(profile=_profile(shifts=[_shift("was", "now", fingerprint="abc123")]))
+        assert any(e.kind == EDGE_MOVED_BY for e in graph.edges)
+        assert any("abc123" in n.text for n in graph.nodes)
+
+    def test_successive_shifts_form_one_chain_rather_than_islands(self):
+        """Each link starts where the previous one ended, all the way to today.
+
+        Contiguity is the property, not the count: the current standpoint from
+        the profile extends the chain past the last recorded shift, which is
+        correct - the expert has read more since it last recorded moving.
+        """
+        graph = _built(
+            profile=_profile(
+                shifts=[
+                    _shift("first", "second", at="2026-01-01T00:00:00+00:00"),
+                    _shift("second", "third", at="2026-05-01T00:00:00+00:00"),
+                ]
+            )
+        )
+        became = [e for e in graph.edges if e.kind == EDGE_BECAME]
+
+        assert len(became) >= 2
+        for earlier, later in pairwise(became):
+            assert earlier.target == later.source
+
+    def test_the_chain_ends_at_the_standpoint_it_holds_today(self):
+        graph = _built(profile=_profile(standpoint="today's reading", shifts=[_shift("was", "now")]))
+        assert graph.current is not None
+        assert graph.current.text == "today's reading"
+
+    def test_a_shift_missing_either_side_is_not_a_shift(self):
+        graph = _built(profile=_profile(shifts=[_shift("was", "")]))
+        assert not graph.has_a_history
+
+
+class TestHavingBeenMovedIsTheMeasurement:
+    def test_an_expert_that_never_changed_its_mind_has_no_history(self):
+        """It may have read a great deal. Nothing moved it."""
+        graph = _built()
+        assert graph.standpoints
+        assert not graph.has_a_history
+
+    def test_one_recorded_shift_is_a_history(self):
+        assert _built(profile=_profile(shifts=[_shift("was", "now")])).has_a_history
+
+    def test_the_render_says_so_plainly_when_nothing_moved_it(self):
+        assert "nothing it read has moved it" in render_perspective(_built())
+
+
+class TestWhatAFactModelWouldDiscard:
+    def test_conduct_is_kept_even_though_it_has_no_truth_value(self):
+        """'I refuse to average live contentions' is not a claim about the world."""
+        graph = _built()
+        assert [c.text for c in graph.commitments] == [
+            "I refuse to average live contentions into false consensus."
+        ]
+        assert any(e.kind == EDGE_HOLDS for e in graph.edges)
+
+    def test_its_own_agenda_is_kept_separately_from_corpus_gaps(self):
+        graph = _built()
+        assert len(graph.pursuits) == 1
+        assert any(e.kind == EDGE_PURSUING for e in graph.edges)
+
+    def test_the_name_it_chose_is_carried_as_its_own(self):
+        assert _built().chosen_name == "Hard Skip"
+
+    def test_the_render_leads_with_the_name_it_picked(self):
+        assert render_perspective(_built()).startswith("# Hard Skip")
+
+
+class TestVivaRevisionsLandOnTheChain:
+    def test_positions_a_viva_moved_become_shifts(self):
+        """Currently loose sentences in a list nothing points at."""
+        viva = SimpleNamespace(positions_that_moved=["I withdraw the confidence on item 9."])
+        graph = _built(viva=viva)
+
+        assert any("item 9" in s.text for s in graph.shifts)
+        assert graph.has_a_history
+
+    def test_each_one_records_that_examination_caused_it(self):
+        viva = SimpleNamespace(positions_that_moved=["moved"])
+        graph = _built(viva=viva)
+        assert any(n.text == "examined under viva" for n in graph.nodes)
+
+
+class TestWalkingBackwards:
+    def test_history_of_a_standpoint_returns_what_produced_it(self):
+        """Assembled by traversal, because the model cannot recall readings
+        that were never in its context."""
+        graph = _built(
+            profile=_profile(shifts=[_shift("I read it as naming.", "I read it as retraction.", fingerprint="abc")])
+        )
+        arrived = next(n for n in graph.standpoints if n.text == "I read it as retraction.")
+
+        chain = graph.history_of(arrived.id)
+
+        kinds = [n.kind for n in chain]
+        assert NODE_STANDPOINT in kinds
+        assert NODE_SHIFT in kinds
+        assert any("abc" in n.text for n in chain)
+
+    def test_a_cycle_cannot_hang_the_walk(self):
+        graph = _built(profile=_profile(shifts=[_shift("a", "b")]))
+        graph.edges.append(type(graph.edges[0])(graph.nodes[1].id, graph.nodes[0].id, EDGE_BECAME))
+        assert graph.history_of(graph.nodes[0].id)
+
+
+class TestSerialization:
+    def test_the_graph_round_trips(self):
+        original = _built(profile=_profile(shifts=[_shift("was", "now")]))
+        restored = PerspectiveGraph.from_dict(original.to_dict())
+        assert restored.stats() == original.stats()
+        assert restored.chosen_name == "Hard Skip"
+
+    def test_junk_is_dropped_rather_than_raising(self):
+        restored = PerspectiveGraph.from_dict({"nodes": ["x", {"kind": "shift"}], "edges": ["y", {"from": "a"}]})
+        assert restored.nodes == []
+        assert restored.edges == []
+
+    def test_an_expert_with_no_profile_yields_an_empty_biography(self):
+        graph = build_perspective_graph(expert_name="E", profile=None)
+        assert not graph.has_a_history
+        assert graph.stats()["standpoints"] == 0

--- a/tests/unit/test_experts/test_portrait_appearance.py
+++ b/tests/unit/test_experts/test_portrait_appearance.py
@@ -1,0 +1,78 @@
+"""An expert that chose how to look gets that, not a picture of its field.
+
+The fallback prompt describes the *subject* an expert studies, so two experts
+on one domain with opposite standpoints render nearly identically - the one
+thing a portrait exists to prevent. These tests hold that a self-authored
+appearance wins outright, and that a missing or broken self-account degrades to
+the old behaviour rather than failing a portrait run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deepr.experts import expert_layout
+from deepr.experts.portraits import _build_prompt, _self_chosen_appearance
+
+
+class TestTheExpertChoosesItsOwnFace:
+    def test_a_written_appearance_is_the_whole_subject(self) -> None:
+        prompt = _build_prompt("tkg", "temporal knowledge graphs", None, appearance="A surveyor at dusk.")
+        assert prompt.startswith("A surveyor at dusk.")
+        assert "temporal knowledge graphs" not in prompt
+
+    def test_the_field_is_used_only_when_nothing_was_chosen(self) -> None:
+        assert "temporal knowledge graphs" in _build_prompt("tkg", "temporal knowledge graphs", None)
+
+    def test_blank_and_whitespace_are_not_a_choice(self) -> None:
+        for empty in (None, "", "   ", "\n\t "):
+            assert "expert in" in _build_prompt("tkg", "graphs", None, appearance=empty)
+
+    def test_the_house_style_still_applies(self) -> None:
+        """A self-chosen portrait has to sit beside the rest of the library."""
+        prompt = _build_prompt("tkg", "graphs", None, appearance="A surveyor at dusk", style="flat vector")
+        assert "flat vector" in prompt
+        assert prompt.endswith("No text or watermarks.")
+
+    def test_the_expert_sentence_is_not_double_punctuated(self) -> None:
+        assert ".. " not in _build_prompt("tkg", "graphs", None, appearance="A surveyor at dusk.")
+
+    def test_a_long_appearance_is_bounded(self) -> None:
+        prompt = _build_prompt("tkg", "graphs", None, appearance="word " * 500)
+        assert len(prompt) < 1400
+
+
+class TestReadingTheChoiceFromDisk:
+    @pytest.fixture(autouse=True)
+    def _fleet(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(expert_layout._paths, "canonical_expert_dir", lambda name: tmp_path / name)
+        self.root = tmp_path
+
+    def _write_self(self, name: str, body: str) -> None:
+        directory = self.root / name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "self.json").write_text(body, encoding="utf-8")
+
+    def test_it_reads_what_the_expert_wrote(self) -> None:
+        self._write_self("cairn", '{"appearance": "A surveyor at dusk."}')
+        assert _self_chosen_appearance("cairn") == "A surveyor at dusk."
+
+    def test_an_expert_with_no_self_account_has_not_chosen(self) -> None:
+        assert _self_chosen_appearance("nobody") == ""
+
+    def test_unreadable_json_falls_back_rather_than_failing_the_run(self) -> None:
+        self._write_self("cairn", "{ not json")
+        assert _self_chosen_appearance("cairn") == ""
+
+    def test_a_self_account_predating_the_field_is_fine(self) -> None:
+        self._write_self("cairn", '{"standpoint": "I read this as a systems problem."}')
+        assert _self_chosen_appearance("cairn") == ""
+
+    def test_it_finds_the_choice_before_migration_too(self) -> None:
+        """Reads fall back, so an unmigrated expert still gets its own face."""
+        directory = self.root / "cairn"
+        directory.mkdir(parents=True)
+        (directory / "profile_card.json").write_text('{"appearance": "A surveyor at dusk."}', encoding="utf-8")
+        assert _self_chosen_appearance("cairn") == "A surveyor at dusk."

--- a/tests/unit/test_experts/test_position_ledger.py
+++ b/tests/unit/test_experts/test_position_ledger.py
@@ -1,0 +1,214 @@
+"""Positions that survive a re-brief, and a record of what changed them.
+
+The defect being removed is the largest destruction of judgement in the system:
+every `expert brief` discarded the previous positions - likelihood bands,
+falsifiers, carried dissent - and re-derived from scratch, so an expert that
+had existed six months had concluded nothing that outlived its last run.
+
+Three distinctions carry the design, and each is tested here: unchanged is not
+a new version, revised is not a replacement, and not-restated is not a
+retirement.
+"""
+
+from types import SimpleNamespace
+
+from deepr.experts.position_ledger import (
+    REASON_NOT_RESTATED,
+    REASON_REVISED,
+    PositionLedger,
+    record_brief,
+)
+from deepr.experts.record_time import END_OF_TIME
+
+JAN = "2026-01-01T00:00:00+00:00"
+JUN = "2026-06-01T00:00:00+00:00"
+DEC = "2026-12-01T00:00:00+00:00"
+
+
+def _position(question, *, stance="it holds", likelihood="likely", falsifier="a counterexample", supported=("f1",)):
+    return SimpleNamespace(
+        question=question,
+        stance=stance,
+        likelihood=likelihood,
+        confidence="moderate",
+        would_change_my_mind=falsifier,
+        unresolved_dissent="",
+        supported_by=list(supported),
+    )
+
+
+class TestAThreadSurvivesARebrief:
+    def test_the_same_question_keeps_one_thread_across_revisions(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Does X hold?")], at=JAN, corpus_fingerprint="c1")
+        record_brief(ledger, [_position("Does X hold?", likelihood="roughly even chance")], at=JUN, corpus_fingerprint="c2")
+
+        assert ledger.stats()["threads"] == 1
+        assert ledger.stats()["versions"] == 2
+
+    def test_a_revision_closes_the_prior_and_opens_a_successor(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q")], at=JAN)
+        record_brief(ledger, [_position("Q", stance="it does not hold")], at=JUN)
+
+        history = ledger.history_of(ledger.versions[0].thread_id)
+        assert history[0].superseded_at == JUN
+        assert history[0].supersession_reason == REASON_REVISED
+        assert history[0].superseded_by == history[1].version_id
+        assert history[1].is_live
+
+    def test_versions_tile_with_no_gap(self):
+        """predecessor.superseded_at == successor.recorded_at, exactly."""
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q")], at=JAN)
+        record_brief(ledger, [_position("Q", stance="changed")], at=JUN)
+
+        history = ledger.history_of(ledger.versions[0].thread_id)
+        assert history[0].superseded_at == history[1].recorded_at
+
+    def test_only_one_version_is_live_per_thread(self):
+        ledger = PositionLedger(expert_name="E")
+        for stamp, stance in ((JAN, "a"), (JUN, "b"), (DEC, "c")):
+            record_brief(ledger, [_position("Q", stance=stance)], at=stamp)
+
+        assert len(ledger.live) == 1
+        assert ledger.live[0].stance == "c"
+
+
+class TestAnIdenticalRestatementIsNotAVersion:
+    def test_restating_the_same_position_adds_no_version(self):
+        """A version differing in nothing is noise; the ledger exists to make
+        real change visible."""
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q")], at=JAN, corpus_fingerprint="c1")
+        changed = record_brief(ledger, [_position("Q")], at=JUN, corpus_fingerprint="c2")
+
+        assert changed["unchanged"] == 1
+        assert changed["revised"] == 0
+        assert len(ledger.versions) == 1
+
+    def test_but_the_survival_evidence_is_kept(self):
+        """Reaching the same position again from new material is the evidence."""
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q")], at=JAN, corpus_fingerprint="c1")
+        record_brief(ledger, [_position("Q")], at=JUN, corpus_fingerprint="c2")
+
+        assert ledger.live[0].corpus_fingerprint == "c2"
+
+    def test_the_question_alone_does_not_make_two_versions_differ(self):
+        """The question is the thread identity, not part of the content."""
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Does X hold?")], at=JAN)
+        record_brief(ledger, [_position("does x hold")], at=JUN)
+
+        assert len(ledger.versions) == 1
+
+
+class TestNotRestatedIsNotRetired:
+    def test_a_position_a_rebrief_did_not_produce_is_closed(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q1"), _position("Q2")], at=JAN)
+        changed = record_brief(ledger, [_position("Q1")], at=JUN)
+
+        assert changed["not_restated"] == 1
+        assert len(ledger.live) == 1
+
+    def test_the_reason_says_only_that_it_was_not_restated(self):
+        """The expert did not decide to drop it; a later pass did not reach it.
+        Calling that a retirement would hide a position vanishing quietly."""
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q1"), _position("Q2")], at=JAN)
+        record_brief(ledger, [_position("Q1")], at=JUN)
+
+        dropped = next(v for v in ledger.versions if not v.is_live)
+        assert dropped.supersession_reason == REASON_NOT_RESTATED
+        assert dropped.superseded_by == ""
+
+    def test_nothing_is_ever_deleted(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q1"), _position("Q2")], at=JAN)
+        record_brief(ledger, [], at=JUN)
+
+        assert len(ledger.versions) == 2
+        assert ledger.live == []
+
+
+class TestSurvivalIsEvidence:
+    def test_it_counts_distinct_corpus_states_not_reruns(self):
+        """Re-running over the same corpus proves nothing new."""
+        ledger = PositionLedger(expert_name="E")
+        for stamp in (JAN, JUN, DEC):
+            record_brief(ledger, [_position("Q")], at=stamp, corpus_fingerprint="same")
+
+        assert ledger.survived(ledger.versions[0].thread_id) == 1
+
+    def test_reaching_it_again_from_new_material_counts(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q")], at=JAN, corpus_fingerprint="c1")
+        record_brief(ledger, [_position("Q", stance="restated")], at=JUN, corpus_fingerprint="c2")
+
+        assert ledger.survived(ledger.versions[0].thread_id) == 2
+
+    def test_a_fresh_position_has_survived_one_state(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q")], at=JAN, corpus_fingerprint="c1")
+        assert ledger.stats()["max_survived"] == 1
+
+
+class TestPointInTime:
+    def test_as_of_returns_what_was_held_then(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q", stance="first")], at=JAN)
+        record_brief(ledger, [_position("Q", stance="second")], at=JUN)
+
+        assert [v.stance for v in ledger.as_of("2026-03-01T00:00:00+00:00")] == ["first"]
+        assert [v.stance for v in ledger.as_of(DEC)] == ["second"]
+
+    def test_the_boundary_belongs_to_the_successor(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q", stance="first")], at=JAN)
+        record_brief(ledger, [_position("Q", stance="second")], at=JUN)
+
+        assert [v.stance for v in ledger.as_of(JUN)] == ["second"]
+
+    def test_a_migrated_version_with_no_timestamp_reads_as_live(self):
+        """A store written before this ledger existed must not vanish."""
+        ledger = PositionLedger.from_dict(
+            {"versions": [{"thread_id": "t", "version_id": "v", "question": "Q", "superseded_at": END_OF_TIME}]}
+        )
+        assert ledger.as_of(JUN)
+
+    def test_history_is_oldest_first(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q", stance="a")], at=JAN)
+        record_brief(ledger, [_position("Q", stance="b")], at=JUN)
+
+        history = ledger.history_of(ledger.versions[0].thread_id)
+        assert [v.stance for v in history] == ["a", "b"]
+
+
+class TestHygiene:
+    def test_a_position_with_no_question_is_skipped(self):
+        ledger = PositionLedger(expert_name="E")
+        assert record_brief(ledger, [_position("  ")], at=JAN)["new"] == 0
+
+    def test_ordering_is_total_within_one_instant(self):
+        """Two versions can share a timestamp, and as_of must not be ambiguous."""
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q1"), _position("Q2")], at=JAN)
+
+        assert len({v.seq for v in ledger.versions}) == 2
+
+    def test_the_ledger_round_trips(self):
+        ledger = PositionLedger(expert_name="E")
+        record_brief(ledger, [_position("Q")], at=JAN, corpus_fingerprint="c1")
+        record_brief(ledger, [_position("Q", stance="revised")], at=JUN, corpus_fingerprint="c2")
+
+        restored = PositionLedger.from_dict(ledger.to_dict())
+
+        assert restored.stats() == ledger.stats()
+        assert len(restored.live) == 1
+
+    def test_junk_versions_are_dropped_rather_than_raising(self):
+        restored = PositionLedger.from_dict({"versions": ["nope", {}, {"thread_id": "t"}]})
+        assert len(restored.versions) == 1

--- a/tests/unit/test_experts/test_position_ledger.py
+++ b/tests/unit/test_experts/test_position_ledger.py
@@ -41,7 +41,9 @@ class TestAThreadSurvivesARebrief:
     def test_the_same_question_keeps_one_thread_across_revisions(self):
         ledger = PositionLedger(expert_name="E")
         record_brief(ledger, [_position("Does X hold?")], at=JAN, corpus_fingerprint="c1")
-        record_brief(ledger, [_position("Does X hold?", likelihood="roughly even chance")], at=JUN, corpus_fingerprint="c2")
+        record_brief(
+            ledger, [_position("Does X hold?", likelihood="roughly even chance")], at=JUN, corpus_fingerprint="c2"
+        )
 
         assert ledger.stats()["threads"] == 1
         assert ledger.stats()["versions"] == 2

--- a/tests/unit/test_experts/test_quality_scorecard.py
+++ b/tests/unit/test_experts/test_quality_scorecard.py
@@ -32,9 +32,7 @@ def test_circular_intent_only_scores_poor() -> None:
 def test_secondary_multi_source_scores_better() -> None:
     beliefs = []
     for i in range(30):
-        refs = (
-            ["report:file:official-a.md", "report:file:official-b.md"] if i < 10 else ["report:file:official-a.md"]
-        )
+        refs = ["report:file:official-a.md", "report:file:official-b.md"] if i < 10 else ["report:file:official-a.md"]
         beliefs.append(
             Belief(
                 claim=f"Official domain claim {i} about LoRa channel presets",

--- a/tests/unit/test_experts/test_quality_scorecard.py
+++ b/tests/unit/test_experts/test_quality_scorecard.py
@@ -33,7 +33,7 @@ def test_secondary_multi_source_scores_better() -> None:
     beliefs = []
     for i in range(30):
         refs = (
-            [f"report:file:official-a.md", f"report:file:official-b.md"] if i < 10 else [f"report:file:official-a.md"]
+            ["report:file:official-a.md", "report:file:official-b.md"] if i < 10 else ["report:file:official-a.md"]
         )
         beliefs.append(
             Belief(

--- a/tests/unit/test_experts/test_record_identity.py
+++ b/tests/unit/test_experts/test_record_identity.py
@@ -1,0 +1,118 @@
+"""Identity that survives a rerun, which positional ids did not.
+
+The bug being fixed: `finding_id = f"{lens}-{ordinal}"` renumbers when a
+partial resume re-runs one lens, so a brief citing `failure-30` silently
+repoints at a different finding. The citation still validates against the id
+set, which is worse than failing - the provenance chain reports itself intact
+while pointing at the wrong evidence.
+"""
+
+from deepr.experts.record_identity import (
+    finding_thread_id,
+    is_stable_id,
+    normalize_text,
+    position_thread_id,
+    version_id,
+)
+
+
+class TestFindingIdentityIsAboutTheCorpus:
+    def test_the_same_finding_keeps_its_id_across_runs(self):
+        first = finding_thread_id(lens="failure", title="Harness over-shackling", anchors=["the agent could not"])
+        second = finding_thread_id(lens="failure", title="Harness over-shackling", anchors=["the agent could not"])
+        assert first == second
+
+    def test_anchor_order_does_not_change_identity(self):
+        """The model returns anchors in whatever order it likes."""
+        a = finding_thread_id(lens="failure", title="T", anchors=["one", "two"])
+        b = finding_thread_id(lens="failure", title="T", anchors=["two", "one"])
+        assert a == b
+
+    def test_reflowing_the_title_does_not_create_a_new_finding(self):
+        """Same passages, same lens, cosmetically different wording."""
+        a = finding_thread_id(lens="failure", title="Harness over-shackling.", anchors=["x"])
+        b = finding_thread_id(lens="failure", title="harness  over shackling", anchors=["x"])
+        assert a == b
+
+    def test_different_anchors_are_a_different_finding(self):
+        """Anchors are what a finding is about in the corpus."""
+        a = finding_thread_id(lens="failure", title="T", anchors=["one"])
+        b = finding_thread_id(lens="failure", title="T", anchors=["something else entirely"])
+        assert a != b
+
+    def test_the_same_title_from_a_different_lens_is_a_different_finding(self):
+        a = finding_thread_id(lens="failure", title="T", anchors=["x"])
+        b = finding_thread_id(lens="contention", title="T", anchors=["x"])
+        assert a != b
+
+    def test_the_lens_stays_readable_in_the_id(self):
+        assert finding_thread_id(lens="failure", title="T", anchors=["x"]).startswith("failure-")
+
+    def test_empty_anchors_still_yield_a_stable_id(self):
+        """A lens that quoted nothing still produced a finding."""
+        assert finding_thread_id(lens="failure", title="T", anchors=[]) == finding_thread_id(
+            lens="failure", title="T", anchors=[""]
+        )
+
+
+class TestPositionIdentityIsTheQuestion:
+    def test_revising_the_stance_keeps_the_same_thread(self):
+        """The whole point. A revision is the same position, restated."""
+        before = position_thread_id("Does multi-agent orchestration survive better models?")
+        after = position_thread_id("Does multi-agent orchestration survive better models?")
+        assert before == after
+
+    def test_a_different_question_is_a_different_thread(self):
+        assert position_thread_id("Does X hold?") != position_thread_id("Does Y hold?")
+
+    def test_punctuation_and_case_do_not_fork_a_thread(self):
+        assert position_thread_id("Does X hold?") == position_thread_id("does x hold")
+
+    def test_it_does_not_depend_on_list_order(self):
+        """position-1 became a different question whenever a brief reordered."""
+        assert position_thread_id("Q") == position_thread_id("Q")
+
+
+class TestVersionIsSeparateFromThread:
+    def test_two_keys_because_one_cannot_do_both(self):
+        """ExpertStance.create hashes title|statement, so a revised stance
+        silently becomes an unrelated record. That is the bug being avoided."""
+        thread = position_thread_id("Does X hold?")
+        v1 = version_id("Does X hold?|likely|because A")
+        v2 = version_id("Does X hold?|roughly even chance|because B")
+        assert v1 != v2
+        assert position_thread_id("Does X hold?") == thread
+
+    def test_identical_content_is_the_same_version(self):
+        assert version_id("same") == version_id("same")
+
+
+class TestHashingHygiene:
+    def test_the_separator_prevents_a_concatenation_collision(self):
+        """Joining "ab"+"c" and "a"+"bc" to one string is how content ids
+        collide on inputs that are not remotely alike."""
+        a = finding_thread_id(lens="failure", title="ab", anchors=["c"])
+        b = finding_thread_id(lens="failure", title="a", anchors=["bc"])
+        assert a != b
+
+    def test_accents_fold_so_one_source_does_not_fork_a_thread(self):
+        assert normalize_text("Café") == normalize_text("Cafe")
+
+    def test_normalize_tolerates_none_and_numbers(self):
+        assert normalize_text(None) == ""
+        assert normalize_text(12) == "12"
+
+
+class TestTellingDurableIdsFromLegacyOnes:
+    def test_a_positional_id_is_recognised_as_legacy(self):
+        """Lets a migration find records to re-key without a separate flag."""
+        assert not is_stable_id("failure-3")
+        assert not is_stable_id("position-1")
+
+    def test_a_derived_id_is_recognised_as_durable(self):
+        assert is_stable_id(finding_thread_id(lens="failure", title="T", anchors=["x"]))
+        assert is_stable_id(position_thread_id("Q"))
+
+    def test_junk_is_not_mistaken_for_durable(self):
+        assert not is_stable_id("")
+        assert not is_stable_id("failure-zzzzzzzzzzzzzzzz")

--- a/tests/unit/test_experts/test_record_time.py
+++ b/tests/unit/test_experts/test_record_time.py
@@ -1,0 +1,119 @@
+"""One clock, one interval convention, one sentinel.
+
+Closed-open is the only convention under which consecutive versions tile the
+timeline with no gap and no overlap, so `predecessor.superseded_at ==
+successor.recorded_at` exactly and a point-in-time read returns exactly one
+version. Everything here exists so that is implemented once rather than three
+times.
+"""
+
+from deepr.experts.record_time import (
+    BEGINNING_OF_TIME,
+    END_OF_TIME,
+    age_days,
+    contains,
+    is_open,
+    overlaps,
+    parse_iso,
+    utc_now,
+)
+
+JAN = "2026-01-01T00:00:00+00:00"
+JUN = "2026-06-01T00:00:00+00:00"
+DEC = "2026-12-01T00:00:00+00:00"
+
+
+class TestClosedOpen:
+    def test_the_start_instant_is_included(self):
+        assert contains(JAN, DEC, JAN)
+
+    def test_the_end_instant_is_excluded(self):
+        assert not contains(JAN, DEC, DEC)
+
+    def test_consecutive_versions_tile_with_no_gap_and_no_overlap(self):
+        """The whole reason for the convention: exactly one version at a boundary."""
+        first = (JAN, JUN)
+        second = (JUN, DEC)
+
+        at_boundary = [contains(*first, JUN), contains(*second, JUN)]
+
+        assert at_boundary == [False, True], "the boundary belongs to exactly one version"
+
+    def test_a_moment_before_the_interval_is_outside(self):
+        assert not contains(JUN, DEC, JAN)
+
+
+class TestTheSentinelRatherThanNull:
+    def test_an_open_interval_contains_any_later_moment(self):
+        assert contains(JAN, END_OF_TIME, DEC)
+
+    def test_an_absent_end_is_treated_as_open_not_as_closed(self):
+        """A record written before this module existed must read as live.
+
+        The bug this avoids already exists elsewhere: a temporal filter that
+        excludes records with missing endpoints, silently under-returning.
+        """
+        assert contains(JAN, "", DEC)
+
+    def test_an_absent_start_means_it_has_always_applied(self):
+        assert contains("", END_OF_TIME, JAN)
+
+    def test_is_open_recognises_both_forms(self):
+        assert is_open(END_OF_TIME)
+        assert is_open("")
+        assert not is_open(DEC)
+
+    def test_the_sentinel_round_trips_through_the_parser(self):
+        """It is datetime.max at UTC, so export and reparse are lossless."""
+        assert parse_iso(END_OF_TIME) is not None
+        assert parse_iso(END_OF_TIME).year == 9999
+
+    def test_the_sentinel_sorts_after_real_timestamps_as_a_string(self):
+        """Sorting without parsing is sometimes right, and must not mis-order."""
+        assert sorted([DEC, END_OF_TIME, JAN])[-1] == END_OF_TIME
+        assert sorted([DEC, BEGINNING_OF_TIME, JAN])[0] == BEGINNING_OF_TIME
+
+
+class TestParsing:
+    def test_a_trailing_z_is_accepted(self):
+        assert parse_iso("2026-06-01T00:00:00Z") == parse_iso(JUN)
+
+    def test_a_naive_timestamp_is_assumed_utc(self):
+        assert parse_iso("2026-06-01T00:00:00") == parse_iso(JUN)
+
+    def test_junk_returns_none_rather_than_raising(self):
+        """One corrupt timestamp must not take down a read across a store."""
+        assert parse_iso("not a date") is None
+        assert parse_iso("") is None
+        assert parse_iso(None) is None
+
+    def test_utc_now_is_parseable_by_our_own_parser(self):
+        assert parse_iso(utc_now()) is not None
+
+
+class TestOverlaps:
+    def test_a_successor_that_continues_does_not_overlap(self):
+        assert not overlaps(JAN, JUN, JUN, DEC)
+
+    def test_a_successor_that_contradicts_does_overlap(self):
+        """Materially stronger than a revision, and worth flagging separately."""
+        assert overlaps(JAN, DEC, JUN, END_OF_TIME)
+
+    def test_two_open_intervals_always_overlap(self):
+        assert overlaps(JAN, END_OF_TIME, JUN, END_OF_TIME)
+
+    def test_disjoint_intervals_do_not(self):
+        assert not overlaps(JAN, JUN, DEC, END_OF_TIME)
+
+
+class TestAgeDays:
+    def test_unknown_is_minus_one_rather_than_zero(self):
+        """Zero is a real answer meaning today; a missing timestamp is not."""
+        assert age_days("") == -1
+        assert age_days("nonsense") == -1
+
+    def test_it_counts_whole_days(self):
+        assert age_days(JAN, now="2026-01-11T00:00:00+00:00") == 10
+
+    def test_a_future_timestamp_clamps_to_zero(self):
+        assert age_days(DEC, now=JAN) == 0

--- a/tests/unit/test_experts/test_research_practice.py
+++ b/tests/unit/test_experts/test_research_practice.py
@@ -243,7 +243,5 @@ class TestSerialization:
         assert restored.watches[0].positions_resting_on_it == 4
 
     def test_junk_is_dropped_rather_than_raising(self):
-        restored = ResearchPractice.from_dict(
-            {"pursuits": ["x", {}], "watches": ["y", {}], "interests": ["z", {}]}
-        )
+        restored = ResearchPractice.from_dict({"pursuits": ["x", {}], "watches": ["y", {}], "interests": ["z", {}]})
         assert restored.pursuits == restored.watches == restored.interests == []

--- a/tests/unit/test_experts/test_research_practice.py
+++ b/tests/unit/test_experts/test_research_practice.py
@@ -1,0 +1,249 @@
+"""What an expert does to stay expert, rather than what it knows.
+
+The split under test throughout: which sources it follows is measured and not
+the model's call, while what it chases and where its attention goes is entirely
+the model's. Letting a model rank sources would reintroduce exactly the
+guessing that measuring them replaced.
+"""
+
+from deepr.experts.research_practice import (
+    DEPTH_DEEPENING,
+    DEPTH_MAINTAINING,
+    PURSUIT_ABANDONED,
+    PURSUIT_ANSWERED,
+    Interest,
+    Pursuit,
+    ResearchPractice,
+    Watch,
+    apply_practice_update,
+    build_practice_prompt,
+    open_pursuits,
+    render_practice,
+    resolve_pursuit,
+    set_interests,
+    update_watches,
+)
+
+AT = "2026-08-09T00:00:00+00:00"
+
+
+def _practice(**overrides) -> ResearchPractice:
+    practice = ResearchPractice(expert_name="E")
+    for key, value in overrides.items():
+        setattr(practice, key, value)
+    return practice
+
+
+class TestPursuitsAreChoicesNotGaps:
+    def test_a_pursuit_records_why_it_matters(self):
+        """A gap is missing material. A pursuit is something it chose to care about."""
+        practice = _practice()
+        open_pursuits(practice, ["Does X scale?"], origin="viva", at=AT, why="it decides position 3")
+
+        assert practice.pursuits[0].why_it_matters == "it decides position 3"
+        assert practice.pursuits[0].origin == "viva"
+
+    def test_the_same_question_does_not_open_twice(self):
+        practice = _practice()
+        open_pursuits(practice, ["Does X scale?"], origin="viva", at=AT)
+        added = open_pursuits(practice, ["does x scale"], origin="profile", at=AT)
+
+        assert added == 0
+        assert len(practice.pursuits) == 1
+
+    def test_an_abandoned_question_does_not_silently_reopen(self):
+        """Reopening a line of enquiry should be a decision. Reappearing is not one."""
+        practice = _practice(pursuits=[Pursuit(question="Does X scale?", status=PURSUIT_ABANDONED)])
+
+        assert open_pursuits(practice, ["Does X scale?"], origin="viva", at=AT) == 0
+
+    def test_answering_one_records_what_answered_it(self):
+        practice = _practice()
+        open_pursuits(practice, ["Does X scale?"], origin="viva", at=AT)
+
+        assert resolve_pursuit(practice, "does X scale", resolution="the 2026 benchmark settles it", at=AT)
+        assert practice.pursuits[0].status == PURSUIT_ANSWERED
+        assert practice.pursuits[0].resolution == "the 2026 benchmark settles it"
+
+    def test_resolving_something_it_is_not_chasing_reports_no_match(self):
+        assert not resolve_pursuit(_practice(), "unheard of", resolution="x", at=AT)
+
+
+class TestAttentionIsEarnedNotChosen:
+    def test_a_source_carrying_positions_becomes_a_watch(self):
+        practice = _practice()
+        update_watches(practice, [("anthropic.com", 6)], at=AT)
+
+        assert practice.watches[0].origin == "anthropic.com"
+        assert practice.watches[0].positions_resting_on_it == 6
+
+    def test_watches_are_ordered_by_how_much_rests_on_them(self):
+        practice = _practice()
+        update_watches(practice, [("minor.org", 1), ("major.org", 9)], at=AT)
+
+        assert [w.origin for w in practice.watches] == ["major.org", "minor.org"]
+
+    def test_a_quiet_round_does_not_drop_a_source(self):
+        """A publisher with a quiet quarter has not stopped mattering."""
+        practice = _practice()
+        update_watches(practice, [("a.org", 3)], at=AT)
+        update_watches(practice, [], at=AT)
+
+        assert [w.origin for w in practice.watches] == ["a.org"]
+        assert practice.watches[0].quiet_rounds == 1
+
+    def test_three_quiet_rounds_drops_it(self):
+        """How a field moving on becomes visible instead of carried forever."""
+        practice = _practice()
+        update_watches(practice, [("a.org", 3)], at=AT)
+        for _ in range(3):
+            update_watches(practice, [], at=AT)
+
+        assert practice.watches == []
+
+    def test_carrying_something_again_resets_the_counter(self):
+        practice = _practice()
+        update_watches(practice, [("a.org", 3)], at=AT)
+        update_watches(practice, [], at=AT)
+        update_watches(practice, [("a.org", 1)], at=AT)
+
+        assert practice.watches[0].quiet_rounds == 0
+
+    def test_the_reading_list_is_bounded(self):
+        practice = _practice()
+        update_watches(practice, [(f"pub{i}.org", i) for i in range(30)], at=AT)
+
+        assert len(practice.watches) == 12
+
+
+class TestTheDeepeningBudget:
+    def test_excess_deepening_areas_are_demoted_not_dropped(self):
+        """It still cares; it just cannot go deep on eight things at once."""
+        practice = _practice()
+        set_interests(practice, [Interest(area=f"area {i}", depth=DEPTH_DEEPENING) for i in range(6)])
+
+        assert len(practice.deepening) == 3
+        assert len(practice.interests) == 6
+        assert all(i.depth == DEPTH_MAINTAINING for i in practice.interests[3:])
+
+    def test_a_demoted_area_says_why(self):
+        practice = _practice()
+        set_interests(practice, [Interest(area=f"a{i}", depth=DEPTH_DEEPENING) for i in range(4)])
+
+        assert "deepening budget is full" in practice.interests[3].why
+
+
+class TestWhetherItIsPractisingAtAll:
+    def test_a_live_question_and_somewhere_to_look_is_a_practice(self):
+        practice = _practice(pursuits=[Pursuit(question="Q")], watches=[Watch(origin="a.org")])
+        assert practice.is_practising
+
+    def test_questions_with_nowhere_to_look_is_not(self):
+        assert not _practice(pursuits=[Pursuit(question="Q")]).is_practising
+
+    def test_sources_with_nothing_to_chase_is_not(self):
+        """Waiting to be re-researched, which is what the whole fleet does."""
+        assert not _practice(watches=[Watch(origin="a.org")]).is_practising
+
+    def test_the_render_says_so_plainly(self):
+        assert "waiting to be re-researched" in render_practice(_practice())
+
+
+class TestNextReading:
+    def test_questions_come_before_sources(self):
+        """A question is a better search than a topic."""
+        practice = _practice(pursuits=[Pursuit(question="Does X scale?")], watches=[Watch(origin="a.org")])
+
+        assert practice.next_reading()[0] == "Does X scale?"
+
+    def test_answered_questions_drop_off_the_list(self):
+        practice = _practice(pursuits=[Pursuit(question="Q", status=PURSUIT_ANSWERED)])
+        assert practice.next_reading() == []
+
+
+class TestTheAgenticHalf:
+    def test_the_prompt_tells_it_the_source_list_is_not_its_call(self):
+        prompt = build_practice_prompt(expert_name="E", standpoint="S", practice=_practice(), material="M")
+        assert "already settled" in prompt
+        assert "cannot promote a source you" in prompt
+
+    def test_the_prompt_carries_the_deepening_budget(self):
+        prompt = build_practice_prompt(expert_name="E", standpoint="S", practice=_practice(), material="M")
+        assert "At most 3 may be deepening" in prompt
+
+    def test_abandoning_is_offered_as_a_real_finding(self):
+        prompt = build_practice_prompt(expert_name="E", standpoint="S", practice=_practice(), material="M")
+        assert "is not a failure" in prompt
+
+    def test_an_update_answers_abandons_and_opens(self):
+        practice = _practice()
+        open_pursuits(practice, ["settled one", "wrong question"], origin="viva", at=AT)
+
+        changed = apply_practice_update(
+            practice,
+            {
+                "reviewed": [
+                    {"question": "settled one", "verdict": "answered", "resolution": "the 2026 study"},
+                    {"question": "wrong question", "verdict": "abandon", "resolution": "it was the wrong frame"},
+                ],
+                "new_pursuits": [{"question": "a fresh one", "why_it_matters": "it decides position 3"}],
+                "interests": [{"area": "verification", "depth": "deepening"}],
+            },
+            at=AT,
+        )
+
+        assert changed == {"answered": 1, "abandoned": 1, "opened": 1}
+        assert [p.question for p in practice.live_pursuits] == ["a fresh one"]
+        assert practice.deepening[0].area == "verification"
+
+    def test_a_question_answered_then_reasked_does_not_reopen(self):
+        """Resolutions apply before new pursuits, so the rephrase deduplicates."""
+        practice = _practice()
+        open_pursuits(practice, ["Does X scale?"], origin="viva", at=AT)
+
+        apply_practice_update(
+            practice,
+            {
+                "reviewed": [{"question": "Does X scale?", "verdict": "answered", "resolution": "yes"}],
+                "new_pursuits": [{"question": "does x scale"}],
+            },
+            at=AT,
+        )
+
+        assert len(practice.pursuits) == 1
+        assert practice.pursuits[0].status == PURSUIT_ANSWERED
+
+    def test_junk_in_the_reply_does_not_corrupt_the_practice(self):
+        practice = _practice()
+        changed = apply_practice_update(
+            practice, {"reviewed": ["nope", {}], "new_pursuits": [None, {"question": "  "}]}, at=AT
+        )
+        assert changed == {"answered": 0, "abandoned": 0, "opened": 0}
+        assert practice.pursuits == []
+
+    def test_an_abandon_with_no_reason_still_records_that_it_was_abandoned(self):
+        practice = _practice()
+        open_pursuits(practice, ["Q"], origin="viva", at=AT)
+        apply_practice_update(practice, {"reviewed": [{"question": "Q", "verdict": "abandon"}]}, at=AT)
+
+        assert practice.pursuits[0].status == PURSUIT_ABANDONED
+        assert "without a stated reason" in practice.pursuits[0].resolution
+
+
+class TestSerialization:
+    def test_the_practice_round_trips(self):
+        practice = _practice(
+            pursuits=[Pursuit(question="Q", origin="viva")],
+            watches=[Watch(origin="a.org", positions_resting_on_it=4)],
+            interests=[Interest(area="verification", depth=DEPTH_DEEPENING)],
+        )
+        restored = ResearchPractice.from_dict(practice.to_dict())
+
+        assert restored.stats() == practice.stats()
+        assert restored.watches[0].positions_resting_on_it == 4
+
+    def test_junk_is_dropped_rather_than_raising(self):
+        restored = ResearchPractice.from_dict(
+            {"pursuits": ["x", {}], "watches": ["y", {}], "interests": ["z", {}]}
+        )
+        assert restored.pursuits == restored.watches == restored.interests == []

--- a/tests/unit/test_experts/test_self_model_updates.py
+++ b/tests/unit/test_experts/test_self_model_updates.py
@@ -28,6 +28,7 @@ from deepr.experts.self_model_updates import (
     default_self_model_update_dir,
     propose_self_model_update,
 )
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 
 
 def _profile(manifest: ExpertManifest) -> ExpertProfile:
@@ -35,7 +36,7 @@ def _profile(manifest: ExpertManifest) -> ExpertProfile:
         name="Self Model Update Expert",
         vector_store_id="",
         domain="self-model updates",
-        knowledge_cutoff_date=datetime(2026, 6, 26, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, tzinfo=UTC),
     )
     profile.get_manifest = lambda: manifest  # type: ignore[method-assign]

--- a/tests/unit/test_experts/test_stage_contract.py
+++ b/tests/unit/test_experts/test_stage_contract.py
@@ -23,12 +23,12 @@ def _artifacts(**overrides):
     """A fully healthy expert, unless a key is overridden with None or junk."""
     defaults = {
         "corpus/index.jsonl": {"active_count": 12},
-        "study.json": {"totals": {"findings": 40, "grounded_findings": 31}},
-        "brief.json": {"positions": [{"question": "Q"}]},
-        "profile_card.json": {"standpoint": "I read this as a systems problem."},
+        "noticed/current.json": {"totals": {"findings": 40, "grounded_findings": 31}},
+        "hold/current.json": {"positions": [{"question": "Q"}]},
+        "self.json": {"standpoint": "I read this as a systems problem."},
         "graph/evidence.json": {"stats": {"is_formed": True}},
-        "practice.json": {"stats": {"live_pursuits": 3}},
-        "viva.json": {"exchanges": [{"question": "Q"}]},
+        "attend/practice.json": {"stats": {"live_pursuits": 3}},
+        "met/examination.json": {"exchanges": [{"question": "Q"}]},
     }
     return {**defaults, **overrides}
 
@@ -36,7 +36,7 @@ def _artifacts(**overrides):
 class TestPresenceIsNotValidity:
     def test_a_brief_holding_no_positions_blocks_the_profile(self):
         """The exact failure: a timed-out synthesis wrote a parseable, useless brief."""
-        state = evaluate_stage(get_stage(STAGE_PROFILE), _artifacts(**{"brief.json": {"positions": []}}))
+        state = evaluate_stage(get_stage(STAGE_PROFILE), _artifacts(**{"hold/current.json": {"positions": []}}))
 
         assert state.status == "blocked"
         assert "holds no positions" in state.blockers[0].reason
@@ -45,13 +45,14 @@ class TestPresenceIsNotValidity:
     def test_a_study_with_findings_that_anchor_in_nothing_blocks_the_brief(self):
         """Briefing from it produces positions resting on text nobody can open."""
         state = evaluate_stage(
-            get_stage(STAGE_BRIEF), _artifacts(**{"study.json": {"totals": {"findings": 40, "grounded_findings": 0}}})
+            get_stage(STAGE_BRIEF),
+            _artifacts(**{"noticed/current.json": {"totals": {"findings": 40, "grounded_findings": 0}}}),
         )
         assert state.status == "blocked"
 
     def test_an_unreadable_input_blocks_exactly_like_a_missing_one(self):
         """Treating a corrupt file as present is how the corruption travels."""
-        missing = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"study.json": None}))
+        missing = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"noticed/current.json": None}))
         assert missing.status == "blocked"
 
     def test_an_empty_corpus_blocks_the_study(self):
@@ -62,7 +63,7 @@ class TestPresenceIsNotValidity:
 class TestProducingAFileIsNotSucceeding:
     def test_an_artifact_that_carries_nothing_reads_as_failed_not_done(self):
         """Without this, an empty output is indistinguishable from a good one."""
-        state = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"brief.json": {"positions": []}}))
+        state = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"hold/current.json": {"positions": []}}))
         assert state.produced
         assert state.status == "failed"
 
@@ -70,7 +71,7 @@ class TestProducingAFileIsNotSucceeding:
         assert evaluate_stage(get_stage(STAGE_BRIEF), _artifacts()).status == "done"
 
     def test_an_absent_artifact_with_inputs_met_reads_as_ready(self):
-        state = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"brief.json": None}))
+        state = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"hold/current.json": None}))
         assert state.status == "ready"
 
     def test_a_graph_that_is_a_pile_of_nodes_reads_as_failed(self):
@@ -89,11 +90,11 @@ class TestWhatToDoNext:
     def test_a_failed_stage_outranks_a_ready_one(self):
         """Building on top of a stage that produced nothing usable is how a
         timed-out brief became a standpoint about the pipeline failing."""
-        states = evaluate_all(_artifacts(**{"brief.json": {"positions": []}, "practice.json": None}))
+        states = evaluate_all(_artifacts(**{"hold/current.json": {"positions": []}, "attend/practice.json": None}))
         assert next_stage(states).name == STAGE_BRIEF
 
     def test_otherwise_the_first_runnable_stage_wins(self):
-        states = evaluate_all(_artifacts(**{"practice.json": None, "viva.json": None}))
+        states = evaluate_all(_artifacts(**{"attend/practice.json": None, "met/examination.json": None}))
         assert next_stage(states).name == "practice"
 
     def test_a_complete_expert_has_nothing_next(self):
@@ -114,7 +115,7 @@ class TestTheWholeLoop:
 
     def test_the_graph_needs_both_a_study_and_a_brief(self):
         """It joins claims to passages, so half the chain is not enough."""
-        state = evaluate_stage(get_stage(STAGE_GRAPH), _artifacts(**{"brief.json": {"positions": []}}))
+        state = evaluate_stage(get_stage(STAGE_GRAPH), _artifacts(**{"hold/current.json": {"positions": []}}))
         assert state.status == "blocked"
 
     def test_every_blocker_names_a_command_that_would_fix_it(self):
@@ -123,6 +124,6 @@ class TestTheWholeLoop:
                 assert blocker.fix.startswith("expert "), blocker
 
     def test_states_serialize_for_the_json_surface(self):
-        payload = evaluate_all(_artifacts(**{"brief.json": {"positions": []}}))[2].to_dict()
+        payload = evaluate_all(_artifacts(**{"hold/current.json": {"positions": []}}))[2].to_dict()
         assert payload["status"] == "failed"
         assert payload["success_means"]

--- a/tests/unit/test_experts/test_stage_contract.py
+++ b/tests/unit/test_experts/test_stage_contract.py
@@ -1,0 +1,128 @@
+"""Preconditions declared once, instead of patched in after each one bites.
+
+The distinction the whole module turns on: presence is not validity. Every
+guard in the loop asked "does the file exist and parse". A brief holding zero
+positions passes both, and profiling against it produced a standpoint about the
+pipeline failing rather than about the subject.
+"""
+
+from deepr.experts.stage_contract import (
+    STAGE_BRIEF,
+    STAGE_GRAPH,
+    STAGE_PROFILE,
+    STAGE_STUDY,
+    STAGES,
+    evaluate_all,
+    evaluate_stage,
+    get_stage,
+    next_stage,
+)
+
+
+def _artifacts(**overrides):
+    """A fully healthy expert, unless a key is overridden with None or junk."""
+    defaults = {
+        "corpus/index.jsonl": {"active_count": 12},
+        "study.json": {"totals": {"findings": 40, "grounded_findings": 31}},
+        "brief.json": {"positions": [{"question": "Q"}]},
+        "profile_card.json": {"standpoint": "I read this as a systems problem."},
+        "graph/evidence.json": {"stats": {"is_formed": True}},
+        "practice.json": {"stats": {"live_pursuits": 3}},
+        "viva.json": {"exchanges": [{"question": "Q"}]},
+    }
+    return {**defaults, **overrides}
+
+
+class TestPresenceIsNotValidity:
+    def test_a_brief_holding_no_positions_blocks_the_profile(self):
+        """The exact failure: a timed-out synthesis wrote a parseable, useless brief."""
+        state = evaluate_stage(get_stage(STAGE_PROFILE), _artifacts(**{"brief.json": {"positions": []}}))
+
+        assert state.status == "blocked"
+        assert "holds no positions" in state.blockers[0].reason
+        assert state.blockers[0].fix == "expert brief"
+
+    def test_a_study_with_findings_that_anchor_in_nothing_blocks_the_brief(self):
+        """Briefing from it produces positions resting on text nobody can open."""
+        state = evaluate_stage(
+            get_stage(STAGE_BRIEF), _artifacts(**{"study.json": {"totals": {"findings": 40, "grounded_findings": 0}}})
+        )
+        assert state.status == "blocked"
+
+    def test_an_unreadable_input_blocks_exactly_like_a_missing_one(self):
+        """Treating a corrupt file as present is how the corruption travels."""
+        missing = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"study.json": None}))
+        assert missing.status == "blocked"
+
+    def test_an_empty_corpus_blocks_the_study(self):
+        state = evaluate_stage(get_stage(STAGE_STUDY), _artifacts(**{"corpus/index.jsonl": {"active_count": 0}}))
+        assert "nothing to read" in state.blockers[0].reason
+
+
+class TestProducingAFileIsNotSucceeding:
+    def test_an_artifact_that_carries_nothing_reads_as_failed_not_done(self):
+        """Without this, an empty output is indistinguishable from a good one."""
+        state = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"brief.json": {"positions": []}}))
+        assert state.produced
+        assert state.status == "failed"
+
+    def test_a_real_artifact_reads_as_done(self):
+        assert evaluate_stage(get_stage(STAGE_BRIEF), _artifacts()).status == "done"
+
+    def test_an_absent_artifact_with_inputs_met_reads_as_ready(self):
+        state = evaluate_stage(get_stage(STAGE_BRIEF), _artifacts(**{"brief.json": None}))
+        assert state.status == "ready"
+
+    def test_a_graph_that_is_a_pile_of_nodes_reads_as_failed(self):
+        state = evaluate_stage(
+            get_stage(STAGE_GRAPH), _artifacts(**{"graph/evidence.json": {"stats": {"is_formed": False}}})
+        )
+        assert state.status == "failed"
+
+    def test_every_stage_states_what_success_means(self):
+        """A status nobody can interpret is not a status."""
+        for stage in STAGES:
+            assert stage.success_means, stage.name
+
+
+class TestWhatToDoNext:
+    def test_a_failed_stage_outranks_a_ready_one(self):
+        """Building on top of a stage that produced nothing usable is how a
+        timed-out brief became a standpoint about the pipeline failing."""
+        states = evaluate_all(_artifacts(**{"brief.json": {"positions": []}, "practice.json": None}))
+        assert next_stage(states).name == STAGE_BRIEF
+
+    def test_otherwise_the_first_runnable_stage_wins(self):
+        states = evaluate_all(_artifacts(**{"practice.json": None, "viva.json": None}))
+        assert next_stage(states).name == "practice"
+
+    def test_a_complete_expert_has_nothing_next(self):
+        assert next_stage(evaluate_all(_artifacts())) is None
+
+    def test_a_blocked_stage_is_never_offered_as_next(self):
+        states = evaluate_all({"corpus/index.jsonl": None})
+        assert next_stage(states).name == "acquire"
+
+
+class TestTheWholeLoop:
+    def test_an_empty_expert_blocks_everything_downstream_of_acquire(self):
+        states = {s.name: s for s in evaluate_all({})}
+        assert states["acquire"].status == "ready"
+        assert states["study"].status == "blocked"
+        assert states["brief"].status == "blocked"
+        assert states["profile"].status == "blocked"
+
+    def test_the_graph_needs_both_a_study_and_a_brief(self):
+        """It joins claims to passages, so half the chain is not enough."""
+        state = evaluate_stage(get_stage(STAGE_GRAPH), _artifacts(**{"brief.json": {"positions": []}}))
+        assert state.status == "blocked"
+
+    def test_every_blocker_names_a_command_that_would_fix_it(self):
+        for state in evaluate_all({}):
+            for blocker in state.blockers:
+                assert blocker.fix.startswith("expert "), blocker
+
+    def test_states_serialize_for_the_json_surface(self):
+        payload = evaluate_all(_artifacts(**{"brief.json": {"positions": []}}))[2].to_dict()
+        assert payload["status"] == "failed"
+        assert payload["success_means"]

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -11,6 +11,7 @@ from deepr.experts.study import (
     extract_json_object,
     run_study,
 )
+from deepr.experts.study_contracts import LensOutcome
 from deepr.experts.study_lenses import LENSES
 
 CORPUS_TEXT = (
@@ -355,3 +356,69 @@ class TestRunStudy:
         coverage = result.axis_coverage()
         assert coverage["interrogation"] >= 2
         assert coverage["perspective"] >= 2
+
+
+class TestReentrancy:
+    """Recovery is structural, not conversational.
+
+    A study is tens of model calls over many minutes. Holding it all in memory
+    until the end means one interruption discards work that already succeeded
+    and was already paid for.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_pass_is_checkpointed_after_every_lens(self, corpus):
+        seen: list[int] = []
+        result = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=_completion_returning({"fail_patterns": [{"name": "x", "anchors": [CORPUS_TEXT[:60]]}]}),
+            lens_keys=["failure", "mechanism"],
+            checkpoint=lambda r: seen.append(len(r.outcomes)),
+        )
+        assert seen == [1, 2]
+        assert len(result.outcomes) == 2
+
+    @pytest.mark.asyncio
+    async def test_a_completed_lens_is_reused_rather_than_re_read(self, corpus):
+        calls: list[str] = []
+
+        async def _completion(prompt):
+            calls.append(prompt)
+            return json.dumps({"fail_patterns": [{"name": "x", "anchors": [CORPUS_TEXT[:60]]}]})
+
+        first = await run_study(expert_name="E", corpus=corpus, completion=_completion, lens_keys=["failure"])
+        after_first = len(calls)
+
+        second = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=_completion,
+            lens_keys=["failure", "mechanism"],
+            resume_from=first.outcomes,
+        )
+
+        assert len(calls) > after_first, "the new lens must still run"
+        assert len(second.outcomes) == 2
+        assert any("Resumed" in limit for limit in second.limitations)
+
+    @pytest.mark.asyncio
+    async def test_a_failed_lens_is_retried_rather_than_reused(self, corpus):
+        """Reusing a parse failure would make the interruption permanent."""
+        failed = LensOutcome(lens="failure", axis="interrogation", status="parse_failed")
+        calls: list[str] = []
+
+        async def _completion(prompt):
+            calls.append(prompt)
+            return json.dumps({"fail_patterns": [{"name": "x", "anchors": [CORPUS_TEXT[:60]]}]})
+
+        result = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=_completion,
+            lens_keys=["failure"],
+            resume_from=[failed],
+        )
+
+        assert calls, "a failed lens must be re-read"
+        assert result.outcomes[0].status == "ok"

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -448,7 +448,7 @@ class TestResumeIsCorpusAware:
         )
 
         assert not any("Resumed" in limit for limit in second.limitations)
-        assert any("corpus changed" in limit for limit in second.limitations)
+        assert any("could not be shown to have read this corpus" in limit for limit in second.limitations)
 
     @pytest.mark.asyncio
     async def test_an_unchanged_corpus_still_resumes(self, corpus):
@@ -466,8 +466,18 @@ class TestResumeIsCorpusAware:
         assert any("Resumed" in limit for limit in second.limitations)
 
     @pytest.mark.asyncio
-    async def test_an_outcome_without_a_fingerprint_is_still_reusable(self, corpus):
-        """Studies written before this existed must not all be discarded."""
+    async def test_an_outcome_that_cannot_prove_what_it_read_is_re_read(self, corpus):
+        """The guard fails closed, and the earlier fail-open version was wrong.
+
+        It was written to spare legacy studies a re-read. Measured on a live
+        expert, every outcome on disk carried an empty fingerprint - so the
+        exception was the rule, and every lens was reused unconditionally
+        however much the corpus had grown. That is the exact failure the
+        fingerprint exists to prevent.
+
+        The trade is one re-read per lens, once, against an expert that
+        silently stops learning from everything it acquires afterwards.
+        """
         legacy = LensOutcome(lens="failure", axis="interrogation", status="ok")
         result = await run_study(
             expert_name="E",
@@ -476,4 +486,5 @@ class TestResumeIsCorpusAware:
             lens_keys=["failure"],
             resume_from=[legacy],
         )
-        assert any("Resumed" in limit for limit in result.limitations)
+        assert not any("Resumed" in limit for limit in result.limitations)
+        assert any("could not be shown to have read this corpus" in limit for limit in result.limitations)

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -422,3 +422,58 @@ class TestReentrancy:
 
         assert calls, "a failed lens must be re-read"
         assert result.outcomes[0].status == "ok"
+
+
+class TestResumeIsCorpusAware:
+    """An expert accumulates sources; resume must not outrun that.
+
+    Keyed on lens name alone, adding a source and re-running reuses findings
+    that never saw the new material - an expert that silently stops learning
+    from what it retained.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_lens_is_re_read_when_the_corpus_grew(self, corpus, tmp_path):
+        completion = _completion_returning({"fail_patterns": [{"name": "x", "anchors": [CORPUS_TEXT[:60]]}]})
+        first = await run_study(expert_name="E", corpus=corpus, completion=completion, lens_keys=["failure"])
+        assert first.outcomes[0].corpus_fingerprint
+
+        corpus.add("A third source arriving after the first pass.", origin_key="url:three.example")
+        second = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=completion,
+            lens_keys=["failure"],
+            resume_from=first.outcomes,
+        )
+
+        assert not any("Resumed" in limit for limit in second.limitations)
+        assert any("corpus changed" in limit for limit in second.limitations)
+
+    @pytest.mark.asyncio
+    async def test_an_unchanged_corpus_still_resumes(self, corpus):
+        completion = _completion_returning({"fail_patterns": [{"name": "x", "anchors": [CORPUS_TEXT[:60]]}]})
+        first = await run_study(expert_name="E", corpus=corpus, completion=completion, lens_keys=["failure"])
+
+        second = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=completion,
+            lens_keys=["failure"],
+            resume_from=first.outcomes,
+        )
+
+        assert any("Resumed" in limit for limit in second.limitations)
+
+    @pytest.mark.asyncio
+    async def test_an_outcome_without_a_fingerprint_is_still_reusable(self, corpus):
+        """Studies written before this existed must not all be discarded."""
+        legacy = LensOutcome(lens="failure", axis="interrogation", status="ok")
+        result = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=_completion_returning({"fail_patterns": []}),
+            lens_keys=["failure"],
+            resume_from=[legacy],
+        )
+        assert any("Resumed" in limit for limit in result.limitations)

--- a/tests/unit/test_experts/test_study.py
+++ b/tests/unit/test_experts/test_study.py
@@ -197,15 +197,100 @@ class TestProvenanceHonesty:
 
         assert findings[0].corpus_shas == [zulu[0][0].sha256]
 
-    def test_findings_get_unique_ids_across_chunks(self, corpus):
+    def test_distinct_findings_get_distinct_ids(self, corpus):
         parsed = {"fail_patterns": [{"name": "a", "anchors": ["x"]}, {"name": "b", "anchors": ["y"]}]}
-        material = corpus.load_study_material()
-        first = build_findings(LENSES["failure"], parsed, material, start_index=1)
-        second = build_findings(LENSES["failure"], parsed, material, start_index=len(first) + 1)
+        findings = build_findings(LENSES["failure"], parsed, corpus.load_study_material())
 
-        ids = [f.finding_id for f in first + second]
-        assert ids == ["failure-1", "failure-2", "failure-3", "failure-4"]
-        assert len(set(ids)) == len(ids)
+        ids = [f.finding_id for f in findings]
+        assert len(set(ids)) == len(ids) == 2
+
+    def test_the_same_finding_seen_twice_gets_the_same_id(self, corpus):
+        """Positional ids could not recognise a re-sighting; content-derived ids can.
+
+        The same finding surfacing in two chunks used to become two findings
+        with two ordinals. It is one finding corroborated twice.
+        """
+        parsed = {"fail_patterns": [{"name": "a", "anchors": ["x"]}]}
+        material = corpus.load_study_material()
+
+        first = build_findings(LENSES["failure"], parsed, material)
+        second = build_findings(LENSES["failure"], parsed, material)
+
+        assert first[0].finding_id == second[0].finding_id
+
+    def test_an_id_does_not_shift_when_an_earlier_finding_disappears(self, corpus):
+        """The bug: a partial resume re-ran one lens, everything renumbered, and
+        a brief citing `failure-30` silently repointed at a different finding.
+        The citation still validated, which is worse than failing."""
+        material = corpus.load_study_material()
+        both = build_findings(
+            LENSES["failure"],
+            {"fail_patterns": [{"name": "a", "anchors": ["x"]}, {"name": "b", "anchors": ["y"]}]},
+            material,
+        )
+        second_only = build_findings(LENSES["failure"], {"fail_patterns": [{"name": "b", "anchors": ["y"]}]}, material)
+
+        assert both[1].finding_id == second_only[0].finding_id
+
+
+class TestReSightingsMergeRatherThanDuplicate:
+    """A finding found again is corroborated, not duplicated.
+
+    Two records sharing one id in the same list would make every downstream
+    lookup keyed by finding_id resolve arbitrarily, so this is a correctness
+    requirement of content-derived ids and not only a nicety.
+    """
+
+    def _finding(self, shas, anchors=("x",)):
+        from deepr.experts.record_identity import finding_thread_id
+        from deepr.experts.study_contracts import StudyFinding
+
+        return StudyFinding(
+            lens="failure",
+            axis="interrogation",
+            kind="fail_patterns",
+            finding_id=finding_thread_id(lens="failure", title="t", anchors=list(anchors)),
+            title="t",
+            anchors=list(anchors),
+            corpus_shas=list(shas),
+            grounded_anchor_count=1,
+        )
+
+    def test_sources_accumulate_across_sightings(self):
+        from deepr.experts.study import _absorb
+
+        findings = [self._finding(["sha-a"])]
+        _absorb(findings, [self._finding(["sha-b"])])
+
+        assert len(findings) == 1
+        assert findings[0].corpus_shas == ["sha-a", "sha-b"]
+
+    def test_a_repeated_source_is_not_counted_twice(self):
+        from deepr.experts.study import _absorb
+
+        findings = [self._finding(["sha-a"])]
+        _absorb(findings, [self._finding(["sha-a"])])
+
+        assert findings[0].corpus_shas == ["sha-a"]
+
+    def test_a_genuinely_different_finding_is_appended(self):
+        from deepr.experts.study import _absorb
+
+        findings = [self._finding(["sha-a"], anchors=("x",))]
+        _absorb(findings, [self._finding(["sha-b"], anchors=("completely other",))])
+
+        assert len(findings) == 2
+
+    def test_a_one_source_finding_becoming_cross_source_is_visible(self):
+        """The evidential claim genuinely changed, and that is the point."""
+        from deepr.experts.study import _absorb
+
+        findings = [self._finding(["sha-a"])]
+        assert len(set(findings[0].corpus_shas)) == 1
+
+        _absorb(findings, [self._finding(["sha-b"])])
+
+        assert len(set(findings[0].corpus_shas)) == 2
 
 
 class TestPrompt:

--- a/tests/unit/test_experts/test_study_capacity.py
+++ b/tests/unit/test_experts/test_study_capacity.py
@@ -1,0 +1,103 @@
+"""Running out of capacity is not the same as finding nothing.
+
+The bug this pins, measured on a live run: a plan backend exhausted its quota
+mid-study. Every remaining call raised, each was caught as a per-chunk failure
+string, the pass carried on calling a dead backend for every remaining chunk
+and lens, and it then wrote a complete-looking study.json with 44 findings from
+two of eight lenses. The reason was recorded only as prose in `limitations`
+that no downstream code reads, and `brief` consumed the result as truth.
+
+The distinction that has to survive into the artifact: "the corpus had nothing
+to say" and "I could not ask" are different results.
+"""
+
+import pytest
+
+from deepr.experts.study import _is_capacity_failure, run_study
+from deepr.experts.study_lenses import LENSES
+
+from .test_study import CORPUS_TEXT, _completion_returning, corpus  # noqa: F401
+
+
+class TestTellingTheTwoApart:
+    def test_a_plan_quota_error_is_a_capacity_failure(self):
+        from deepr.backends.plan_quota.errors import PlanQuotaExhausted
+
+        assert _is_capacity_failure(PlanQuotaExhausted("weekly limit reached"))
+
+    def test_a_stringified_backend_failure_is_recognised_too(self):
+        """Plan CLIs surface this through stderr, wrapped, not as our type."""
+        assert _is_capacity_failure(RuntimeError("API error (status 402 Payment Required): usage balance exhausted"))
+        assert _is_capacity_failure(RuntimeError("429 rate limit exceeded"))
+
+    def test_a_model_answering_badly_is_not_a_capacity_failure(self):
+        """A prose answer is a genuinely partial result; the pass should continue."""
+        assert not _is_capacity_failure(ValueError("no JSON object in response"))
+        assert not _is_capacity_failure(TimeoutError("read timed out"))
+
+
+class TestTheStudyStopsRatherThanDegrading:
+    @pytest.mark.asyncio
+    async def test_exhaustion_stops_the_pass_instead_of_thinning_it(self, corpus):
+        """It used to keep calling a dead backend for every remaining lens."""
+        calls = {"n": 0}
+
+        async def dies_after_one(prompt: str) -> str:
+            calls["n"] += 1
+            if calls["n"] > 1:
+                raise RuntimeError("API error (status 402 Payment Required): usage balance exhausted")
+            return '{"fail_patterns": [{"name": "x", "anchors": ["' + CORPUS_TEXT[:60] + '"]}]}'
+
+        result = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=dies_after_one,
+            lens_keys=["failure", "contention", "mechanism"],
+        )
+
+        # Three lenses were asked for; it must not have called the backend once
+        # per chunk per lens after capacity ran out.
+        assert calls["n"] < 6
+        assert any("Capacity ran out" in limit for limit in result.limitations)
+
+    @pytest.mark.asyncio
+    async def test_the_limitation_says_incomplete_rather_than_thin(self, corpus):
+        async def dead(prompt: str) -> str:
+            raise RuntimeError("plan quota exhausted")
+
+        result = await run_study(expert_name="E", corpus=corpus, completion=dead, lens_keys=["failure", "contention"])
+
+        note = next(limit for limit in result.limitations if "Capacity ran out" in limit)
+        assert "incomplete rather than thin" in note
+        assert "never read" in note
+
+    @pytest.mark.asyncio
+    async def test_findings_gathered_before_exhaustion_are_kept(self, corpus):
+        """They were read before capacity ran out; they are real."""
+        calls = {"n": 0}
+
+        async def dies_after_first_lens(prompt: str) -> str:
+            calls["n"] += 1
+            if calls["n"] > len(LENSES["failure"].output_field) * 0:  # first call only
+                if calls["n"] > 1:
+                    raise RuntimeError("quota exhausted")
+            return '{"fail_patterns": [{"name": "kept", "anchors": ["' + CORPUS_TEXT[:60] + '"]}]}'
+
+        result = await run_study(
+            expert_name="E", corpus=corpus, completion=dies_after_first_lens, lens_keys=["failure", "contention"]
+        )
+
+        assert result.findings, "findings read before exhaustion must survive"
+
+    @pytest.mark.asyncio
+    async def test_a_parse_failure_still_lets_the_pass_continue(self, corpus):
+        """Only capacity stops the run. A bad answer is tolerable per chunk."""
+        result = await run_study(
+            expert_name="E",
+            corpus=corpus,
+            completion=_completion_returning("this is prose, not JSON"),
+            lens_keys=["failure", "contention"],
+        )
+
+        assert not any("Capacity ran out" in limit for limit in result.limitations)
+        assert len(result.outcomes) == 2

--- a/tests/unit/test_experts/test_viva.py
+++ b/tests/unit/test_experts/test_viva.py
@@ -19,6 +19,7 @@ from deepr.experts.viva import (
     attach_judgements,
     build_candidate_prompt,
     build_examiner_prompt,
+    build_judge_prompt,
     parse_questions,
     render_viva,
 )
@@ -197,6 +198,42 @@ class TestPrompts:
 
     def test_the_candidate_is_invited_to_change_its_mind(self):
         assert "changed_my_mind" in build_candidate_prompt(subject="s", brief="B", questions=["Q"])
+
+    def test_examiners_are_required_to_ask_about_the_subject_not_only_the_brief(self):
+        """Measured: without this, a live run returned 12 answered and 0 gaps.
+
+        Reasoning questions can always be answered by introspection - "no, I
+        did not run that check" is honest and is not a knowledge gap. Only a
+        question about substance the corpus may not cover can find something
+        the expert has not read, so the reading queue stays empty without one.
+        """
+        prompt = build_examiner_prompt(subject="s", examiner_frame="f", brief="B")
+        assert "Coverage questions" in prompt
+        assert "third of your questions must be coverage questions" in prompt
+
+    def test_the_judge_decides_on_substance_not_on_candour(self):
+        """Measured: a model gap answer was graded 'answered' for being candid.
+
+        Asked whether aviation human-factors work on alarm fatigue had been
+        consulted, the expert said no and explained what it used instead. The
+        judge rewarded the honesty and threw away the reading-list entry.
+        """
+        prompt = build_judge_prompt(subject="s", exchanges=[_exchange()])
+        assert "does it contain" in prompt
+        assert "explain the absence" in prompt
+        assert "alarm-fatigue" in prompt
+        assert "judging failure" in prompt
+
+    def test_a_gap_must_name_material_outside_the_expert(self):
+        """Measured: over-correcting produced 'the expert explaining its own...'
+
+        No amount of reading fills a missing account of the expert's own
+        reasoning - it already holds everything needed and did not say. Those
+        belong in a re-brief, not in an acquisition queue.
+        """
+        prompt = build_judge_prompt(subject="s", exchanges=[_exchange()])
+        assert "outside the expert" in prompt
+        assert "the expert explaining" in prompt
 
     def test_house_style_reaches_every_prompt(self):
         """No em dashes, per the house rule, stated where the model will see it."""

--- a/tests/unit/test_experts/test_viva.py
+++ b/tests/unit/test_experts/test_viva.py
@@ -108,7 +108,11 @@ class TestAnswers:
         exchanges = [_exchange()]
         moved = attach_answers(
             exchanges,
-            {"answers": [{"question": exchanges[0].question, "answer": "A", "changed_my_mind": "I withdraw position 3."}]},
+            {
+                "answers": [
+                    {"question": exchanges[0].question, "answer": "A", "changed_my_mind": "I withdraw position 3."}
+                ]
+            },
         )
         assert moved == ["I withdraw position 3."]
 
@@ -134,7 +138,11 @@ class TestJudgements:
         exchanges = [_exchange()]
         attach_judgements(
             exchanges,
-            {"judgements": [{"question": exchanges[0].question, "verdict": VERDICT_PARTIAL, "note": "Dodged the sharp half."}]},
+            {
+                "judgements": [
+                    {"question": exchanges[0].question, "verdict": VERDICT_PARTIAL, "note": "Dodged the sharp half."}
+                ]
+            },
         )
         assert exchanges[0].examiner_note == "Dodged the sharp half."
 
@@ -175,7 +183,9 @@ class TestRender:
         assert "has not settled" not in text
 
     def test_the_examiner_is_named_next_to_the_question(self):
-        text = render_viva(VivaResult(expert_name="E", examiners=["furniture"], exchanges=[_exchange(asked_by="furniture")]))
+        text = render_viva(
+            VivaResult(expert_name="E", examiners=["furniture"], exchanges=[_exchange(asked_by="furniture")])
+        )
         assert "asked by furniture" in text
 
     def test_moved_positions_lead_the_document(self):

--- a/tests/unit/test_experts/test_viva.py
+++ b/tests/unit/test_experts/test_viva.py
@@ -1,0 +1,218 @@
+"""Examination where nobody holds the answer key.
+
+The property under test throughout: an unanswered question is an output, not a
+failure. What matters is telling apart the two reasons an expert cannot answer
+- material exists and it has not read it, versus nobody knows - because the
+first is a reading list and the second is the edge of the field.
+"""
+
+import pytest
+
+from deepr.experts.viva import (
+    VERDICT_ANSWERED,
+    VERDICT_CANNOT,
+    VERDICT_OPEN,
+    VERDICT_PARTIAL,
+    VivaExchange,
+    VivaResult,
+    attach_answers,
+    attach_judgements,
+    build_candidate_prompt,
+    build_examiner_prompt,
+    parse_questions,
+    render_viva,
+)
+
+
+def _exchange(**overrides) -> VivaExchange:
+    defaults = dict(
+        question="Why this and not the alternative?",
+        asked_by="provenance",
+        probes="whether the choice was reasoned or inherited",
+        answer="Because the alternative loses the dependency chain.",
+        verdict=VERDICT_ANSWERED,
+    )
+    return VivaExchange(**{**defaults, **overrides})
+
+
+class TestTheTwoKindsOfUnanswered:
+    """The distinction the whole module exists to draw."""
+
+    def test_unread_material_becomes_a_reading_list_entry(self):
+        gap = _exchange(verdict=VERDICT_CANNOT, would_resolve_it="The 2024 revision of the spec.")
+        assert gap.is_gap
+        assert not gap.is_frontier
+
+    def test_an_open_question_is_not_a_deficiency(self):
+        frontier = _exchange(verdict=VERDICT_OPEN)
+        assert frontier.is_frontier
+        assert not frontier.is_gap
+
+    def test_cannot_answer_without_a_route_is_not_a_reading_list_entry(self):
+        """'Go and find out' is not an instruction anyone can follow."""
+        vague = _exchange(verdict=VERDICT_CANNOT, would_resolve_it="")
+        assert not vague.is_gap
+
+    def test_the_reading_queue_is_the_examiners_words_not_the_questions(self):
+        result = VivaResult(
+            expert_name="E",
+            exchanges=[
+                _exchange(verdict=VERDICT_CANNOT, would_resolve_it="The errata list."),
+                _exchange(question="Q2", verdict=VERDICT_OPEN),
+                _exchange(question="Q3"),
+            ],
+        )
+        assert result.reading_queue() == ["The errata list."]
+        assert len(result.frontier) == 1
+        assert len(result.handled) == 1
+
+
+class TestParsing:
+    def test_a_question_with_no_target_is_small_talk_but_still_kept(self):
+        """Recorded without a probe, so the omission is visible in the render."""
+        exchanges = parse_questions({"questions": [{"question": "Thoughts?"}]}, asked_by="x")
+        assert exchanges[0].probes == ""
+
+    def test_questions_without_text_are_dropped(self):
+        parsed = {"questions": [{"probes": "something"}, {"question": "Real?", "probes": "p"}]}
+        assert [e.question for e in parse_questions(parsed, asked_by="x")] == ["Real?"]
+
+    def test_a_flood_of_questions_is_bounded(self):
+        parsed = {"questions": [{"question": f"Q{i}"} for i in range(50)]}
+        assert len(parse_questions(parsed, asked_by="x")) == 8
+
+    def test_junk_entries_do_not_take_the_examination_down(self):
+        parsed = {"questions": ["not a dict", None, {"question": "Real?"}]}
+        assert len(parse_questions(parsed, asked_by="x")) == 1
+
+    def test_the_examiner_is_recorded_on_every_question(self):
+        """A judgement nobody is attached to cannot be argued with."""
+        exchanges = parse_questions({"questions": [{"question": "Q"}]}, asked_by="chinese-writing")
+        assert exchanges[0].asked_by == "chinese-writing"
+
+
+class TestAnswers:
+    def test_answers_match_back_case_insensitively(self):
+        exchanges = [_exchange(answer="")]
+        attach_answers(exchanges, {"answers": [{"question": "WHY THIS AND NOT THE ALTERNATIVE?", "answer": "A"}]})
+        assert exchanges[0].answer == "A"
+
+    def test_an_answer_to_a_question_nobody_asked_is_ignored(self):
+        exchanges = [_exchange(answer="")]
+        attach_answers(exchanges, {"answers": [{"question": "invented", "answer": "A"}]})
+        assert exchanges[0].answer == ""
+
+    def test_a_changed_mind_is_collected(self):
+        """The most valuable outcome available, and the one a score cannot show."""
+        exchanges = [_exchange()]
+        moved = attach_answers(
+            exchanges,
+            {"answers": [{"question": exchanges[0].question, "answer": "A", "changed_my_mind": "I withdraw position 3."}]},
+        )
+        assert moved == ["I withdraw position 3."]
+
+    def test_nothing_moving_is_the_normal_case(self):
+        exchanges = [_exchange()]
+        assert attach_answers(exchanges, {"answers": [{"question": exchanges[0].question, "answer": "A"}]}) == []
+
+
+class TestJudgements:
+    def test_an_unrecognised_verdict_falls_back_to_partial_not_to_a_pass(self):
+        """A malformed judgement must not be able to award a clean result."""
+        exchanges = [_exchange(verdict=VERDICT_ANSWERED)]
+        attach_judgements(exchanges, {"judgements": [{"question": exchanges[0].question, "verdict": "excellent"}]})
+        assert exchanges[0].verdict == VERDICT_PARTIAL
+
+    @pytest.mark.parametrize("verdict", [VERDICT_ANSWERED, VERDICT_PARTIAL, VERDICT_CANNOT, VERDICT_OPEN])
+    def test_every_real_verdict_survives_the_round_trip(self, verdict):
+        exchanges = [_exchange()]
+        attach_judgements(exchanges, {"judgements": [{"question": exchanges[0].question, "verdict": verdict}]})
+        assert exchanges[0].verdict == verdict
+
+    def test_the_note_is_kept_so_the_verdict_can_be_argued_with(self):
+        exchanges = [_exchange()]
+        attach_judgements(
+            exchanges,
+            {"judgements": [{"question": exchanges[0].question, "verdict": VERDICT_PARTIAL, "note": "Dodged the sharp half."}]},
+        )
+        assert exchanges[0].examiner_note == "Dodged the sharp half."
+
+
+class TestSummaryIsNotAScore:
+    def test_no_letter_and_no_number_out_of_anything(self):
+        result = VivaResult(expert_name="E", examiners=["a"], exchanges=[_exchange()])
+        assert "/" not in result.summary()
+
+    def test_an_examination_with_no_questions_says_so_rather_than_passing(self):
+        assert "No questions" in VivaResult(expert_name="E").summary()
+
+    def test_moved_positions_are_surfaced_in_the_summary(self):
+        result = VivaResult(
+            expert_name="E", examiners=["a"], exchanges=[_exchange()], positions_that_moved=["dropped position 2"]
+        )
+        assert "1 position(s) moved" in result.summary()
+
+
+class TestRender:
+    def test_gaps_render_as_work_and_frontier_renders_as_context(self):
+        result = VivaResult(
+            expert_name="Provenance",
+            examiners=["chinese-writing"],
+            exchanges=[
+                _exchange(verdict=VERDICT_CANNOT, would_resolve_it="The errata list."),
+                _exchange(question="Q2", verdict=VERDICT_OPEN),
+            ],
+        )
+        text = render_viva(result)
+        assert "## What to go and read" in text
+        assert "The errata list." in text
+        assert "Not deficiencies" in text
+
+    def test_a_clean_examination_renders_neither_section(self):
+        text = render_viva(VivaResult(expert_name="E", examiners=["a"], exchanges=[_exchange()]))
+        assert "## What to go and read" not in text
+        assert "has not settled" not in text
+
+    def test_the_examiner_is_named_next_to_the_question(self):
+        text = render_viva(VivaResult(expert_name="E", examiners=["furniture"], exchanges=[_exchange(asked_by="furniture")]))
+        assert "asked by furniture" in text
+
+    def test_moved_positions_lead_the_document(self):
+        """What changed is the finding; the transcript is the supporting detail."""
+        result = VivaResult(expert_name="E", exchanges=[_exchange()], positions_that_moved=["withdrew position 3"])
+        text = render_viva(result)
+        assert text.index("withdrew position 3") < text.index(result.exchanges[0].question)
+
+
+class TestPrompts:
+    def test_the_examiner_is_told_it_is_not_the_subject_expert(self):
+        prompt = build_examiner_prompt(subject="hieroglyphs", examiner_frame="evaluation design", brief="B")
+        assert "you are not expected to be" in prompt
+        assert "evaluation design" in prompt
+
+    def test_the_candidate_is_told_that_not_knowing_is_a_real_answer(self):
+        prompt = build_candidate_prompt(subject="s", brief="B", questions=["Q1", "Q2"])
+        assert "not a failure" in prompt
+        assert "1. Q1" in prompt
+
+    def test_the_candidate_is_invited_to_change_its_mind(self):
+        assert "changed_my_mind" in build_candidate_prompt(subject="s", brief="B", questions=["Q"])
+
+    def test_house_style_reaches_every_prompt(self):
+        """No em dashes, per the house rule, stated where the model will see it."""
+        for prompt in (
+            build_examiner_prompt(subject="s", examiner_frame="f", brief="B"),
+            build_candidate_prompt(subject="s", brief="B", questions=["Q"]),
+        ):
+            assert "never an en dash or em dash" in prompt
+
+
+class TestSerialization:
+    def test_the_dict_carries_the_reading_queue_not_just_the_transcript(self):
+        result = VivaResult(
+            expert_name="E",
+            exchanges=[_exchange(verdict=VERDICT_CANNOT, would_resolve_it="The errata list.")],
+        )
+        data = result.to_dict()
+        assert data["reading_queue"] == ["The errata list."]
+        assert data["exchanges"][0]["is_gap"] is True

--- a/tests/unit/test_experts/test_viva_session.py
+++ b/tests/unit/test_experts/test_viva_session.py
@@ -1,0 +1,194 @@
+"""Running an examination against a scripted panel.
+
+The behaviours that matter here are failure behaviours. A viva makes several
+model calls and any of them can come back as prose, as nothing, or as an
+exception; the examination has to degrade rather than collapse, because a panel
+of three where one times out is still a panel of two.
+"""
+
+from deepr.experts.viva import VERDICT_ANSWERED, VERDICT_PARTIAL
+from deepr.experts.viva_session import DEFAULT_PANEL, Examiner, run_viva
+
+_PANEL = [Examiner(name="method", frame="evidence", questions=1)]
+
+
+class _Script:
+    """Replies in order, recording what it was asked."""
+
+    def __init__(self, *replies: str):
+        self.replies = list(replies)
+        self.prompts: list[str] = []
+
+    def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.replies.pop(0) if self.replies else ""
+
+
+def _run(script: _Script, examiners=None):
+    return run_viva(
+        expert_name="E",
+        subject="s",
+        brief="B",
+        examiners=examiners or _PANEL,
+        completion=script,
+    )
+
+
+class TestTheHappyPath:
+    def test_a_full_examination_produces_a_transcript_and_a_reading_list(self):
+        result = _run(
+            _Script(
+                '{"questions": [{"question": "Why this?", "probes": "reasoning"}]}',
+                '{"answers": [{"question": "Why this?", "answer": "Because X."}]}',
+                '{"judgements": [{"question": "Why this?", "verdict": "cannot_answer",'
+                ' "note": "not held", "would_resolve_it": "The 2024 errata."}]}',
+            )
+        )
+        assert result.exchanges[0].answer == "Because X."
+        assert result.reading_queue() == ["The 2024 errata."]
+
+    def test_a_changed_mind_is_carried_into_the_result(self):
+        result = _run(
+            _Script(
+                '{"questions": [{"question": "Q"}]}',
+                '{"answers": [{"question": "Q", "answer": "A", "changed_my_mind": "I withdraw 3."}]}',
+                '{"judgements": [{"question": "Q", "verdict": "answered"}]}',
+            )
+        )
+        assert result.positions_that_moved == ["I withdraw 3."]
+
+    def test_the_candidate_sees_every_question_at_once(self):
+        """Answering question six differently because two covered it is real."""
+        script = _Script(
+            '{"questions": [{"question": "Q1"}, {"question": "Q2"}]}',
+            '{"answers": []}',
+            "{}",
+        )
+        _run(script)
+        assert "1. Q1" in script.prompts[1] and "2. Q2" in script.prompts[1]
+
+
+class TestExaminersJudgeOnlyTheirOwn:
+    def test_a_judgement_cannot_reach_another_examiners_question(self):
+        """Only the asker knows what was being probed."""
+        panel = [Examiner(name="a", frame="f", questions=1), Examiner(name="b", frame="f", questions=1)]
+        result = run_viva(
+            expert_name="E",
+            subject="s",
+            brief="B",
+            examiners=panel,
+            completion=_Script(
+                '{"questions": [{"question": "QA"}]}',
+                '{"questions": [{"question": "QB"}]}',
+                '{"answers": []}',
+                # Examiner a tries to judge both.
+                '{"judgements": [{"question": "QA", "verdict": "answered"},'
+                ' {"question": "QB", "verdict": "cannot_answer", "would_resolve_it": "x"}]}',
+                "{}",
+            ),
+        )
+        by_q = {e.question: e for e in result.exchanges}
+        assert by_q["QA"].verdict == VERDICT_ANSWERED
+        assert by_q["QB"].verdict == VERDICT_ANSWERED  # untouched default, not a's verdict
+
+    def test_each_examiner_is_shown_only_its_own_transcript(self):
+        panel = [Examiner(name="a", frame="f", questions=1), Examiner(name="b", frame="f", questions=1)]
+        script = _Script(
+            '{"questions": [{"question": "QA"}]}',
+            '{"questions": [{"question": "QB"}]}',
+            '{"answers": []}',
+            "{}",
+            "{}",
+        )
+        run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=script)
+        assert "QA" in script.prompts[3] and "QB" not in script.prompts[3]
+
+
+class TestDegradingRatherThanCollapsing:
+    def test_one_examiner_failing_leaves_a_smaller_panel(self):
+        panel = [Examiner(name="a", frame="dies", questions=1), Examiner(name="b", frame="lives", questions=1)]
+
+        def flaky(prompt: str) -> str:
+            if "You come from dies" in prompt:
+                raise TimeoutError("examiner a died")
+            if "You come from lives" in prompt:
+                return '{"questions": [{"question": "QB"}]}'
+            return '{"answers": [{"question": "QB", "answer": "A"}]}'
+
+        result = run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=flaky)
+        assert [e.question for e in result.exchanges] == ["QB"]
+        assert result.exchanges[0].asked_by == "b"
+
+    def test_a_panel_that_all_failed_returns_an_examination_that_says_so(self):
+        result = _run(_Script("not json at all"))
+        assert result.exchanges == []
+        assert "No questions" in result.summary()
+
+    def test_prose_around_the_json_is_recovered(self):
+        result = _run(
+            _Script(
+                'Here are my questions:\n{"questions": [{"question": "Q"}]}\nHope that helps.',
+                '```json\n{"answers": [{"question": "Q", "answer": "A"}]}\n```',
+                "{}",
+            )
+        )
+        assert result.exchanges[0].answer == "A"
+
+    def test_an_unjudged_question_does_not_silently_pass_as_a_gap(self):
+        """A judge that returned nothing leaves the default, which is not is_gap."""
+        result = _run(
+            _Script('{"questions": [{"question": "Q"}]}', '{"answers": []}', "")
+        )
+        assert not result.exchanges[0].is_gap
+        assert result.reading_queue() == []
+
+    def test_a_judge_returning_junk_leaves_partial_rather_than_answered(self):
+        result = _run(
+            _Script(
+                '{"questions": [{"question": "Q"}]}',
+                '{"answers": [{"question": "Q", "answer": "A"}]}',
+                '{"judgements": [{"question": "Q", "verdict": "brilliant"}]}',
+            )
+        )
+        assert result.exchanges[0].verdict == VERDICT_PARTIAL
+
+
+class TestTheDefaultPanel:
+    def test_three_standpoints_not_three_specialists(self):
+        assert len(DEFAULT_PANEL) == 3
+        assert len({e.frame for e in DEFAULT_PANEL}) == 3
+
+    def test_the_opposing_case_has_a_seat(self):
+        """Without one, the panel can agree the candidate is fine by not asking."""
+        assert any("opposing" in e.frame for e in DEFAULT_PANEL)
+
+    def test_each_frame_reaches_the_prompt_that_examiner_sees(self):
+        script = _Script()
+        run_viva(
+            expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script
+        )
+        for examiner in DEFAULT_PANEL:
+            assert any(examiner.frame in p for p in script.prompts)
+
+
+class TestCapacity:
+    def test_the_call_count_is_bounded_by_the_panel(self):
+        """Two per examiner plus one candidate pass. A viva must not be open-ended."""
+        script = _Script()
+        run_viva(
+            expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script
+        )
+        # All examiners returned nothing, so it stops after the question round.
+        assert len(script.prompts) == 3
+
+    def test_a_full_run_costs_two_per_examiner_plus_one(self):
+        script = _Script(
+            '{"questions": [{"question": "Q1"}]}',
+            '{"questions": [{"question": "Q2"}]}',
+            '{"answers": []}',
+            "{}",
+            "{}",
+        )
+        panel = [Examiner(name="a", frame="f1"), Examiner(name="b", frame="f2")]
+        run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=script)
+        assert len(script.prompts) == 5

--- a/tests/unit/test_experts/test_viva_session.py
+++ b/tests/unit/test_experts/test_viva_session.py
@@ -76,21 +76,23 @@ class TestExaminersJudgeOnlyTheirOwn:
     def test_a_judgement_cannot_reach_another_examiners_question(self):
         """Only the asker knows what was being probed."""
         panel = [Examiner(name="a", frame="f", questions=1), Examiner(name="b", frame="f", questions=1)]
-        result = asyncio.run(run_viva(
-            expert_name="E",
-            subject="s",
-            brief="B",
-            examiners=panel,
-            completion=_Script(
-                '{"questions": [{"question": "QA"}]}',
-                '{"questions": [{"question": "QB"}]}',
-                '{"answers": []}',
-                # Examiner a tries to judge both.
-                '{"judgements": [{"question": "QA", "verdict": "answered"},'
-                ' {"question": "QB", "verdict": "cannot_answer", "would_resolve_it": "x"}]}',
-                "{}",
-            ),
-        ))
+        result = asyncio.run(
+            run_viva(
+                expert_name="E",
+                subject="s",
+                brief="B",
+                examiners=panel,
+                completion=_Script(
+                    '{"questions": [{"question": "QA"}]}',
+                    '{"questions": [{"question": "QB"}]}',
+                    '{"answers": []}',
+                    # Examiner a tries to judge both.
+                    '{"judgements": [{"question": "QA", "verdict": "answered"},'
+                    ' {"question": "QB", "verdict": "cannot_answer", "would_resolve_it": "x"}]}',
+                    "{}",
+                ),
+            )
+        )
         by_q = {e.question: e for e in result.exchanges}
         assert by_q["QA"].verdict == VERDICT_ANSWERED
         assert by_q["QB"].verdict == VERDICT_ANSWERED  # untouched default, not a's verdict
@@ -140,9 +142,7 @@ class TestDegradingRatherThanCollapsing:
 
     def test_an_unjudged_question_does_not_silently_pass_as_a_gap(self):
         """A judge that returned nothing leaves the default, which is not is_gap."""
-        result = _run(
-            _Script('{"questions": [{"question": "Q"}]}', '{"answers": []}', "")
-        )
+        result = _run(_Script('{"questions": [{"question": "Q"}]}', '{"answers": []}', ""))
         assert not result.exchanges[0].is_gap
         assert result.reading_queue() == []
 
@@ -168,9 +168,7 @@ class TestTheDefaultPanel:
 
     def test_each_frame_reaches_the_prompt_that_examiner_sees(self):
         script = _Script()
-        asyncio.run(
-            run_viva(expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script)
-        )
+        asyncio.run(run_viva(expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script))
         for examiner in DEFAULT_PANEL:
             assert any(examiner.frame in p for p in script.prompts)
 
@@ -179,9 +177,7 @@ class TestCapacity:
     def test_the_call_count_is_bounded_by_the_panel(self):
         """Two per examiner plus one candidate pass. A viva must not be open-ended."""
         script = _Script()
-        asyncio.run(
-            run_viva(expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script)
-        )
+        asyncio.run(run_viva(expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script))
         # All examiners returned nothing, so it stops after the question round.
         assert len(script.prompts) == 3
 

--- a/tests/unit/test_experts/test_viva_session.py
+++ b/tests/unit/test_experts/test_viva_session.py
@@ -6,6 +6,8 @@ exception; the examination has to degrade rather than collapse, because a panel
 of three where one times out is still a panel of two.
 """
 
+import asyncio
+
 from deepr.experts.viva import VERDICT_ANSWERED, VERDICT_PARTIAL
 from deepr.experts.viva_session import DEFAULT_PANEL, Examiner, run_viva
 
@@ -19,18 +21,20 @@ class _Script:
         self.replies = list(replies)
         self.prompts: list[str] = []
 
-    def __call__(self, prompt: str) -> str:
+    async def __call__(self, prompt: str) -> str:
         self.prompts.append(prompt)
         return self.replies.pop(0) if self.replies else ""
 
 
 def _run(script: _Script, examiners=None):
-    return run_viva(
-        expert_name="E",
-        subject="s",
-        brief="B",
-        examiners=examiners or _PANEL,
-        completion=script,
+    return asyncio.run(
+        run_viva(
+            expert_name="E",
+            subject="s",
+            brief="B",
+            examiners=examiners or _PANEL,
+            completion=script,
+        )
     )
 
 
@@ -72,7 +76,7 @@ class TestExaminersJudgeOnlyTheirOwn:
     def test_a_judgement_cannot_reach_another_examiners_question(self):
         """Only the asker knows what was being probed."""
         panel = [Examiner(name="a", frame="f", questions=1), Examiner(name="b", frame="f", questions=1)]
-        result = run_viva(
+        result = asyncio.run(run_viva(
             expert_name="E",
             subject="s",
             brief="B",
@@ -86,7 +90,7 @@ class TestExaminersJudgeOnlyTheirOwn:
                 ' {"question": "QB", "verdict": "cannot_answer", "would_resolve_it": "x"}]}',
                 "{}",
             ),
-        )
+        ))
         by_q = {e.question: e for e in result.exchanges}
         assert by_q["QA"].verdict == VERDICT_ANSWERED
         assert by_q["QB"].verdict == VERDICT_ANSWERED  # untouched default, not a's verdict
@@ -100,7 +104,7 @@ class TestExaminersJudgeOnlyTheirOwn:
             "{}",
             "{}",
         )
-        run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=script)
+        asyncio.run(run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=script))
         assert "QA" in script.prompts[3] and "QB" not in script.prompts[3]
 
 
@@ -108,14 +112,14 @@ class TestDegradingRatherThanCollapsing:
     def test_one_examiner_failing_leaves_a_smaller_panel(self):
         panel = [Examiner(name="a", frame="dies", questions=1), Examiner(name="b", frame="lives", questions=1)]
 
-        def flaky(prompt: str) -> str:
+        async def flaky(prompt: str) -> str:
             if "You come from dies" in prompt:
                 raise TimeoutError("examiner a died")
             if "You come from lives" in prompt:
                 return '{"questions": [{"question": "QB"}]}'
             return '{"answers": [{"question": "QB", "answer": "A"}]}'
 
-        result = run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=flaky)
+        result = asyncio.run(run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=flaky))
         assert [e.question for e in result.exchanges] == ["QB"]
         assert result.exchanges[0].asked_by == "b"
 
@@ -164,8 +168,8 @@ class TestTheDefaultPanel:
 
     def test_each_frame_reaches_the_prompt_that_examiner_sees(self):
         script = _Script()
-        run_viva(
-            expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script
+        asyncio.run(
+            run_viva(expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script)
         )
         for examiner in DEFAULT_PANEL:
             assert any(examiner.frame in p for p in script.prompts)
@@ -175,8 +179,8 @@ class TestCapacity:
     def test_the_call_count_is_bounded_by_the_panel(self):
         """Two per examiner plus one candidate pass. A viva must not be open-ended."""
         script = _Script()
-        run_viva(
-            expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script
+        asyncio.run(
+            run_viva(expert_name="E", subject="s", brief="B", examiners=list(DEFAULT_PANEL), completion=script)
         )
         # All examiners returned nothing, so it stops after the question round.
         assert len(script.prompts) == 3
@@ -190,5 +194,5 @@ class TestCapacity:
             "{}",
         )
         panel = [Examiner(name="a", frame="f1"), Examiner(name="b", frame="f2")]
-        run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=script)
+        asyncio.run(run_viva(expert_name="E", subject="s", brief="B", examiners=panel, completion=script))
         assert len(script.prompts) == 5

--- a/tests/unit/test_schemas/test_published_contracts.py
+++ b/tests/unit/test_schemas/test_published_contracts.py
@@ -187,6 +187,7 @@ from deepr.mcp.smoke import (
     MCPHttpSmokeStep,
     build_http_registration_manifest,
 )
+from tests.expert_time_helpers import recent_cutoff as _recent_cutoff
 from tests.unit.graph_commit_helpers import (
     graph_commit_agenda_operation,
     graph_commit_concept_operation,
@@ -532,7 +533,7 @@ def test_expert_self_model_schema_validates_runtime_payload():
         name="Self Model Expert",
         vector_store_id="vs-self-model",
         domain="self models",
-        knowledge_cutoff_date=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
         installed_skills=["consult-review"],
     )
@@ -555,7 +556,7 @@ def test_expert_next_schema_validates_runtime_payload():
         name="Next Action Expert",
         vector_store_id="",
         domain="expert operations",
-        knowledge_cutoff_date=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
     )
     manifest = ExpertManifest(
         expert_name=profile.name,
@@ -576,7 +577,7 @@ def test_expert_memory_card_schema_validates_runtime_payload():
         name="Memory Card Contract Expert",
         vector_store_id="vs-memory-contract",
         domain="expert memory",
-        knowledge_cutoff_date=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
     )
     manifest = ExpertManifest(
@@ -619,7 +620,7 @@ def test_metacognitive_monitor_schema_validates_runtime_payload():
         name="Monitor Expert",
         vector_store_id="vs-monitor",
         domain="monitoring",
-        knowledge_cutoff_date=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
     )
     manifest = ExpertManifest(
@@ -646,7 +647,7 @@ def test_self_model_update_schema_validates_runtime_payload(tmp_path):
         name="Self Model Update Contract Expert",
         vector_store_id="",
         domain="self-model updates",
-        knowledge_cutoff_date=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
     )
     manifest = ExpertManifest(
@@ -682,7 +683,7 @@ def test_self_model_update_acceptance_schema_validates_runtime_payload(tmp_path)
         name="Self Model Acceptance Contract Expert",
         vector_store_id="",
         domain="self-model updates",
-        knowledge_cutoff_date=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
     )
     manifest = ExpertManifest(
@@ -726,7 +727,7 @@ def test_metacognitive_promotion_schema_validates_runtime_payload(tmp_path):
         name="Promotion Expert",
         vector_store_id="vs-promotion",
         domain="promotion",
-        knowledge_cutoff_date=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        knowledge_cutoff_date=_recent_cutoff(),
         last_knowledge_refresh=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
     )
     manifest = ExpertManifest(

--- a/tests/unit/test_security/test_key_quarantine.py
+++ b/tests/unit/test_security/test_key_quarantine.py
@@ -1,0 +1,93 @@
+"""Metered keys removed from Deepr's own process, not merely checked.
+
+The gap this closes was found by auditing a real machine. Every key in `.env`
+was renamed, and three were still live in the process - OPENAI, XAI and
+ANTHROPIC - because they were set at the Windows user level and `.env` was
+never their only source. Editing `.env` looks like disarming something and is
+not.
+"""
+
+from deepr.security.key_quarantine import (
+    OPT_OUT_VAR,
+    QUARANTINE_PREFIX,
+    live_metered_names,
+    quarantine_metered_keys,
+    quarantined_names,
+)
+
+
+class TestKeysAreMovedNotJustChecked:
+    def test_a_metered_key_is_removed_from_the_environment(self):
+        """A guard has to be reached. An absent variable cannot be read."""
+        env = {"OPENAI_API_KEY": "sk-proj-live", "PATH": "/usr/bin"}
+
+        moved = quarantine_metered_keys(env)
+
+        assert moved == ["OPENAI_API_KEY"]
+        assert "OPENAI_API_KEY" not in env
+        assert env["PATH"] == "/usr/bin"
+
+    def test_the_value_is_preserved_rather_than_destroyed(self):
+        """Silently destroying a credential someone set on purpose is its own
+        kind of surprise."""
+        env = {"ANTHROPIC_API_KEY": "sk-ant-live"}
+        quarantine_metered_keys(env)
+
+        assert env[QUARANTINE_PREFIX + "ANTHROPIC_API_KEY"] == "sk-ant-live"
+
+    def test_every_key_the_windows_audit_found_is_covered(self):
+        """The three that survived a full .env rename on the real machine."""
+        env = {"OPENAI_API_KEY": "a", "XAI_API_KEY": "b", "ANTHROPIC_API_KEY": "c"}
+
+        quarantine_metered_keys(env)
+
+        assert live_metered_names(env) == []
+
+    def test_it_reaches_wider_than_the_plan_quota_adapters(self):
+        """This runs in Deepr's process, where any importable SDK could read one."""
+        env = {"OPENROUTER_API_KEY": "x", "MISTRAL_API_KEY": "y", "GROQ_API_KEY": "z"}
+        assert len(quarantine_metered_keys(env)) == 3
+
+    def test_a_blank_key_is_not_treated_as_present(self):
+        """Blanked-out entries are the disarmed state, not something to move."""
+        env = {"OPENAI_API_KEY": "", "XAI_API_KEY": "   "}
+        assert quarantine_metered_keys(env) == []
+
+    def test_non_key_variables_are_untouched(self):
+        env = {"DEEPR_MAX_COST_PER_DAY": "5.0", "HOME": "/home/x"}
+        quarantine_metered_keys(env)
+        assert env == {"DEEPR_MAX_COST_PER_DAY": "5.0", "HOME": "/home/x"}
+
+
+class TestTheEscapeHatch:
+    def test_an_operator_can_opt_out_deliberately(self):
+        """A safety measure with no escape hatch gets disabled wholesale."""
+        env = {OPT_OUT_VAR: "1", "OPENAI_API_KEY": "sk-live"}
+
+        assert quarantine_metered_keys(env) == []
+        assert env["OPENAI_API_KEY"] == "sk-live"
+
+    def test_the_opt_out_requires_a_truthy_value(self):
+        env = {OPT_OUT_VAR: "no", "OPENAI_API_KEY": "sk-live"}
+        assert quarantine_metered_keys(env) == ["OPENAI_API_KEY"]
+
+
+class TestReporting:
+    def test_what_was_moved_can_be_listed_back(self):
+        env = {"OPENAI_API_KEY": "a", "GEMINI_API_KEY": "b"}
+        quarantine_metered_keys(env)
+
+        assert quarantined_names(env) == ["GEMINI_API_KEY", "OPENAI_API_KEY"]
+
+    def test_live_names_is_the_honest_answer_to_can_this_bill_me(self):
+        env = {"OPENAI_API_KEY": "a"}
+        assert live_metered_names(env) == ["OPENAI_API_KEY"]
+
+        quarantine_metered_keys(env)
+        assert live_metered_names(env) == []
+
+    def test_running_twice_is_a_no_op(self):
+        env = {"OPENAI_API_KEY": "a"}
+        quarantine_metered_keys(env)
+        assert quarantine_metered_keys(env) == []
+        assert env[QUARANTINE_PREFIX + "OPENAI_API_KEY"] == "a"


### PR DESCRIPTION
Eight commits on one thread: making an expert something you can consult rather than a fact list you can query.

## What this adds

**An expert can source itself.** `corpus_search` runs six acquisition arms (descriptive, adversarial, genre, primary, recency, terminology), interleaved round-robin so early stopping cannot skip the adversarial queries. Query text is model-written; only the arm structure is enforced. Throttled at 2.5s, injectable so the suite does not pay for it.

**All four plan CLIs work.** claude, grok, codex and antigravity were each reported as blocked for a different reason, and all three causes were in Deepr's own config rather than in the CLIs. Tools are stripped at dispatch instead of auto-approved, and the Windows `.cmd` shim problem is bypassed by mapping to the native `.exe`. opencode and kiro stay blocked, for reasons that are still true.

**Study is resumable and honest about what it did.** Chunks now pack multiple sources so cross-source comparison is structurally possible (measured: 0 to 4 cross-source findings on the same corpus, lens and model). Findings are grounded against the chunk the lens actually saw rather than the whole corpus, which was silently misattributing anchors. A study that grounds nothing exits 2 instead of 0.

**Examination without an answer key.** `viva.py` and `viva_session.py` run a doctoral viva: examiners from other standpoints probe, the candidate answers, and each examiner judges only what it asked. The judgement that matters is the split between "answerable from material that exists" (a reading list) and "nobody knows" (the edge of the field). No score, because the useful outputs are the reading list and the occasional position that does not survive a good question.

**Fleet triage.** `deepr expert health` grades all 49 experts and pairs every letter with one next action. The ladder is a progression, one thing per rung, and the only difference between A and S is whether anyone has actually consulted the expert lately.

## What this deliberately does not claim

The grade is artifact hygiene, not quality. Five mutually-agreeing bad sources score exactly like five good ones. It answers "which three of fifty need work this week" and nothing else; whether an expert knows anything is a per-subject test, and `docs/design/what-an-expert-is.md` says so at length.

## Cost

$0. Every model call routes to local or prepaid plan quota. Paid API stayed frozen at a $0.00 hard ceiling for the whole of this work, verified via `deepr costs show`, with all four API keys present in the environment and stripped from every plan-quota child process.

## Verification

- Full expert suite: 2891 passing
- Guards at baseline: C901 134, S 55, file-size, docs, paid-API boundary
- `ruff check src tests` clean