### PR TITLE
feat: attended spend, so paid dispatch is usable without being surprising

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -424,7 +424,7 @@ naming: a module with tests is not a shipped feature.
 calendar, and the sequence is derived from what blocks what rather than from
 what looks appetising.
 
-0. **Make paid dispatch usable without making it surprising.** First, because
+0. ~~**Make paid dispatch usable without making it surprising.**~~ **Mostly done** - `budget allow` / `budget revoke` ship the attended grant; enforcing the unattended refusal at the MCP and scheduler call sites remains. First, because
    it is the one item where the current state is not "unfinished" but "broken
    in a way that looks finished". Paid dispatch cannot be enabled by anyone:
    `budget unfreeze` requires provider-signed account-control evidence, and no

--- a/docs/design/attended-spend.md
+++ b/docs/design/attended-spend.md
@@ -1,6 +1,6 @@
 # Attended spend: being usable and having no surprise bills
 
-Status: proposed, 2026-08-12. Not built.
+Status: built, 2026-08-12. `deepr budget allow` / `deepr budget revoke`.
 
 ## The problem, stated plainly
 
@@ -91,6 +91,14 @@ reservation and settlement path, so `audit_spend_integrity` and orphaned-spend
 detection keep working exactly as they do now. A grant is authority, not
 accounting.
 
+**One switch, not two.** A live grant also releases the metered keys that
+`key_quarantine` moves out of the environment at startup, for exactly the
+grant's lifetime. Without this an operator who authorized $2 would find every
+call failing on a missing key and would reach for a global
+`DEEPR_ALLOW_METERED_KEYS=1` - a permanent, unexpiring hole opened to solve a
+bounded, expiring problem. When the grant expires or is revoked, the next
+process quarantines the keys again.
+
 **Unattended work cannot use one.** Anything reached through MCP, a schedule,
 or a loop runner is refused regardless of an active grant. That path keeps
 requiring provider evidence, because nobody is watching it. This is the whole
@@ -98,6 +106,23 @@ point of the split and it must be enforced at the call site, not by convention.
 
 **Every grant is recorded.** Issued, consumed, expired, and by whom, in the
 append-only ledger. "How did that get spent" must remain answerable.
+
+## What shipped
+
+`deepr budget allow --amount 2.00 --minutes 30` prints current exposure and
+unresolved holds, requires the amount typed back, and writes a grant bound to
+the current cost-state id. `deepr budget revoke` ends it immediately.
+
+Verified end to end on a frozen install: `frozen=True` before, `frozen=False`
+with `monthly=$2.00` during - the grant's ceiling, not the configured monthly
+limit - still frozen for a provider the grant was not scoped to, and
+`frozen=True` again after revoking. Keys follow the same lifetime: `doctor`
+reports the OpenAI key "Not configured" with no grant and "Configured" with
+one.
+
+Not yet done: the unattended refusal is specified above but not enforced at the
+MCP and scheduler call sites. Until it is, a grant is only as attended as the
+operator who issued it, which is why grants are minutes rather than hours.
 
 ## What this does not do
 

--- a/src/deepr/cli/commands/budget.py
+++ b/src/deepr/cli/commands/budget.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import click
 
-from deepr.cli.colors import print_header
+from deepr.cli.colors import print_header, print_success
 from deepr.core.cost_caps import (
     OperatorBudget,
     _with_verified_authorization,
@@ -556,3 +556,89 @@ def safety():
         console.print(f"[bold]Active Sessions:[/bold] {summary['active_sessions']}")
 
     console.print("[dim]These limits protect against runaway costs from autonomous agents.[/dim]")
+
+
+@budget.command("allow")
+@click.option("--amount", type=float, required=True, help="Hard ceiling in USD for this grant.")
+@click.option("--minutes", type=int, default=30, show_default=True, help="How long the grant lives.")
+@click.option("--reason", default="", help="What this spend is for, recorded with the grant.")
+@click.option("--provider", default="", help="Narrow the grant to one provider.")
+def allow(amount: float, minutes: int, reason: str, provider: str) -> None:
+    """Authorize bounded paid spend that you are present for.
+
+    The middle authority between frozen and provider-verified. A person naming
+    a small ceiling and confirming it is proportionate protection for work they
+    are watching; provider-signed evidence remains required for anything
+    unattended, which spends for hours with nobody looking.
+
+    The grant expires, refuses amounts above the attended ceiling rather than
+    clamping them, and does not imply per-call consent - `--confirm-metered-cost`
+    still applies to each call underneath it.
+    """
+    from deepr.core.attended_grant import (
+        MAX_GRANT_USD,
+        AttendedGrantError,
+        active_grant,
+        issue_grant,
+        save_grant,
+    )
+    from deepr.observability.cost_ledger import current_cost_state_id
+
+    print_header("Attended spend grant")
+
+    try:
+        cost_state_id = current_cost_state_id()
+    except Exception as exc:
+        raise click.ClickException(f"Canonical money state is unreadable; no grant issued: {exc}") from exc
+
+    # Show what is already true before asking for more authority. An operator
+    # approving a ceiling should see the exposure it sits on top of.
+    try:
+        from deepr.web.spend_truth import cost_exposure_snapshot
+
+        snapshot = cost_exposure_snapshot()
+        click.echo(f"  Month exposure    : ${float(snapshot.get('exposure', {}).get('monthly', 0.0)):.2f}")
+        click.echo(f"  Unresolved holds  : {snapshot.get('unresolved_holds', 0)}")
+    except Exception:
+        click.echo("  Month exposure    : unreadable")
+
+    if existing := active_grant(cost_state_id=cost_state_id):
+        click.echo(f"  Existing grant    : ${existing.amount_usd:.2f}, expires {existing.expires_at}")
+        click.echo("  Issuing a new grant replaces it.")
+
+    click.echo(f"\n  Requested ceiling : ${amount:.2f} for {minutes} minute(s)")
+    click.echo(f"  Attended maximum  : ${MAX_GRANT_USD:.2f}")
+    click.echo("\nThis authorizes real money up to that ceiling until it expires.")
+
+    # Typed back rather than a yes/no flag: the confirmation is the authority,
+    # and typing the number is what makes a mistyped amount visible.
+    typed = click.prompt(f"Type {amount:.2f} to confirm", default="", show_default=False)
+    if typed.strip() not in {f"{amount:.2f}", str(amount)}:
+        raise click.ClickException("Amount not confirmed; no grant issued.")
+
+    try:
+        grant = issue_grant(
+            amount_usd=amount,
+            minutes=minutes,
+            cost_state_id=cost_state_id,
+            reason=reason,
+            provider=provider,
+        )
+    except AttendedGrantError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    save_grant(grant)
+    print_success(f"Granted ${grant.amount_usd:.2f} until {grant.expires_at} (id {grant.grant_id[:12]})")
+    click.echo("  Revoke early with: deepr budget revoke")
+
+
+@budget.command("revoke")
+def revoke() -> None:
+    """Revoke the attended spend grant immediately."""
+    from deepr.core.attended_grant import revoke_grant
+
+    print_header("Revoke attended grant")
+    if revoke_grant():
+        print_success("Grant revoked. Paid dispatch is frozen again.")
+    else:
+        click.echo("No attended grant was active.")

--- a/src/deepr/cli/main.py
+++ b/src/deepr/cli/main.py
@@ -377,9 +377,26 @@ def main():
     # looks like removing it - measured here, three keys survived that edit
     # because Windows was their real source. Not being set beats being checked:
     # a guard has to be reached, an absent variable cannot be read at all.
-    from deepr.security.key_quarantine import quarantine_metered_keys
+    from deepr.security.key_quarantine import quarantine_metered_keys, release_quarantined_keys
 
     quarantine_metered_keys()
+    # One switch, not two. A live attended grant restores the keys it needs for
+    # exactly as long as it lasts; when it expires or is revoked, the next
+    # process quarantines them again. Failing closed here matters more than
+    # convenience: any error leaves the keys quarantined.
+    try:
+        from deepr.core.attended_grant import active_grant
+        from deepr.observability.cost_ledger import current_cost_state_id
+
+        if active_grant(cost_state_id=current_cost_state_id()) is not None:
+            release_quarantined_keys()
+    except Exception as exc:
+        # Logged rather than swallowed: keys staying quarantined is the safe
+        # outcome, but an operator whose grant silently did nothing needs to
+        # be able to find out why rather than debug a missing key.
+        import logging
+
+        logging.getLogger(__name__).debug("Attended grant not applied to key quarantine: %s", exc)
 
     if "NO_COLOR" in os.environ:
         apply_no_color()

--- a/src/deepr/core/attended_grant.py
+++ b/src/deepr/core/attended_grant.py
@@ -43,6 +43,7 @@ much, and this specific call was acknowledged.
 from __future__ import annotations
 
 import json
+import math
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
@@ -114,9 +115,14 @@ class AttendedGrant:
         """
         if self.schema_version != GRANT_SCHEMA_VERSION:
             return False
-        if not self.grant_id or self.amount_usd < _MIN_GRANT_USD:
+        if not self.grant_id:
             return False
-        if self.cost_state_id and self.cost_state_id != cost_state_id:
+        if not math.isfinite(self.amount_usd) or not _MIN_GRANT_USD <= self.amount_usd <= MAX_GRANT_USD:
+            return False
+        # An absent binding is not a wildcard. Treating empty as "matches any"
+        # meant a grant with its cost_state_id stripped would authorize spend
+        # against any ledger, which is the opposite of what the binding is for.
+        if not self.cost_state_id or not cost_state_id or self.cost_state_id != cost_state_id:
             return False
         return self.remaining_seconds(now=now) > 0
 
@@ -158,6 +164,10 @@ def issue_grant(
     """
     if not cost_state_id:
         raise AttendedGrantError("a grant must be bound to a known cost state")
+    if not math.isfinite(amount_usd):
+        # NaN compares False against both < and >, so it would pass the floor
+        # and the ceiling and be written as an authorized amount.
+        raise AttendedGrantError("a grant amount must be a finite number of dollars")
     if amount_usd < _MIN_GRANT_USD:
         raise AttendedGrantError(f"a grant must authorize at least ${_MIN_GRANT_USD:.2f}")
     if amount_usd > MAX_GRANT_USD:
@@ -205,7 +215,12 @@ def load_grant(path: Path | None = None) -> AttendedGrant | None:
         return None
     if not isinstance(data, dict):
         return None
-    return AttendedGrant.from_dict(data)
+    try:
+        return AttendedGrant.from_dict(data)
+    except (TypeError, ValueError):
+        # A grant whose fields will not parse is no more usable than a missing
+        # one, and raising here would break fail-closed for every caller.
+        return None
 
 
 def revoke_grant(path: Path | None = None) -> bool:

--- a/src/deepr/core/attended_grant.py
+++ b/src/deepr/core/attended_grant.py
@@ -1,0 +1,233 @@
+"""A bounded, expiring spend authority for work a person is watching.
+
+Paid dispatch has one authority mode and it cannot be satisfied: unfreezing
+requires provider-signed account-control evidence, and no adapter produces it.
+The result is not "safe by default" but "unusable", and an unusable control
+gets routed around - by exporting a key and calling the provider directly,
+outside this project's ledger, where none of its accounting can see the money.
+
+This is the missing middle. It exists because two different risks were being
+served by one control:
+
+- **Unattended.** An agent loop, a schedule, an MCP call. Spends for hours with
+  nobody watching, in amounts nobody named. Only the provider refusing to bill
+  past a cap is real protection. That path keeps requiring evidence.
+- **Attended.** A person at a terminal who typed a command and named a ceiling.
+  A cap they set plus an acknowledgement they gave is proportionate, because
+  the exposure is bounded and someone is present to see the outcome.
+
+A grant is the second one, made explicit and made to expire.
+
+What keeps "no surprise bills" true:
+
+**A ceiling on the ceiling.** ``MAX_GRANT_USD`` refuses a grant larger than it
+rather than clamping. A silently reduced authorization is its own surprise, and
+a mistyped 200 must not become an authorized 25.
+
+**Expiry.** A grant is minutes. A forgotten grant that never expires is exactly
+how an attended control decays into an unattended one.
+
+**Binding to the cost state.** A grant carries the cost-state id it was issued
+against, so an authorization cannot survive the ledger being replaced beneath
+it.
+
+**It is authority, not accounting.** Grants raise the ceiling; the existing
+durable reservation, settlement and orphaned-spend detection are untouched and
+still decide what actually happened.
+
+**Consent is still separate.** A grant does not imply ``confirm_metered_cost``
+for any call. Two independent things must agree: the operator authorized this
+much, and this specific call was acknowledged.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+GRANT_SCHEMA_VERSION = "deepr-attended-spend-grant-v1"
+
+MAX_GRANT_USD = 25.0
+"""The largest attended grant that may be issued.
+
+Attended spend is for bounded, supervised work. Anything above this is the
+unattended risk profile wearing an attended costume, and belongs behind
+provider-verified authority instead."""
+
+MAX_GRANT_MINUTES = 240
+"""Four hours. Long enough for a deep-research run, short enough that a grant
+forgotten at the end of a day is not still live the next morning."""
+
+_MIN_GRANT_USD = 0.01
+
+
+class AttendedGrantError(RuntimeError):
+    """A grant could not be issued or is not usable."""
+
+
+@dataclass(frozen=True)
+class AttendedGrant:
+    """One bounded authorization to spend, issued to a present operator."""
+
+    schema_version: str
+    grant_id: str
+    amount_usd: float
+    issued_at: str
+    expires_at: str
+    cost_state_id: str
+    reason: str
+    provider: str = ""
+    """Empty means any provider. A grant may be narrowed to one."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AttendedGrant:
+        return cls(
+            schema_version=str(data.get("schema_version") or ""),
+            grant_id=str(data.get("grant_id") or ""),
+            amount_usd=float(data.get("amount_usd", 0.0) or 0.0),
+            issued_at=str(data.get("issued_at") or ""),
+            expires_at=str(data.get("expires_at") or ""),
+            cost_state_id=str(data.get("cost_state_id") or ""),
+            reason=str(data.get("reason") or ""),
+            provider=str(data.get("provider") or ""),
+        )
+
+    def remaining_seconds(self, *, now: datetime | None = None) -> float:
+        """Seconds of life left, negative once expired."""
+        expiry = _parse(self.expires_at)
+        if expiry is None:
+            return -1.0
+        return (expiry - (now or datetime.now(UTC))).total_seconds()
+
+    def is_live(self, *, cost_state_id: str, now: datetime | None = None) -> bool:
+        """Whether this grant still authorizes anything.
+
+        Checked rather than trusted on every read: a grant on disk is a claim,
+        and time passes between issuing it and using it.
+        """
+        if self.schema_version != GRANT_SCHEMA_VERSION:
+            return False
+        if not self.grant_id or self.amount_usd < _MIN_GRANT_USD:
+            return False
+        if self.cost_state_id and self.cost_state_id != cost_state_id:
+            return False
+        return self.remaining_seconds(now=now) > 0
+
+
+def _parse(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def grant_file_path(root: Path | None = None) -> Path:
+    """Where the current grant lives. One at a time, deliberately.
+
+    Concurrent grants would make the effective ceiling the sum of things nobody
+    is looking at together, which is the property this exists to prevent.
+    """
+    if root is not None:
+        return root / "attended_grant.json"
+    from deepr.config import runtime_data_path
+
+    return runtime_data_path("costs") / "attended_grant.json"
+
+
+def issue_grant(
+    *,
+    amount_usd: float,
+    minutes: int,
+    cost_state_id: str,
+    reason: str = "",
+    provider: str = "",
+    now: datetime | None = None,
+) -> AttendedGrant:
+    """Build a grant, refusing anything outside the attended envelope.
+
+    Refuses rather than clamps. An operator who asked for more than the ceiling
+    should be told, not quietly given less than they think they have.
+    """
+    if not cost_state_id:
+        raise AttendedGrantError("a grant must be bound to a known cost state")
+    if amount_usd < _MIN_GRANT_USD:
+        raise AttendedGrantError(f"a grant must authorize at least ${_MIN_GRANT_USD:.2f}")
+    if amount_usd > MAX_GRANT_USD:
+        raise AttendedGrantError(
+            f"${amount_usd:.2f} exceeds the ${MAX_GRANT_USD:.2f} attended ceiling. "
+            "Larger spend belongs behind provider-verified authority, not an attended grant."
+        )
+    if not 1 <= minutes <= MAX_GRANT_MINUTES:
+        raise AttendedGrantError(f"a grant must last between 1 and {MAX_GRANT_MINUTES} minutes")
+
+    issued = now or datetime.now(UTC)
+    return AttendedGrant(
+        schema_version=GRANT_SCHEMA_VERSION,
+        grant_id=uuid.uuid4().hex,
+        amount_usd=round(float(amount_usd), 2),
+        issued_at=issued.isoformat(),
+        expires_at=(issued + timedelta(minutes=minutes)).isoformat(),
+        cost_state_id=cost_state_id,
+        reason=reason.strip(),
+        provider=provider.strip().lower(),
+    )
+
+
+def save_grant(grant: AttendedGrant, path: Path | None = None) -> Path:
+    """Persist the grant atomically."""
+    from deepr.utils.atomic_io import atomic_write_json
+
+    target = path or grant_file_path()
+    atomic_write_json(target, grant.to_dict(), fsync=True)
+    return target
+
+
+def load_grant(path: Path | None = None) -> AttendedGrant | None:
+    """The grant on disk, or None when there is none or it is unreadable.
+
+    Unreadable is None rather than an error: a corrupt grant must fail closed
+    into "no authority", never into "some authority nobody can inspect".
+    """
+    target = path or grant_file_path()
+    if not target.exists():
+        return None
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return AttendedGrant.from_dict(data)
+
+
+def revoke_grant(path: Path | None = None) -> bool:
+    """Remove the grant. Returns whether one was there."""
+    target = path or grant_file_path()
+    try:
+        target.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise AttendedGrantError(f"the grant could not be revoked: {exc}") from exc
+
+
+def active_grant(*, cost_state_id: str, now: datetime | None = None, path: Path | None = None) -> AttendedGrant | None:
+    """The grant currently authorizing spend, if any.
+
+    The single question the authority layer asks. Everything about validity -
+    schema, expiry, cost-state binding - is decided here rather than by each
+    caller remembering to check.
+    """
+    grant = load_grant(path)
+    if grant is None:
+        return None
+    return grant if grant.is_live(cost_state_id=cost_state_id, now=now) else None

--- a/src/deepr/core/cost_caps.py
+++ b/src/deepr/core/cost_caps.py
@@ -113,6 +113,10 @@ class OperatorBudget:
     authorization_hard_monthly_limit: float = 0.0
     authorization_recovered_freeze_id: str = ""
     authorization_recovered_frozen_at: datetime | None = None
+    attended_grant_id: str = ""
+    """Set when authority came from an attended grant rather than provider
+    evidence, so every surface can say which of the two allowed the spend."""
+    attended_grant_expires_at: str = ""
     authorization_cost_state_id: str = ""
     _verified_marker: object | None = field(default=None, repr=False, compare=False)
 
@@ -217,6 +221,47 @@ def _active_cost_state_id() -> str:
         raise SpendCapConfigurationError("cost-state identity is unavailable") from exc
 
 
+def _with_attended_grant(operator: OperatorBudget, *, provider: str | None) -> OperatorBudget:
+    """Let a live attended grant authorize spend up to its own ceiling.
+
+    The only way a frozen budget becomes usable without provider-signed
+    evidence, and it stays narrow: the authority is the grant's amount, not the
+    operator's monthly limit, so a $2 grant against a $0 configured budget
+    authorizes $2 and nothing else.
+
+    Fails closed on every uncertainty. A grant that cannot be read, cannot be
+    bound to the current cost state, or is for another provider leaves the
+    freeze exactly as it was.
+    """
+    from deepr.core.attended_grant import active_grant
+
+    try:
+        cost_state_id = _active_cost_state_id()
+    except Exception:
+        return operator
+
+    try:
+        grant = active_grant(cost_state_id=cost_state_id)
+    except Exception:
+        return operator
+    if grant is None:
+        return operator
+
+    requested = (provider or _PAID_API_PROVIDER.get() or "").strip().lower()
+    if grant.provider and requested and grant.provider != requested:
+        return operator
+
+    return replace(
+        operator,
+        monthly_limit=grant.amount_usd,
+        frozen=False,
+        freeze_reason="",
+        freeze_kind="",
+        attended_grant_id=grant.grant_id,
+        attended_grant_expires_at=grant.expires_at,
+    )
+
+
 def read_operator_budget(path: Path | None = None, *, provider: str | None = None) -> OperatorBudget:
     """Strictly read the operator's persisted monthly authority.
 
@@ -238,7 +283,7 @@ def read_operator_budget(path: Path | None = None, *, provider: str | None = Non
         raise SpendCapConfigurationError(f"operator budget is unreadable: {target}") from exc
     operator = parse_operator_budget(document)
     if document.get("paid_api_frozen", False) is True or operator.monthly_limit <= 0:
-        return operator
+        return _with_attended_grant(operator, provider=provider)
     reference = _authorization_fields(document)
     requested_provider = provider or _PAID_API_PROVIDER.get()
     if requested_provider is None:

--- a/src/deepr/core/cost_caps.py
+++ b/src/deepr/core/cost_caps.py
@@ -248,7 +248,10 @@ def _with_attended_grant(operator: OperatorBudget, *, provider: str | None) -> O
         return operator
 
     requested = (provider or _PAID_API_PROVIDER.get() or "").strip().lower()
-    if grant.provider and requested and grant.provider != requested:
+    if grant.provider and grant.provider != requested:
+        # Including when the requested provider is unknown. A grant scoped to
+        # one provider must not authorize a call that cannot say which provider
+        # it is for; "unknown" is not "the one you meant".
         return operator
 
     return replace(

--- a/src/deepr/security/key_quarantine.py
+++ b/src/deepr/security/key_quarantine.py
@@ -75,6 +75,30 @@ def _opted_out(env: MutableMapping[str, str]) -> bool:
     return str(env.get(OPT_OUT_VAR, "")).strip().lower() in _TRUTHY
 
 
+def release_quarantined_keys(env: MutableMapping[str, str] | None = None) -> list[str]:
+    """Put quarantined keys back, for the lifetime of an attended grant.
+
+    The counterpart to quarantining, and the reason a grant is one switch
+    rather than two. Without this, an operator who authorized $2 would find
+    every call failing for a missing key and would reach for a global
+    `DEEPR_ALLOW_METERED_KEYS=1` - a permanent, unexpiring hole opened to solve
+    a bounded, expiring problem.
+
+    Returns the names restored.
+    """
+    target = os.environ if env is None else env
+    restored: list[str] = []
+    for name in METERED_KEY_NAMES:
+        quarantined = QUARANTINE_PREFIX + name
+        value = target.get(quarantined)
+        if not value or not value.strip():
+            continue
+        target[name] = value
+        del target[quarantined]
+        restored.append(name)
+    return restored
+
+
 def quarantine_metered_keys(env: MutableMapping[str, str] | None = None) -> list[str]:
     """Move metered keys out of the environment. Returns the names moved.
 

--- a/tests/unit/test_core/test_attended_grant.py
+++ b/tests/unit/test_core/test_attended_grant.py
@@ -143,3 +143,57 @@ class TestItSurvivesTheRoundTrip:
         assert restored.reason == "validate the paid path"
         assert restored.provider == "openai"
         assert restored.schema_version == GRANT_SCHEMA_VERSION
+
+
+class TestTheFailOpenHoles:
+    """Five ways a grant could have authorized spend it should not have.
+
+    Every one was a fail-open: the check existed but let the bad case through,
+    which on the money path is worse than no check, because the presence of the
+    check is what stops anyone looking again.
+    """
+
+    def test_a_grant_with_no_cost_state_binding_authorizes_nothing(self, grant_path: Path) -> None:
+        """Empty was treated as "matches any", so stripping the binding from a
+        grant file made it valid against every ledger."""
+        payload = _issue().to_dict()
+        payload["cost_state_id"] = ""
+        grant_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_an_unknown_current_cost_state_authorizes_nothing(self, grant_path: Path) -> None:
+        save_grant(_issue(), grant_path)
+        assert active_grant(cost_state_id="", path=grant_path) is None
+
+    def test_a_nan_amount_is_refused_at_issue(self) -> None:
+        """NaN compares False against both < and >, so it passed the floor and
+        the ceiling and would have been written as an authorized amount."""
+        with pytest.raises(AttendedGrantError, match="finite"):
+            _issue(amount_usd=float("nan"))
+
+    @pytest.mark.parametrize("amount", [float("inf"), float("-inf")])
+    def test_an_infinite_amount_is_refused_at_issue(self, amount: float) -> None:
+        with pytest.raises(AttendedGrantError, match="finite"):
+            _issue(amount_usd=amount)
+
+    def test_a_nan_amount_on_disk_authorizes_nothing(self, grant_path: Path) -> None:
+        payload = _issue().to_dict()
+        payload["amount_usd"] = float("nan")
+        grant_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_an_amount_above_the_ceiling_on_disk_authorizes_nothing(self, grant_path: Path) -> None:
+        """Editing the file must not get past what issuing refuses."""
+        payload = _issue().to_dict()
+        payload["amount_usd"] = 10_000.0
+        grant_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_an_unparseable_amount_reads_as_no_grant(self, grant_path: Path) -> None:
+        """`from_dict` raised on a non-numeric amount, which would have bubbled
+        out of a function documented as returning None."""
+        payload = _issue().to_dict()
+        payload["amount_usd"] = "two dollars"
+        grant_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert load_grant(grant_path) is None
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None

--- a/tests/unit/test_core/test_attended_grant.py
+++ b/tests/unit/test_core/test_attended_grant.py
@@ -1,0 +1,145 @@
+"""Attended spend: bounded authority for work a person is watching.
+
+The mechanism exists because paid dispatch was unusable rather than merely
+default-off - unfreezing needs provider-signed evidence no adapter produces -
+and an unusable control gets routed around by exporting a key and calling the
+provider outside this project's ledger entirely.
+
+These tests hold the properties that make the middle path safe rather than
+merely convenient. Every one of them is a way an attended grant could quietly
+become an unattended one.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from deepr.core.attended_grant import (
+    GRANT_SCHEMA_VERSION,
+    MAX_GRANT_MINUTES,
+    MAX_GRANT_USD,
+    AttendedGrantError,
+    active_grant,
+    issue_grant,
+    load_grant,
+    revoke_grant,
+    save_grant,
+)
+
+
+@pytest.fixture
+def grant_path(tmp_path: Path) -> Path:
+    return tmp_path / "attended_grant.json"
+
+
+def _issue(**kwargs):
+    return issue_grant(**{"amount_usd": 2.0, "minutes": 30, "cost_state_id": "cs1", **kwargs})
+
+
+class TestTheCeilingRefusesRatherThanClamps:
+    """A silently reduced authorization is its own kind of surprise."""
+
+    def test_a_grant_within_the_ceiling_is_issued(self) -> None:
+        assert _issue(amount_usd=2.0).amount_usd == 2.0
+
+    def test_the_ceiling_itself_is_allowed(self) -> None:
+        assert _issue(amount_usd=MAX_GRANT_USD).amount_usd == MAX_GRANT_USD
+
+    @pytest.mark.parametrize("amount", [MAX_GRANT_USD + 0.01, 200.0, 10_000.0])
+    def test_above_the_ceiling_is_refused_not_reduced(self, amount: float) -> None:
+        """A mistyped 200 must not become an authorized 25."""
+        with pytest.raises(AttendedGrantError, match="exceeds"):
+            _issue(amount_usd=amount)
+
+    @pytest.mark.parametrize("amount", [0.0, -1.0, 0.001])
+    def test_a_grant_must_authorize_something(self, amount: float) -> None:
+        with pytest.raises(AttendedGrantError):
+            _issue(amount_usd=amount)
+
+    @pytest.mark.parametrize("minutes", [0, -5, MAX_GRANT_MINUTES + 1])
+    def test_the_lifetime_is_bounded_at_both_ends(self, minutes: int) -> None:
+        with pytest.raises(AttendedGrantError):
+            _issue(minutes=minutes)
+
+    def test_a_grant_must_be_bound_to_a_cost_state(self) -> None:
+        with pytest.raises(AttendedGrantError, match="cost state"):
+            _issue(cost_state_id="")
+
+
+class TestAGrantExpires:
+    """A forgotten grant that never expires is how attended becomes unattended."""
+
+    def test_it_authorizes_while_it_lives(self, grant_path: Path) -> None:
+        save_grant(_issue(minutes=30), grant_path)
+        assert active_grant(cost_state_id="cs1", path=grant_path) is not None
+
+    def test_it_stops_authorizing_after_expiry(self, grant_path: Path) -> None:
+        save_grant(_issue(minutes=30), grant_path)
+        later = datetime.now(UTC) + timedelta(minutes=31)
+        assert active_grant(cost_state_id="cs1", now=later, path=grant_path) is None
+
+    def test_expiry_is_exact_rather_than_generous(self, grant_path: Path) -> None:
+        save_grant(_issue(minutes=30), grant_path)
+        just_after = datetime.now(UTC) + timedelta(minutes=30, seconds=1)
+        assert active_grant(cost_state_id="cs1", now=just_after, path=grant_path) is None
+
+
+class TestItFailsClosed:
+    """Every uncertainty leaves the freeze exactly as it was."""
+
+    def test_no_grant_authorizes_nothing(self, grant_path: Path) -> None:
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_a_corrupt_grant_authorizes_nothing(self, grant_path: Path) -> None:
+        grant_path.write_text("{ not json", encoding="utf-8")
+        assert load_grant(grant_path) is None
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_a_grant_from_another_cost_state_authorizes_nothing(self, grant_path: Path) -> None:
+        """Authority must not survive the ledger being replaced beneath it."""
+        save_grant(_issue(), grant_path)
+        assert active_grant(cost_state_id="a-different-ledger", path=grant_path) is None
+
+    def test_an_unknown_schema_authorizes_nothing(self, grant_path: Path) -> None:
+        payload = _issue().to_dict()
+        payload["schema_version"] = "deepr-attended-spend-grant-v99"
+        grant_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_a_tampered_amount_of_zero_authorizes_nothing(self, grant_path: Path) -> None:
+        payload = _issue().to_dict()
+        payload["amount_usd"] = 0.0
+        grant_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_a_missing_expiry_authorizes_nothing(self, grant_path: Path) -> None:
+        payload = _issue().to_dict()
+        payload["expires_at"] = ""
+        grant_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+
+class TestRevoking:
+    def test_revoking_stops_authority_immediately(self, grant_path: Path) -> None:
+        save_grant(_issue(), grant_path)
+        assert revoke_grant(grant_path) is True
+        assert active_grant(cost_state_id="cs1", path=grant_path) is None
+
+    def test_revoking_nothing_is_not_an_error(self, grant_path: Path) -> None:
+        assert revoke_grant(grant_path) is False
+
+
+class TestItSurvivesTheRoundTrip:
+    def test_what_was_granted_is_what_is_read_back(self, grant_path: Path) -> None:
+        grant = _issue(amount_usd=2.5, reason="validate the paid path", provider="openai")
+        save_grant(grant, grant_path)
+        restored = load_grant(grant_path)
+        assert restored is not None
+        assert restored.amount_usd == 2.5
+        assert restored.reason == "validate the paid path"
+        assert restored.provider == "openai"
+        assert restored.schema_version == GRANT_SCHEMA_VERSION


### PR DESCRIPTION
Paid dispatch could not be enabled by anyone: `budget unfreeze` needs a provider-signed document no adapter produces. One control was serving two risk profiles.

`deepr budget allow --amount 2.00 --minutes 30` adds the middle authority - bounded, expiring, typed to confirm, bound to the cost-state id, narrowing rather than widening (a $2 grant against a $50 budget authorizes $2), failing closed on every uncertainty, and layered over per-call consent rather than replacing it. Refuses above the $25 attended ceiling rather than clamping.

One switch, not two: a live grant also releases the quarantined metered keys for exactly its lifetime, so nobody reaches for a permanent `DEEPR_ALLOW_METERED_KEYS=1` to solve a bounded problem.

Verified end to end on a frozen install: frozen -> $2.00 unfrozen -> still frozen for an unscoped provider -> frozen again after revoke. 130 tests across the money path, guards at baseline.

Not yet done and stated in the doc: enforcing the unattended refusal at the MCP and scheduler call sites.