### PR TITLE
release: v2.46.0 an expert that holds a view

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -364,9 +364,19 @@ reliable product, not a four-language architecture diagram.
 
 ---
 
-## Current Status (v2.45.0)
+## Current Status (v2.46.0)
 
-**Shipped in v2.45.0 (see docs/CHANGELOG.md):** the v2 expert stack is now
+**Shipped in v2.46.0 (see docs/CHANGELOG.md):** an expert now holds a view
+rather than a list of claims. A position ledger keeps every view it has held
+with what moved each one; a viva examines it and returns a reading list
+separated from a genuine frontier; a perspective graph records the biography of
+the standpoint. Expert directories are named from the expert's point of view -
+`self.json`, `noticed/`, `hold/`, `became/`, `attend/`, `met/` - and all 57
+experts migrated, verified field by field against a pre-migration backup with
+zero differences. Metered API keys are moved out of the process environment at
+startup rather than merely checked for.
+
+**Shipped in v2.45.0:** the v2 expert stack is now
 reachable from `consult`, an expert can source its own corpus, and several
 measurements that were quietly false have been corrected. Corpus independence
 is reported as effective origin count rather than document count; a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.46.0] - 2026-08-11
+
+An expert stops being a list of retrieved claims and becomes something that
+holds a view, can say how it came to it, and can be examined on it.
+
+2.45.0 made an expert's measurements honest. This release gives it something to
+be honest about: a standpoint of its own, a record of every view it has held
+and what moved each one, and an examination that separates what it can answer
+from what nobody can.
+
+### Added
+
+- **A position ledger** (`deepr.experts.position_ledger`,
+  `hold/history.json`). Every view an expert has held, appended with what moved
+  it and the corpus it was formed over. Positions carry a durable identity
+  (`deepr.experts.record_identity`) so a falsifier registered today still
+  refers to the same question after a re-brief.
+
+  Identity alone was not enough. A brief with no memory of its own prior
+  questions rephrases them, and a content-derived id then matches nothing:
+  the same corpus briefed twice produced 7 different questions and restated 0
+  of 9. Showing the brief its prior positions fixed it - 7 revised, 0 dropped.
+  A falsifier clock started before that would have reset itself every run
+  while appearing to work.
+
+- **A viva** (`deepr.experts.viva`, `viva_session`, `deepr expert viva`).
+  Examiners holding other standpoints put questions to the expert. The valuable
+  output is not a score: it is the split between what is answerable from
+  material the expert has not read yet - a reading list - and what nobody
+  currently knows, which is a research frontier.
+
+- **A perspective graph** (`deepr.experts.perspective_graph`, `became/`). The
+  biography of a viewpoint: standpoints, shifts, encounters, commitments and
+  pursuits. Distinct from the evidence graph
+  (`deepr.experts.evidence_graph`), which answers "why do you think that";
+  this answers "who are you and what moved you". Having a history is what
+  distinguishes an experienced expert from a new one.
+
+- **A research practice** (`deepr.experts.research_practice`, `attend/`).
+  Pursuits an expert is chasing, watches on sources worth staying current with,
+  and standing interests. Watches are earned from evidence rather than ranked
+  by a model.
+
+- **A self-account** (`deepr.experts.expert_profile_card`, `self.json`). The
+  expert's own name, standpoint, preferred lens, open questions, known
+  weaknesses, voice, what it would be glad to be asked, and how it wants to be
+  depicted. Shifts are appended, never rewritten.
+
+- **A stage contract** (`deepr.experts.stage_contract`, `deepr expert status`).
+  Presence is not validity. A synthesis that timed out still wrote a brief
+  holding zero positions and exited 0; the next stage read it, found it
+  parseable, and produced a standpoint about the pipeline failing rather than
+  about the subject. Stages now report `failed` - the artifact exists and
+  carries nothing - separately from `blocked` and `ready`.
+
+- **Key quarantine** (`deepr.security.key_quarantine`). Metered API keys are
+  moved out of `os.environ` into a `DEEPR_QUARANTINED_` prefix at startup, so
+  no client library can pick one up. Checking for keys is a policy; removing
+  them is a property.
+
+- **Model provenance** (`deepr.experts.model_provenance`). Work is ranked by
+  the *weakest* model in its chain, and an unknown model never satisfies a
+  floor.
+
+- **Adaptive plan capacity** (`deepr.experts.backend_pool`,
+  `deepr.backends.quota_headroom`). An exhausted plan is dropped from rotation
+  for the rest of a run and never persisted, since quota returns. Capacity
+  exhaustion is recorded as itself: "the corpus had nothing to say" and "I
+  could not ask" are different outcomes and now survive into the artifact.
+
+- **Source discovery** (`deepr.experts.corpus_search`,
+  `deepr.experts.query_proposal`). An expert can find candidate sources rather
+  than waiting for someone to name URLs.
+
+- **`deepr expert migrate`**, which moves experts to the current layout. Dry
+  run by default; never overwrites; reports a non-empty directory instead of
+  deleting it.
+
+- **Experts choose how they are depicted** (`appearance` in `self.json`). The
+  portrait prompt described the subject an expert studies, with a hash-seeded
+  demographic rotation for variety, so two experts on one domain with opposite
+  standpoints rendered nearly identically - backwards for the thing a portrait
+  is for. An expert that chooses its own name now chooses its own face, and the
+  old prompt remains the fallback for an expert with no self-account.
+
 ### Changed
 
 - **Expert directories are named from the expert's point of view**
@@ -32,14 +117,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The migration reports a non-empty directory instead of deleting it, which is
   the only reason that was caught.
 
-### Added
+### Fixed
 
-- **Experts choose how they are depicted** (`appearance` in `self.json`). The
-  portrait prompt described the subject an expert studies, with a hash-seeded
-  demographic rotation for variety, so two experts on one domain with opposite
-  standpoints rendered nearly identically - backwards for the thing a portrait
-  is for. An expert that chooses its own name now chooses its own face, and the
-  old prompt remains the fallback for an expert with no self-account.
+- **Early stopping could skip a search arm.** `every_arm_tried` compared
+  against a hardcoded 5 while `ARMS` held 6, so a plan carrying all six could
+  satisfy the gate with one arm never run, and which arm got dropped was
+  whatever the interleave left last. Comparing against `len(ARMS)` would have
+  been worse: `plan_queries` emits no terminology queries for many subjects, so
+  the gate would never open and every query would run - the roughly
+  120-request burst that got three builds rate-limited. Coverage is now judged
+  against the arms the plan actually contains.
+
+- **Fleet health sorted backwards** against its own heading, so within a grade
+  the experts most in need of sources sat at the bottom of a list whose purpose
+  is showing what needs attention.
+
+- **Sixteen tests had an expiry date.** Freshness is `now - knowledge_cutoff`
+  checked against thresholds that are fractions of domain velocity, and those
+  tests hardcoded a fixed date - which pins a date, not a band. It read as
+  fresh when written, crossed into aging at 45 days of real elapsed time, and
+  four tests that index into `proposals[0]` began asserting against a
+  different proposal. Nothing in the suite had changed. Cutoffs are now
+  expressed as an age with the intended band named (`tests/expert_time_helpers`).
+
+- **Capacity exhaustion no longer silently degrades a study.** A run that could
+  not ask now says so instead of reporting a thin result.
 
 ## [2.45.0] - 2026-08-07
 

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,11 +1,24 @@
 # Supported Surface
 
-Status: v2.44.0 current main, 2026-08-05. This document defines what users and host
+Status: v2.46.0 current main, 2026-08-11. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
 data remains portable if development stops. Production metered dispatch remains
 frozen since v2.40 until provider account-control adapters land.
 
-**v2.44.0 adds the expert study surface as experimental**: retained corpus
+**v2.46.0 renames the files inside an expert directory.** They were named
+after the commands that wrote them; they are now named for what they are:
+`self.json`, `noticed/`, `hold/current.json` and `hold/history.json`,
+`became/`, `attend/`, `met/`. `corpus/` is unchanged.
+
+This matters to the portability contract below, so it is stated here rather
+than only in the changelog. Nothing is lost and nothing needs converting by
+hand: `deepr expert migrate` moves an expert in place, dry run by default, and
+every reader resolves the old path when only the old path exists, so an
+un-migrated expert stays fully readable. All 57 experts in the reference fleet
+were migrated and verified field by field against a pre-migration backup with
+zero differences. `beliefs/` and `knowledge/` are v1 storage and are untouched.
+
+**v2.44.0 added the expert study surface as experimental**: retained corpus
 (`corpus/index.jsonl` plus content-addressed sources), the multi-lens study pass,
 coverage reporting, and the notebook render. These are additive; existing belief
 stores are untouched and keep working. The study pass proposes findings and never
@@ -596,6 +609,11 @@ If development stops, users keep these portable artifacts:
   reports root.
 - Expert profiles, belief stores, event logs, edge stores, gap manifests, and
   loop-run records under the configured data root.
+- An expert's own account of itself (`self.json`), what it noticed in what it
+  read (`noticed/`), the view it currently holds and every view it has held
+  (`hold/`), what changed it (`became/`), what it is chasing (`attend/`), and
+  what has been put to it (`met/`). All plain JSON and Markdown under the
+  expert's directory, readable without Deepr.
 - Generated expert memory cards (`EXPERT.md`) when written. These are derived
   orientation views over canonical state, including labeled original-idea
   perspective state, and can be regenerated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepr-research"
-version = "2.45.0"
+version = "2.46.0"
 description = "Research automation platform that replicates human research team workflows using AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/deepr/__init__.py
+++ b/src/deepr/__init__.py
@@ -5,7 +5,7 @@ Keep package import lightweight by lazily importing heavy modules.
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "2.45.0"
+__version__ = "2.46.0"
 __author__ = "Nick Seal"
 
 if TYPE_CHECKING:

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "deepr-research"
-version = "2.45.0"
+version = "2.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Version bump, changelog and roadmap status for the work merged in #124.

An expert stops being a list of retrieved claims and becomes something that
holds a view, can say how it came to it, and can be examined on it. 2.45.0 made
an expert's measurements honest; this gives it something to be honest about.

- A position ledger: every view held, with what moved it and the corpus it was
  formed over, keyed on durable identity so a falsifier survives a re-brief.
- A viva: examiners from other standpoints, returning a reading list separated
  from a genuine frontier.
- A perspective graph: the biography of a standpoint, distinct from the
  evidence graph that records what rests on what.
- Expert directories named from the expert's point of view. All 57 migrated,
  verified field by field against a backup with zero differences.
- Metered API keys moved out of the process environment at startup rather than
  merely checked for.

Also records three defects found in review of #124 and one class of latent test
bug: sixteen tests hardcoded a knowledge cutoff whose freshness band drifted
with the calendar until four of them failed with no change to the suite.