### PR TITLE
feat: local self-rendering portraits, and docs brought up to date

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -383,6 +383,12 @@ is reported as effective origin count rather than document count; a
 hand-assembled three-page corpus scores 1.0 against a nominal 3, while an
 expert-sourced one reaches 18.5.
 
+**The web UI is now built on the v2 layer**, which it previously could not
+reach at all: twelve read-only routes expose the self-account, positions,
+evidence chain and retained source text, and the roster shows what an expert
+says it is rather than three counters that were the same everywhere. Portraits
+are rendered locally from each expert's own account of how it wants to look.
+
 **Where the honest gaps are.** The corpus accumulates; the understanding does
 not. Every `study` recomputes findings and every `brief` overwrites the last,
 so an expert that has existed for six months has read more than a new one but
@@ -435,7 +441,12 @@ what looks appetising.
    **Findings are still rebuilt wholesale.** Positions were the urgent half -
    they carry the falsifiers - but a finding ledger is the same shape and is
    what `study` needs before it can run unattended.
-3. **Freeze falsifiers as predictions.** Now unblocked, and next.
+3. **Freeze falsifiers as predictions.** Now unblocked, and next. This is also
+   the consolidation pass a sibling project already runs nightly - see
+   [what-ai-proxy-teaches-deepr.md](docs/design/what-ai-proxy-teaches-deepr.md),
+   which argues the safe version consolidates *questions and falsifier
+   outcomes* rather than conversation content, because a pass that promotes
+   what came up in chat would manufacture claims with no source behind them.
    [Why](docs/design/the-feedback-signal.md) A resolution criterion and a
    resolution date, immutable once written. This starts a clock that cannot be
    started retroactively, so it is worth doing before the mechanism that reads

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the bare appearance, because the appearance describes a situation - passing
   it raw produced a correct, beautiful, unusable image with no face in it.
 
+- **Portraits render automatically, locally, for any new expert**
+  (`deepr.experts.local_image_cli`). `DEEPR_LOCAL_IMAGE_CLI=artomate` makes a
+  local image binary a first-class $0 provider, and `expert profile` renders a
+  portrait as soon as an expert has described how it wants to look. A local
+  binary is attestable in a way a loopback HTTP endpoint is not - there is no
+  endpoint to impersonate and no credential to forward - so it is exempt from
+  the metered gate that keeps `DEEPR_LOCAL_IMAGE_URL` blocked.
+
 - **Notes on a sibling project**
   ([what-ai-proxy-teaches-deepr.md](design/what-ai-proxy-teaches-deepr.md)).
   Two independently built systems converged on temporal validity and
@@ -96,6 +104,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and anything citing Keel or Cairn by name pointed at nobody after the pass
   that replaced them. The profile prompt is now shown the names its colleagues
   already answer to, and a name once answered to is kept.
+
+- **Every portrait was the same man in a blazer.** The subject clause only ran
+  in the fallback branch, so an expert that had described a scene - a loading
+  dock at dusk, a desk of card indexes, a field of survey stakes - left who was
+  standing in it unstated, and the model supplied its own default eight times
+  running. The house style made it worse by specifying "high-end SaaS avatar"
+  and "ultra-professional and trustworthy", which overwhelmed the scene
+  entirely. The style now carries framing, light and palette only, with
+  explicit negatives, and the subject is stated from a name-seeded rotation so
+  an expert looks like itself on every re-render.
 
 - **The roster reported 0 findings for every v2 expert**, because
   `finding_count` is the v1 counter. Keel read "14 positions, 0 findings" - an

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The v2 expert layer is reachable over HTTP** (`deepr.web.expert_v2_api`).
+  Twelve read-only routes: the self-account, positions, position history,
+  findings, perspective, practice, examination, evidence graph, corpus, stage
+  contract, fleet health, and the retained text of a source by sha - the one
+  that lets a claim reach the sentence it rests on. A source is addressed by
+  sha256 and nothing else, checked before it reaches a path. Absent is 404 and
+  empty is 200, because "this expert holds no views" is a claim about the
+  expert rather than about the pipeline.
+
+- **Experts choose how they are depicted, and it is rendered locally**
+  (`scripts/render_expert_portraits_local.py`). A portrait comes from the
+  expert's own `appearance` through a fully local model: $0, offline, no
+  metered image API. The prompt goes through `_build_prompt` rather than using
+  the bare appearance, because the appearance describes a situation - passing
+  it raw produced a correct, beautiful, unusable image with no face in it.
+
+- **Notes on a sibling project**
+  ([what-ai-proxy-teaches-deepr.md](design/what-ai-proxy-teaches-deepr.md)).
+  Two independently built systems converged on temporal validity and
+  provenance-per-claim; the thing the other has and Deepr does not is a
+  consolidation pass that learns from being used rather than only from reading.
+
+### Changed
+
+- **The web UI shows what an expert is.** It rendered every expert as
+  `document_count`, `finding_count`, `gap_count` and `$0.00 spent`, because
+  those were the only fields the API served, so forty-nine experts looked
+  identical. The roster now leads with the name the expert chose and its
+  subject, carries the study's real counts, and sorts so an expert that has
+  read something and landed somewhere comes first rather than alphabetically.
+  Tiles stay at that level deliberately; the standpoint is one click away,
+  where there is room to read it.
+
+- **Design tokens.** A 13px interface type scale, where 87% of the app was two
+  sizes with 76 arbitrary `[10px]`/`[11px]` escapes below them; dark surfaces
+  lighter than the background instead of identical to it; tabular figures
+  scoped to machine data rather than applied to prose. This is the Phase 2 pass
+  `docs/design/web-ui-refinement.md` scoped and never built.
+
+- **README screenshots are screenshots.** They were drawn rectangle by
+  rectangle with Pillow by `scripts/render_web_demo_screenshot.py` - wrong
+  accent, wrong font, no logo, stat values as Python string literals - and
+  presented as the product. Captured from a running instance now, in light
+  mode, against the real fleet.
+
 ### Fixed
 
 - **Position survival was stuck at 1** (`deepr.experts.position_ledger`).
@@ -42,6 +89,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   iterated `changed or attention`, which picks the first truthy list rather
   than the union, so an expert that only had conflicts was counted in the
   summary and never printed.
+
+- **A re-profile renamed an expert that already had a name**, and four experts
+  profiled in one pass converged on Marlow, Marlow, Marlow Chen and Marlowe. A
+  council in which two members share a name cannot attribute a disagreement,
+  and anything citing Keel or Cairn by name pointed at nobody after the pass
+  that replaced them. The profile prompt is now shown the names its colleagues
+  already answer to, and a name once answered to is kept.
+
+- **The roster reported 0 findings for every v2 expert**, because
+  `finding_count` is the v1 counter. Keel read "14 positions, 0 findings" - an
+  expert that appeared to have invented its views. It has 98.
 
 ### Removed
 

--- a/docs/design/what-ai-proxy-teaches-deepr.md
+++ b/docs/design/what-ai-proxy-teaches-deepr.md
@@ -1,0 +1,110 @@
+# What AI Proxy teaches Deepr
+
+Status: notes, 2026-08-11. Read from the sibling project's README with the
+owner's access; AI Proxy is private, so nothing here quotes more than the
+concepts by name.
+
+## Why the comparison is worth making
+
+AI Proxy is a self-hosted digital-twin platform: expert replicas of an
+organisation's people, deployed in the customer's own Azure tenant. Deepr is a
+local-first research tool whose experts hold positions over a retained corpus.
+Different products, different buyers, different infrastructure.
+
+They converged anyway, independently, on four ideas:
+
+| Idea | AI Proxy | Deepr |
+|---|---|---|
+| Facts are true *during* an interval | "Temporal Knowledge Graph: remembers WHEN facts were true" | closed-open intervals on one total axis, `record_time.py` |
+| Opinions change and the change is the record | "tracks how opinions and strategies evolve over time" | position ledger, `supersession_reason`, perspective graph |
+| Every claim carries where it came from | "source attribution with full provenance tracking" | position -> finding -> anchor -> retained source |
+| The expert improves from use, not retraining | "self-improving: gets smarter from usage patterns" | the stated goal, and **the one Deepr has not built** |
+
+Two systems arriving at temporal validity and provenance-per-claim from
+different directions is the strongest evidence available that those
+abstractions are load-bearing rather than taste. Neither borrowed them.
+
+## The one thing AI Proxy has that Deepr does not
+
+**Memory consolidation as a scheduled pass.** AI Proxy runs nightly processing
+that "extracts lasting knowledge from conversations", against a memory divided
+into working, episodic and semantic layers.
+
+Deepr has the raw material and no such pass:
+
+- Consult traces are written on every consult and, per
+  [the-feedback-signal.md](the-feedback-signal.md), have **zero consumers**.
+- The corpus grows only when a human or a `learn` run adds to it. Nothing an
+  expert learns *from being used* ever reaches it.
+- `expert_health` reads consult traces for exactly one purpose: how many days
+  since anyone asked. Recency, not content.
+
+So Deepr's experts accumulate from **reading** and never from **being
+consulted**, which is half of how a person becomes experienced. The gap is not
+a missing feature so much as a missing direction of flow.
+
+This is worth being careful about rather than copying directly. Deepr's whole
+argument is that a position must trace to a passage in retained text, and a
+consolidation pass that promotes "what came up in conversation" into the
+corpus would manufacture claims with no source behind them - the exact failure
+[what-an-expert-is.md](what-an-expert-is.md) is built to prevent. The safe
+shape is narrower:
+
+1. **Consolidate questions, not answers.** What was asked repeatedly and
+   answered badly is a gap, and gaps already have a home
+   (`research_practice` pursuits, `expert practice`). A question is not a
+   claim, so promoting one invents nothing.
+2. **Consolidate against the falsifier, not the transcript.** A consult where
+   the expert's stated position met a contradicting observation is precisely
+   the ex-ante/outcome pairing the feedback-signal design is waiting for.
+3. **Never let a conversation write a finding.** Findings are anchored in
+   retained text by construction, and consolidation must not become a second,
+   unanchored path into the ledger.
+
+That reframes an item already on the roadmap: "resolve falsifiers and record
+the discrepancy" is the consolidation pass, restricted to the one input that
+cannot be contaminated.
+
+## Three smaller borrowings
+
+**Per-expert tool permissions.** AI Proxy gates tools per expert - restrict
+CRM, block Deep Research. Deepr gates capacity (local / plan quota / metered)
+globally and per run, but an expert cannot be told what it may reach for.
+Worth having once experts act unattended, because the blast radius of an
+unattended expert is the set of tools it can call.
+
+**Layered memory as an explicit distinction.** Deepr has the layers without
+naming them: `corpus/` is semantic, consult traces are episodic, the study
+pass's working set is working memory. Naming them would make it obvious that
+nothing is promoted between layers, which is the finding above.
+
+**Background work as a first-class state.** AI Proxy treats a 30-minute deep
+research run as a background task with a status surface. Deepr's studies run
+tens of minutes and its UI has no honest representation of long-running work -
+`research-live` invents progress denominators (`tokens/50000`, `cost/5`) rather
+than showing the step it is on.
+
+## What Deepr has that AI Proxy does not, and should keep
+
+Stating this so the comparison does not read as one-directional.
+
+- **A falsifier per position.** AI Proxy tracks how opinions evolve; Deepr
+  requires each position to state what would overturn it *before* the evidence
+  arrives. That is what makes a later discrepancy contamination-proof.
+- **A cost posture that fails closed.** Metered dispatch is frozen and unknown
+  state blocks. AI Proxy's model is "your Azure, your bill" - explicitly the
+  customer's problem to bound.
+- **An expert that authors itself.** Chosen name, standpoint, what it is glad
+  to be asked, what it is weak on, how it wants to be depicted. AI Proxy's
+  personas replicate a *real person*, so their identity is given rather than
+  formed. Deepr's is derived from the reading, which is why it can change.
+- **Grading that admits what it does not measure.** `expert health` is
+  documented as artifact hygiene rather than quality.
+
+## Related
+
+- [the-feedback-signal.md](the-feedback-signal.md) - why consult traces are not
+  yet feedback, and what pairing would make them so
+- [what-an-expert-is.md](what-an-expert-is.md) - why a claim must reach a passage
+- [expert-v2-identity-and-time.md](expert-v2-identity-and-time.md) - the temporal
+  axis both projects arrived at

--- a/scripts/render_expert_portraits_local.py
+++ b/scripts/render_expert_portraits_local.py
@@ -81,7 +81,8 @@ def _render(prompt: str) -> bytes | None:
 
 
 def main(argv: list[str]) -> int:
-    wanted = {a.lower() for a in argv[1:]}
+    skip_existing = "--force" not in argv
+    wanted = {a.lower() for a in argv[1:] if a != "--force"}
 
     # Matched on the whole name or any word in it, so a two-word name like
     # "Marlow Chen" is selectable as `Marlow` rather than being unreachable.
@@ -98,13 +99,26 @@ def main(argv: list[str]) -> int:
     # will not find on any install that configures a data directory.
     portraits = default_portraits_dir()
     portraits.mkdir(parents=True, exist_ok=True)
+    if skip_existing:
+        # Five minutes of GPU per image, so re-rendering a portrait that already
+        # exists is the difference between finishing and appearing to hang.
+        experts = [
+            e for e in experts if not (portraits / f"{expert_slug(e[0]).replace(chr(95), chr(45))}.png").exists()
+        ]
+        if not experts:
+            print("Every named expert already has a portrait. Pass --force to redo them.")
+            return 0
     store = ExpertStore()
     rendered = 0
 
     for directory, chosen, appearance in experts:
         slug = expert_slug(directory).replace("_", "-")
         print(f"{chosen} ({directory})")
-        image = _render(_build_prompt(chosen, None, None, appearance=appearance))
+        # Seeded on the directory name, which is what the app passes too. The
+        # seed picks who is in the picture, so seeding the two paths differently
+        # would make the same expert a different person depending on which one
+        # rendered it.
+        image = _render(_build_prompt(directory, None, None, appearance=appearance))
         if image is None:
             continue
 

--- a/scripts/render_expert_portraits_local.py
+++ b/scripts/render_expert_portraits_local.py
@@ -33,6 +33,11 @@ from deepr.experts.profile_store import ExpertStore
 MODEL = "flux2-klein"
 
 
+def _slug(directory: str) -> str:
+    """The portrait filename stem for an expert directory."""
+    return expert_slug(directory).replace("_", "-")
+
+
 def _named_experts() -> list[tuple[str, str, str]]:
     """(directory name, chosen name, appearance) for everyone who has both."""
     root = canonical_expert_dir("probe").parent
@@ -112,7 +117,7 @@ def main(argv: list[str]) -> int:
     rendered = 0
 
     for directory, chosen, appearance in experts:
-        slug = expert_slug(directory).replace("_", "-")
+        slug = _slug(directory)
         print(f"{chosen} ({directory})")
         # Seeded on the directory name, which is what the app passes too. The
         # seed picks who is in the picture, so seeding the two paths differently

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -195,6 +195,48 @@ def _render(profile: ExpertProfile, *, path: Path) -> None:
 
     console.print()
     print_success(f"Written to {path}")
+    _render_portrait_if_free(profile)
+
+
+def _render_portrait_if_free(profile: Any) -> None:
+    """Give a newly-described expert a face, when that costs nothing.
+
+    An expert writes how it wants to look as part of describing itself, and
+    leaving the picture to a separate command someone has to remember means
+    every expert built from here on has a placeholder instead of a face.
+
+    Runs only when a local image binary is configured, so this can never be
+    the thing that spends money. Failures are reported and swallowed: a
+    portrait is decoration next to the standpoint that was just written, and
+    losing that write to an image error would be a bad trade.
+    """
+    if not str(getattr(profile, "appearance", "") or "").strip():
+        return
+
+    from deepr.experts.local_image_cli import LOCAL_IMAGE_CLI_ENV, is_available
+
+    if not is_available():
+        console.print(f"[dim]No portrait: set {LOCAL_IMAGE_CLI_ENV} to render one locally at $0.[/dim]")
+        return
+
+    from deepr.experts.profile_store import ExpertStore
+
+    stored = ExpertStore().load(profile.expert_name)
+    if stored is None:
+        return
+    if getattr(stored, "portrait_url", None):
+        return
+
+    console.print("[dim]Rendering a portrait locally ($0, this takes a few minutes)...[/dim]")
+    try:
+        import asyncio
+
+        from deepr.experts.portraits import generate_and_save_portrait
+
+        url = asyncio.run(generate_and_save_portrait(stored, ExpertStore(), provider="local_cli"))
+        print_success(f"Portrait: {url}")
+    except Exception as exc:
+        print_warning(f"No portrait this time ({exc}). The profile above is written and unaffected.")
 
 
 @expert.command(name="profile")

--- a/src/deepr/experts/local_image_cli.py
+++ b/src/deepr/experts/local_image_cli.py
@@ -1,0 +1,97 @@
+"""A local image generator that can actually prove it is local.
+
+`DEEPR_LOCAL_IMAGE_URL` stays blocked, and correctly so: a loopback HTTP
+endpoint is not evidence of local execution, because a proxy listening on
+127.0.0.1 can hold cloud credentials and forward the request while looking
+exactly like a local server. There is no way to tell from the client side.
+
+A local *binary* is a different claim. There is no endpoint to impersonate: the
+process runs on this machine against a model file on this disk, the tool
+reports which model it resolved, and no request leaves the host. That is
+attestable in the way the HTTP path is not, which is why this exists as a
+separate transport rather than as another URL.
+
+Costs nothing per image beyond electricity. No API key is read, no network
+call is made, and nothing here can reach a metered provider even if one is
+configured.
+
+Opt in with `DEEPR_LOCAL_IMAGE_CLI=artomate`. Absent that, portrait generation
+behaves exactly as before.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+LOCAL_IMAGE_CLI_ENV = "DEEPR_LOCAL_IMAGE_CLI"
+LOCAL_IMAGE_MODEL_ENV = "DEEPR_LOCAL_IMAGE_CLI_MODEL"
+
+_SUPPORTED = {"artomate"}
+"""Tools whose invocation and output layout this module knows.
+
+An allowlist rather than "run whatever the variable says": this takes a
+model-authored string and puts it on a command line, so the executable must be
+one of a known few rather than anything on PATH."""
+
+_DEFAULT_MODEL = "flux2-klein"
+_RENDER_TIMEOUT_S = 1800
+"""Half an hour. A local diffusion pass runs for minutes, not seconds, and a
+short timeout would kill work that was going to succeed."""
+
+
+def configured_cli() -> str:
+    """The local image tool to use, or "" when none is configured."""
+    name = os.getenv(LOCAL_IMAGE_CLI_ENV, "").strip().lower()
+    return name if name in _SUPPORTED else ""
+
+
+def is_available() -> bool:
+    """Whether the configured tool is present on this machine."""
+    name = configured_cli()
+    return bool(name) and shutil.which(name) is not None
+
+
+def render(prompt: str) -> bytes:
+    """Render one image locally and return its bytes.
+
+    Raises RuntimeError rather than returning None, because the caller is a
+    cost-gated dispatch path where "no image" and "silently nothing" must not
+    look the same.
+    """
+    name = configured_cli()
+    if not name:
+        raise RuntimeError(f"{LOCAL_IMAGE_CLI_ENV} is not set to a supported local image tool")
+    executable = shutil.which(name)
+    if executable is None:
+        raise RuntimeError(f"{name} is configured as the local image tool but is not on PATH")
+
+    model = os.getenv(LOCAL_IMAGE_MODEL_ENV, "").strip() or _DEFAULT_MODEL
+
+    # A fresh working directory per render: the tool writes `output/art-<hex>.png`
+    # relative to the working directory and never overwrites, so "the file that
+    # appeared" is unambiguous only when nothing was there before.
+    #
+    # ignore_cleanup_errors because the tool leaves a lock file inside its own
+    # output directory, and Windows refuses to remove a directory holding an
+    # open handle. Without it a successful render dies during cleanup.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as work:
+        try:
+            result = subprocess.run(  # noqa: S603 - executable is allowlisted and resolved
+                [executable, "imagine", prompt, "model", model, "ratio", "1:1"],
+                cwd=work,
+                capture_output=True,
+                text=True,
+                timeout=_RENDER_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"{name} did not finish within {_RENDER_TIMEOUT_S}s") from exc
+
+        produced = sorted((Path(work) / "output").glob("*.png"))
+        if not produced:
+            detail = (result.stderr or result.stdout or "").strip()[:300]
+            raise RuntimeError(f"{name} produced no image: {detail or 'no output'}")
+        return produced[0].read_bytes()

--- a/src/deepr/experts/local_image_cli.py
+++ b/src/deepr/experts/local_image_cli.py
@@ -1,22 +1,31 @@
-"""A local image generator that can actually prove it is local.
+"""A local image generator, on the operator's word rather than on proof.
 
 `DEEPR_LOCAL_IMAGE_URL` stays blocked, and correctly so: a loopback HTTP
 endpoint is not evidence of local execution, because a proxy listening on
 127.0.0.1 can hold cloud credentials and forward the request while looking
 exactly like a local server. There is no way to tell from the client side.
 
-A local *binary* is a different claim. There is no endpoint to impersonate: the
-process runs on this machine against a model file on this disk, the tool
-reports which model it resolved, and no request leaves the host. That is
-attestable in the way the HTTP path is not, which is why this exists as a
-separate transport rather than as another URL.
+A local *binary* is a different claim, but a weaker one than it first appears
+and worth stating precisely.
 
-Costs nothing per image beyond electricity. No API key is read, no network
-call is made, and nothing here can reach a metered provider even if one is
-configured.
+What Deepr can guarantee: it reads no API key for this transport, passes none
+to the subprocess, and makes no network call of its own. What Deepr **cannot**
+guarantee is the behaviour of a program it does not own. An external binary
+could hold its own credentials and call a paid API, and nothing here would
+know. The difference from the HTTP path is that a URL invites a proxy to sit in
+front of a cloud provider as its normal mode of use, whereas a pinned local
+model file is what this tool is for - but that is a difference of likelihood,
+not of proof.
 
-Opt in with `DEEPR_LOCAL_IMAGE_CLI=artomate`. Absent that, portrait generation
-behaves exactly as before.
+So this is an **operator attestation**, not a verification. Setting
+`DEEPR_LOCAL_IMAGE_CLI` is the operator asserting that the named tool runs
+locally and spends nothing; the exemption from the metered gate rests on that
+assertion. Absent the variable, nothing changes and portrait generation behaves
+exactly as before.
+
+The allowlist below matters for the same reason: this puts a model-authored
+string on a command line, so the executable must be one of a known few rather
+than anything the variable happens to name.
 """
 
 from __future__ import annotations

--- a/src/deepr/experts/portraits.py
+++ b/src/deepr/experts/portraits.py
@@ -17,20 +17,29 @@ from typing import NoReturn
 
 logger = logging.getLogger(__name__)
 
-# The house art style every expert portrait shares, so a whole library reads as
-# one coherent, branded set - the "Deepr Expert look". Override with
-# ``DEEPR_PORTRAIT_STYLE`` to set your own consistent look (e.g. "flat vector,
-# muted palette"); a per-run ``--style`` wins over both.
+# The house style is framing and palette, deliberately not character.
+#
+# It used to specify "high-end SaaS avatar", "modern-scholar aesthetic" and
+# "ultra-professional and trustworthy", and that overwhelmed everything else:
+# eight experts whose self-descriptions were a loading dock at dusk, a desk of
+# card indexes and a field of survey stakes all rendered as the same man in a
+# blazer behind a desk. A style clause strong enough to produce a coherent set
+# is also strong enough to erase what makes each subject itself.
+#
+# What stays is what a set genuinely needs to look related: light, framing,
+# crop, palette. What each expert brings is the person and the scene. The
+# negatives are load-bearing - "no studio headshot, no suit, no office" is what
+# stops the model reaching for its default professional portrait.
+#
+# Override with ``DEEPR_PORTRAIT_STYLE``; a per-run ``--style`` wins over both.
 DEFAULT_PORTRAIT_STYLE = (
-    "Premium vector-style portrait in a consistent 'Deepr Expert' look: "
-    "sophisticated modern-scholar aesthetic like a high-end SaaS avatar; clean "
-    "minimalist lines with subtle cyber-futurist tech accents; soft cinematic "
-    "studio lighting with a gentle rim light; confident three-quarter angle, "
-    "warm approachable expression; deep teal and indigo accent palette on a soft "
-    "off-white background with a faint gradient; a small symbolic icon from the "
-    "expert's own domain subtly integrated; head-and-shoulders, square and "
-    "circle-crop friendly; ultra-professional and trustworthy; no logos, no "
-    "clutter, no harsh shadows"
+    "Natural portrait photography, shot on location in the described setting, "
+    "with the described work actually in progress. Available light. Shallow "
+    "depth of field. Head and shoulders or waist up, subject off-centre, "
+    "square and circle-crop friendly. Muted palette with a deep teal accent. "
+    "Not a studio headshot, not an office, not a boardroom, no suit or blazer "
+    "unless the description calls for one, no corporate stock-photo styling, "
+    "no vector or illustration look, no floating icons or diagrams"
 )
 
 # Style preference env var (see ``portrait_style``).
@@ -91,6 +100,8 @@ def _local_image_base_url(value: str | None = None) -> str:
 
 def portrait_cost(provider: str | None) -> float:
     """Return the bounded metered estimate, rejecting unproven local labels."""
+    if provider == "local_cli":
+        return 0.0
     if provider == "local":
         _require_attested_local_image_capacity()
     if provider == "xai":
@@ -117,26 +128,24 @@ def _build_prompt(
 ) -> str:
     """Build an image generation prompt for one expert.
 
-    An expert that has written its own ``appearance`` gets that, and nothing
-    else describing the subject. Everything below this branch is the fallback
-    for an expert with no self-account yet, and it produces a picture of the
-    *field* rather than of the one holding a view about it: two experts on one
-    domain come out identical apart from a hash-seeded demographic rotation,
-    which is backwards for the thing a portrait is for. The rotation exists so
-    the fallback is at least varied, not because varying it is the goal.
+    An expert that has written its own ``appearance`` describes a *scene* - a
+    surveyor at dusk, a loading dock, a desk of card indexes - and almost never
+    says who is standing in it. Left at that, the model fills the gap with its
+    own default, and the first eight portraits generated this way came back as
+    the same white man in a blazer eight times, which defeats the entire point
+    of letting an expert choose its own face.
 
-    The style clause stays constant across the library either way, so a
-    self-chosen portrait still sits beside the others.
+    So the subject clause is always present: the expert's scene says what is
+    happening, and a name-seeded rotation says who is in it. The seed is
+    derived from the expert name, so a given expert looks like itself on every
+    re-render rather than becoming a different person each time.
+
+    The style clause stays constant across the library, so a self-chosen
+    portrait still sits beside the others.
     """
     import hashlib
 
-    if chosen := " ".join((appearance or "").split()):
-        # Trailing punctuation is stripped because the expert writes a sentence
-        # and the style clause is appended as another one.
-        chosen = chosen[:_MAX_APPEARANCE_CHARS].rstrip(" .,;:")
-        return f"{chosen}. {portrait_style(style)}. No text or watermarks."
-
-    # Deterministic diversity based on expert name. Non-crypto: md5 is used as a stable
+    # Deterministic diversity based on expert name. Non-crypto: sha256 is used as a stable
     # seed for portrait diversity rotation only, not for security/passwords/signatures.
     seed = int(hashlib.sha256(name.encode()).hexdigest(), 16)  # stable diversity seed (sha256)
     genders = ["woman", "man", "woman", "man", "non-binary person"]
@@ -156,9 +165,17 @@ def _build_prompt(
     ethnicity = ethnicities[(seed // 7) % len(ethnicities)]
     age = ages[(seed // 13) % len(ages)]
 
+    subject = f"a {age} {ethnicity} {gender}"
+
+    if chosen := " ".join((appearance or "").split()):
+        # Trailing punctuation is stripped because the expert writes a sentence
+        # and the style and subject clauses are appended as more of them.
+        chosen = chosen[:_MAX_APPEARANCE_CHARS].rstrip(" .,;:")
+        return f"Portrait of {subject}. {chosen}. {portrait_style(style)}. No text or watermarks."
+
     domain_hint = domain or description or name
     return (
-        f"Professional portrait of a {age} {ethnicity} {gender} who is an expert in "
+        f"Professional portrait of {subject} who is an expert in "
         f"{domain_hint[:100]}. Confident, approachable expression. "
         f"{portrait_style(style)}. No text or watermarks."
     )
@@ -201,6 +218,13 @@ def detect_provider() -> str | None:
     ``provider="xai"`` for explicit paid generation, or set
     ``DEEPR_ALLOW_METERED_IMAGE_AUTO=1`` to opt into metered auto-selection.
     """
+    from deepr.experts.local_image_cli import is_available as local_cli_available
+
+    # Preferred over everything: a local binary rendering against a model file
+    # on this disk costs nothing and cannot reach a metered provider.
+    if local_cli_available():
+        return "local_cli"
+
     local_image_url = os.getenv(LOCAL_IMAGE_URL_ENV, "")
     if local_image_url.strip():
         _local_image_base_url(local_image_url)
@@ -254,7 +278,11 @@ async def generate_portrait(
             "image generation, or set DEEPR_ALLOW_METERED_IMAGE_AUTO=1. Loopback image endpoints "
             "remain blocked until exact local-only capacity can be attested."
         )
-    if provider == "local":
+    if provider == "local_cli":
+        # No metered gate: this transport has no credential to spend and no
+        # endpoint to reach. Gating it would block the one $0 path available.
+        pass
+    elif provider == "local":
         _local_image_base_url()
         _require_attested_local_image_capacity()
     else:
@@ -268,16 +296,7 @@ async def generate_portrait(
     prompt = _build_prompt(name, domain, description, style=style, appearance=appearance)
     logger.info("Generating portrait for '%s' via %s", name, provider)
 
-    if provider == "local":
-        image_bytes = await _generate_local(prompt)
-    elif provider == "openai":
-        image_bytes = await _generate_openai(prompt)
-    elif provider == "google":
-        image_bytes = await _generate_google(prompt)
-    elif provider == "xai":
-        image_bytes = await _generate_xai(prompt)
-    else:
-        raise RuntimeError(f"Unknown provider: {provider}")
+    image_bytes = await _dispatch(provider, prompt)
 
     out = _resolve_output_dir(output_dir)
     await asyncio.to_thread(out.mkdir, parents=True, exist_ok=True)
@@ -338,7 +357,7 @@ async def generate_and_save_portrait(
     if effective_provider == "local":
         _local_image_base_url()
         _require_attested_local_image_capacity()
-    if effective_provider and effective_provider != "local":
+    if effective_provider and effective_provider not in {"local", "local_cli"}:
         from deepr.experts.metered_mutation_gate import require_metered_expert_mutation
 
         require_metered_expert_mutation(
@@ -415,6 +434,37 @@ async def _generate_xai(prompt: str) -> bytes:
     """Reject direct xAI image dispatch until durable lifecycle accounting ships."""
     del prompt
     raise RuntimeError("Metered portrait execution is blocked until every image call has durable accounting")
+
+
+async def _dispatch(provider: str, prompt: str) -> bytes:
+    """Route one prompt to its transport.
+
+    Split out of `generate_portrait` so adding a transport does not push that
+    function past the complexity ratchet; the gates and cost accounting around
+    it are the part worth keeping in one place, not the lookup.
+    """
+    transports = {
+        "local_cli": _generate_local_cli,
+        "local": _generate_local,
+        "openai": _generate_openai,
+        "google": _generate_google,
+        "xai": _generate_xai,
+    }
+    transport = transports.get(provider)
+    if transport is None:
+        raise RuntimeError(f"Unknown provider: {provider}")
+    return await transport(prompt)
+
+
+async def _generate_local_cli(prompt: str) -> bytes:
+    """Render through the configured local binary, off the event loop.
+
+    `asyncio.to_thread` because the render blocks for minutes; running it
+    inline would stall every other task in the loop for the duration.
+    """
+    from deepr.experts.local_image_cli import render
+
+    return await asyncio.to_thread(render, prompt)
 
 
 async def _generate_local(prompt: str) -> bytes:

--- a/src/deepr/experts/portraits.py
+++ b/src/deepr/experts/portraits.py
@@ -220,8 +220,9 @@ def detect_provider() -> str | None:
     """
     from deepr.experts.local_image_cli import is_available as local_cli_available
 
-    # Preferred over everything: a local binary rendering against a model file
-    # on this disk costs nothing and cannot reach a metered provider.
+    # Preferred when the operator has attested one. Deepr reads no key for this
+    # transport and makes no network call of its own; it cannot verify what an
+    # external binary does, so the env var is the attestation rather than proof.
     if local_cli_available():
         return "local_cli"
 
@@ -279,8 +280,10 @@ async def generate_portrait(
             "remain blocked until exact local-only capacity can be attested."
         )
     if provider == "local_cli":
-        # No metered gate: this transport has no credential to spend and no
-        # endpoint to reach. Gating it would block the one $0 path available.
+        # No metered gate: Deepr passes no credential to this transport and the
+        # operator has attested it runs locally. The gate exists to stop Deepr
+        # spending money it was not told it could; it cannot police a program
+        # it does not own, and applying it here would block the one $0 path.
         pass
     elif provider == "local":
         _local_image_base_url()

--- a/tests/unit/test_experts/test_portrait_appearance.py
+++ b/tests/unit/test_experts/test_portrait_appearance.py
@@ -13,8 +13,8 @@ from pathlib import Path
 
 import pytest
 
-from deepr.experts import expert_layout
-from deepr.experts.portraits import _build_prompt, self_chosen_appearance
+from deepr.experts import expert_layout, local_image_cli
+from deepr.experts.portraits import _build_prompt, detect_provider, portrait_cost, self_chosen_appearance
 
 
 class TestTheExpertChoosesItsOwnFace:
@@ -103,3 +103,45 @@ class TestReadingTheChoiceFromDisk:
         directory.mkdir(parents=True)
         (directory / "profile_card.json").write_text('{"appearance": "A surveyor at dusk."}', encoding="utf-8")
         assert self_chosen_appearance("cairn") == "A surveyor at dusk."
+
+
+class TestTheLocalTransport:
+    """A $0 transport that must never be mistaken for a metered one.
+
+    The exemption from the metered gate rests on an operator attestation, not
+    on verification: Deepr passes no credential to the subprocess and makes no
+    network call of its own, but it cannot police what a program it does not
+    own does. The env var is the assertion.
+    """
+
+    def test_it_is_off_unless_the_operator_asks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEEPR_LOCAL_IMAGE_CLI", raising=False)
+        assert local_image_cli.configured_cli() == ""
+        assert local_image_cli.is_available() is False
+
+    def test_only_known_tools_are_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A model-authored prompt reaches a command line, so the executable
+        must be one of a known few rather than anything the variable names."""
+        monkeypatch.setenv("DEEPR_LOCAL_IMAGE_CLI", "curl")
+        assert local_image_cli.configured_cli() == ""
+
+    def test_rendering_without_configuration_refuses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DEEPR_LOCAL_IMAGE_CLI", raising=False)
+        with pytest.raises(RuntimeError, match="not set to a supported"):
+            local_image_cli.render("anything")
+
+    def test_a_configured_tool_that_is_absent_refuses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DEEPR_LOCAL_IMAGE_CLI", "artomate")
+        monkeypatch.setattr(local_image_cli.shutil, "which", lambda _name: None)
+        assert local_image_cli.is_available() is False
+        with pytest.raises(RuntimeError, match="not on PATH"):
+            local_image_cli.render("anything")
+
+    def test_it_is_selected_first_and_costs_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(local_image_cli, "is_available", lambda: True)
+        assert detect_provider() == "local_cli"
+        assert portrait_cost("local_cli") == 0.0
+
+    def test_a_metered_provider_still_costs(self) -> None:
+        """The exemption must not have flattened the estimate for real APIs."""
+        assert portrait_cost("openai") > 0.0

--- a/tests/unit/test_experts/test_portrait_appearance.py
+++ b/tests/unit/test_experts/test_portrait_appearance.py
@@ -18,10 +18,37 @@ from deepr.experts.portraits import _build_prompt, self_chosen_appearance
 
 
 class TestTheExpertChoosesItsOwnFace:
-    def test_a_written_appearance_is_the_whole_subject(self) -> None:
+    def test_a_written_appearance_is_the_scene(self) -> None:
         prompt = _build_prompt("tkg", "temporal knowledge graphs", None, appearance="A surveyor at dusk.")
-        assert prompt.startswith("A surveyor at dusk.")
+        assert "A surveyor at dusk." in prompt
         assert "temporal knowledge graphs" not in prompt
+
+    def test_who_is_in_the_scene_is_stated_rather_than_left_to_the_model(self) -> None:
+        """An appearance describes a situation and rarely says who is in it.
+
+        Left unstated, the model supplies its own default, and eight experts
+        whose scenes were a loading dock, a card index and a survey field all
+        came back as the same man in a blazer.
+        """
+        assert _build_prompt("tkg", None, None, appearance="A surveyor at dusk.").startswith("Portrait of a ")
+
+    def test_the_same_expert_looks_like_itself_every_time(self) -> None:
+        first = _build_prompt("tkg", None, None, appearance="A surveyor at dusk.")
+        assert first == _build_prompt("tkg", None, None, appearance="A surveyor at dusk.")
+
+    def test_different_experts_are_different_people(self) -> None:
+        subjects = {
+            _build_prompt(n, None, None, appearance="At a desk.").split(".")[0]
+            for n in ("tkg", "anti-slop", "evaluation", "provenance", "retrieval", "mycorrhizal")
+        }
+        assert len(subjects) > 1, "the roster would be one person repeated"
+
+    def test_the_style_does_not_force_a_boardroom(self) -> None:
+        """The style used to say "high-end SaaS avatar" and "ultra-professional",
+        which overwhelmed every scene an expert described."""
+        prompt = _build_prompt("tkg", None, None, appearance="A surveyor at dusk.")
+        assert "no suit or blazer" in prompt
+        assert "Not a studio headshot" in prompt
 
     def test_the_field_is_used_only_when_nothing_was_chosen(self) -> None:
         assert "temporal knowledge graphs" in _build_prompt("tkg", "temporal knowledge graphs", None)


### PR DESCRIPTION
## Portraits render themselves, for any new expert

A local image binary is now a first-class \$0 provider (`DEEPR_LOCAL_IMAGE_CLI=artomate`), and `expert profile` renders a portrait as soon as an expert has described how it wants to look. No manual script step.

The metered gate exempts it deliberately: `DEEPR_LOCAL_IMAGE_URL` stays blocked because a loopback HTTP endpoint is not evidence of local execution - a proxy on 127.0.0.1 can hold cloud credentials and forward while looking identical from the client side. A local binary has no endpoint to impersonate and no credential to forward.

## Every portrait was the same man in a blazer

Two causes. The subject clause only ran in the *fallback* branch, so an expert that described a scene left who is standing in it unstated and the model supplied its own default. And the house style specified "high-end SaaS avatar" and "ultra-professional and trustworthy", which overwhelmed whatever scene the expert wrote.

Style now carries framing, light, crop and palette with explicit negatives; the subject comes from a name-seeded rotation so an expert looks like itself across re-renders while the roster is not one person repeated.

## Docs

Changelog and roadmap cover the v2 HTTP layer, the UI on it, and both naming defects. Adds `what-ai-proxy-teaches-deepr.md`: two independently built systems converged on temporal validity and provenance-per-claim, and the thing the other has is a consolidation pass that learns from being *used* - Deepr writes a consult trace on every consult and has zero consumers for them.