### PR TITLE
fix: harden expert profile migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/blisspixel/deepr/actions/workflows/ci.yml/badge.svg)](https://github.com/blisspixel/deepr/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.49.0-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.49.0)
+[![Version](https://img.shields.io/badge/version-2.49.1-blue)](https://github.com/blisspixel/deepr/releases/tag/v2.49.1)
 
 **Persistent domain experts built from bounded, auditable research.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,7 +363,12 @@ reliable product, not a four-language architecture diagram.
 
 ---
 
-## Current Status (v2.49.0)
+## Current Status (v2.49.1)
+
+**Shipped in v2.49.1 (see docs/CHANGELOG.md):** expert-profile migration now
+normalizes and validates schema versions consistently, refuses future or
+fractional schemas, and re-reads under the profile save lock so it cannot
+overwrite a concurrent newer save.
 
 **Shipped in v2.49.0 (see docs/CHANGELOG.md):** attended metered authority is
 now a persistent cumulative wallet chosen by the operator, with a separate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.49.1] - 2026-08-13
+
+### Fixed
+
+- Profile migration now normalizes numeric schema strings before comparing
+  versions, rejects fractional, invalid, and future schema versions, and uses
+  the same validation for direct deserialization. A valid legacy profile with
+  `"schema_version": "4"` no longer crashes during migration, and malformed
+  versions can no longer be truncated into a supported schema.
+- Profile migration now re-reads the document while holding the same file lock
+  used by normal saves. A concurrent save that completes while migration is
+  waiting can no longer be overwritten by the stale pre-lock profile.
+
 ## [2.49.0] - 2026-08-13
 
 ### Added

--- a/docs/MCP_A2A_INTEROP_CHECKLIST.md
+++ b/docs/MCP_A2A_INTEROP_CHECKLIST.md
@@ -1,6 +1,6 @@
 # MCP and A2A Interop Checklist
 
-Status: current with Deepr v2.49.0. Last reviewed: 2026-08-13.
+Status: current with Deepr v2.49.1. Last reviewed: 2026-08-13.
 
 Use this checklist when connecting Deepr experts to another agent host through
 MCP or A2A. It is a compact integration review, not the command guide. For

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,6 +1,6 @@
 # Model Selection Guide
 
-Status: current with Deepr v2.49.0. Last reviewed: 2026-08-13.
+Status: current with Deepr v2.49.1. Last reviewed: 2026-08-13.
 
 The source of truth for model IDs, pricing estimates, context windows, and
 routing metadata is [src/deepr/providers/registry.py](../src/deepr/providers/registry.py).

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,6 +1,6 @@
 # Supported Surface
 
-Status: v2.49.0 current main, 2026-08-13. This document defines what users and host
+Status: v2.49.1 current main, 2026-08-13. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
 data remains portable if development stops. Unattended metered dispatch remains
 frozen until provider account-control adapters land. The narrow attended absorb

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -6,7 +6,7 @@
 
 Transform research from isolated queries into cumulative understanding. Build systems that learn and improve over time.
 
-## Current State (v2.49.0)
+## Current State (v2.49.1)
 
 What works today:
 - Write-free bounded provider-research preview and offline billing

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,6 +1,6 @@
 # Deepr Threat Model
 
-Status: current with Deepr v2.49.0. Last reviewed: 2026-08-13.
+Status: current with Deepr v2.49.1. Last reviewed: 2026-08-13.
 
 This document is the repository-scoped threat model for Deepr. It is intended
 for security reviews, design reviews, and future bug discovery. It should stay

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepr-research"
-version = "2.49.0"
+version = "2.49.1"
 description = "Research automation platform that replicates human research team workflows using AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/deepr/__init__.py
+++ b/src/deepr/__init__.py
@@ -5,7 +5,7 @@ Keep package import lightweight by lazily importing heavy modules.
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "2.49.0"
+__version__ = "2.49.1"
 __author__ = "Nick Seal"
 
 if TYPE_CHECKING:

--- a/src/deepr/experts/profile_store.py
+++ b/src/deepr/experts/profile_store.py
@@ -134,9 +134,13 @@ def migrate_profile_data(data: dict[str, Any]) -> dict[str, Any]:
         Migrated profile data at current schema version
     """
     # Determine current version (default to 1 if not present)
-    current_version = int(float(data.get("schema_version") or 1))
+    current_version = _profile_schema_version(data)
 
-    if current_version >= PROFILE_SCHEMA_VERSION:
+    if current_version > PROFILE_SCHEMA_VERSION:
+        raise ValueError(
+            f"profile schema_version {current_version} is newer than supported version {PROFILE_SCHEMA_VERSION}"
+        )
+    if current_version == PROFILE_SCHEMA_VERSION:
         return data
 
     # Apply migrations sequentially
@@ -155,6 +159,22 @@ def migrate_profile_data(data: dict[str, Any]) -> dict[str, Any]:
         current_version = next_version
 
     return data
+
+
+def _profile_schema_version(data: dict[str, Any]) -> int:
+    """Return the normalized integral schema version used by migrations."""
+    raw_version = data.get("schema_version")
+    if raw_version is None or raw_version == "":
+        return 1
+    if isinstance(raw_version, bool):
+        raise ValueError("profile schema_version must be an integer")
+    try:
+        numeric_version = float(raw_version)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("profile schema_version must be an integer") from exc
+    if not numeric_version.is_integer() or numeric_version < 1:
+        raise ValueError("profile schema_version must be an integer")
+    return int(numeric_version)
 
 
 # =============================================================================
@@ -356,20 +376,30 @@ class ExpertStore:
 
         # Apply migrations if needed
         if migrate:
-            original_version = data.get("schema_version", 1)
+            original_version = _profile_schema_version(data)
             data = migrate_profile_data(data)
 
             # Save migrated data if version changed
-            if persist_migration and data.get("schema_version", 1) > original_version:
+            if persist_migration and _profile_schema_version(data) > original_version:
                 from deepr.utils.atomic_io import atomic_write_json
 
-                atomic_write_json(path, data)
-                logger.info(
-                    "Migrated profile '%s' from v%d to v%d",
-                    name,
-                    original_version,
-                    data["schema_version"],
-                )
+                lock_path = path.with_suffix(path.suffix + ".lock")
+                with FileLock(str(lock_path), timeout=10):
+                    # A normal save may have completed after the first read.
+                    # Re-read under the shared lock so migration cannot replace
+                    # a newer profile with the stale pre-lock document.
+                    with open(path, encoding="utf-8") as f:
+                        locked_data = json.load(f)
+                    locked_version = _profile_schema_version(locked_data)
+                    data = migrate_profile_data(locked_data)
+                    if _profile_schema_version(data) > locked_version:
+                        atomic_write_json(path, data)
+                        logger.info(
+                            "Migrated profile '%s' from v%d to v%d",
+                            name,
+                            locked_version,
+                            data["schema_version"],
+                        )
 
         return ExpertProfile.from_dict(data)
 

--- a/src/deepr/experts/serializer.py
+++ b/src/deepr/experts/serializer.py
@@ -7,6 +7,7 @@ serialization.
 Requirements: 5.5 - Extract to_dict/from_dict logic
 """
 
+import math
 from dataclasses import asdict
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -29,6 +30,31 @@ COMPOSED_FIELDS = ["_temporal_state", "_freshness_checker", "_budget_manager", "
 
 # Metadata fields to exclude from ExpertProfile constructor.
 METADATA_FIELDS: list[str] = []
+
+
+def _normalized_schema_version(value: object) -> int:
+    """Return one supported integral profile schema version."""
+    if isinstance(value, bool):
+        raise ValueError("profile schema_version must be an integer")
+    if isinstance(value, int):
+        version = value
+    elif isinstance(value, (float, str)):
+        try:
+            numeric_version = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("profile schema_version must be an integer") from exc
+        if not math.isfinite(numeric_version) or not numeric_version.is_integer():
+            raise ValueError("profile schema_version must be an integer")
+        version = int(numeric_version)
+    else:
+        raise ValueError("profile schema_version must be an integer")
+    if version < 1:
+        raise ValueError("profile schema_version must be an integer")
+    from deepr.experts.profile_store import PROFILE_SCHEMA_VERSION
+
+    if version > PROFILE_SCHEMA_VERSION:
+        raise ValueError(f"profile schema_version {version} is newer than supported version {PROFILE_SCHEMA_VERSION}")
+    return version
 
 
 def datetime_to_iso(dt: datetime | None) -> str | None:
@@ -116,8 +142,8 @@ def dict_to_profile_kwargs(data: dict[str, Any]) -> dict[str, Any]:
     for field in METADATA_FIELDS:
         kwargs.pop(field, None)
 
-    if "schema_version" in kwargs and isinstance(kwargs["schema_version"], str):
-        kwargs["schema_version"] = int(float(kwargs["schema_version"]))
+    if "schema_version" in kwargs:
+        kwargs["schema_version"] = _normalized_schema_version(kwargs["schema_version"])
 
     # Convert ISO format strings to datetime
     for field in DATETIME_FIELDS:

--- a/tests/unit/test_experts/test_profile_store.py
+++ b/tests/unit/test_experts/test_profile_store.py
@@ -65,6 +65,16 @@ class TestMigrations:
         migrated = migrate_profile_data(current_data)
         assert migrated == current_data
 
+    def test_future_profile_schema_is_not_silently_downgraded(self):
+        future_data = {
+            "name": "future-expert",
+            "vector_store_id": "vs_future",
+            "schema_version": PROFILE_SCHEMA_VERSION + 1,
+        }
+
+        with pytest.raises(ValueError, match="newer than supported"):
+            migrate_profile_data(future_data)
+
 
 class TestExpertStore:
     """Tests for ExpertStore class."""
@@ -95,6 +105,72 @@ class TestExpertStore:
         assert loaded.description == "Test expert for unit tests"
         assert loaded.schema_version == PROFILE_SCHEMA_VERSION
         assert loaded.roster_tier == "standard"
+
+    def test_load_normalizes_string_schema_version_before_comparing_migration(self, store, sample_profile):
+        profile_path = store._get_profile_path(sample_profile.name)
+        profile_path.parent.mkdir(parents=True)
+        payload = sample_profile.to_dict()
+        payload["schema_version"] = "4"
+        payload.pop("roster_tier", None)
+        profile_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = store.load(sample_profile.name)
+
+        assert loaded is not None
+        assert loaded.roster_tier == "standard"
+        assert json.loads(profile_path.read_text(encoding="utf-8"))["schema_version"] == PROFILE_SCHEMA_VERSION
+
+    def test_migration_reloads_under_save_lock_before_persisting(
+        self,
+        store,
+        sample_profile,
+        monkeypatch,
+        caplog,
+    ):
+        profile_path = store._get_profile_path(sample_profile.name)
+        profile_path.parent.mkdir(parents=True)
+        legacy = sample_profile.to_dict()
+        legacy["schema_version"] = 4
+        legacy.pop("roster_tier", None)
+        profile_path.write_text(json.dumps(legacy), encoding="utf-8")
+
+        concurrent = sample_profile.to_dict()
+        concurrent["schema_version"] = PROFILE_SCHEMA_VERSION
+        concurrent["description"] = "saved while migration was waiting"
+        concurrent["roster_tier"] = "flagship"
+
+        class CompletingSave:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def __enter__(self):
+                profile_path.write_text(json.dumps(concurrent), encoding="utf-8")
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        monkeypatch.setattr("deepr.experts.profile_store.FileLock", CompletingSave)
+
+        with caplog.at_level("INFO", logger="deepr.experts.profile_store"):
+            loaded = store.load(sample_profile.name)
+
+        assert loaded is not None
+        assert loaded.description == "saved while migration was waiting"
+        assert loaded.roster_tier == "flagship"
+        assert json.loads(profile_path.read_text(encoding="utf-8"))["description"] == concurrent["description"]
+        assert "Migrated profile" not in caplog.text
+
+    @pytest.mark.parametrize("invalid_version", [True, 0, -1, 4.5, "not-a-version"])
+    def test_load_rejects_invalid_schema_versions(self, store, sample_profile, invalid_version):
+        profile_path = store._get_profile_path(sample_profile.name)
+        profile_path.parent.mkdir(parents=True)
+        payload = sample_profile.to_dict()
+        payload["schema_version"] = invalid_version
+        profile_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="schema_version"):
+            store.load(sample_profile.name)
 
     def test_flagship_roster_tier_round_trips(self, store, sample_profile):
         sample_profile.roster_tier = "flagship"

--- a/tests/unit/test_experts/test_serializer.py
+++ b/tests/unit/test_experts/test_serializer.py
@@ -2,6 +2,8 @@
 
 from datetime import UTC, datetime
 
+import pytest
+
 from deepr.experts.profile import PROFILE_SCHEMA_VERSION, ExpertProfile
 from deepr.experts.serializer import (
     COMPOSED_FIELDS,
@@ -89,6 +91,18 @@ class TestDictToProfileKwargs:
         data = {"name": "test", "schema_version": "2.0"}
         result = dict_to_profile_kwargs(data)
         assert result["schema_version"] == 2
+
+    @pytest.mark.parametrize(
+        "invalid_version",
+        [True, 0, -1, 2.5, "0", "-1", "2.5", "nan", "not-a-version", []],
+    )
+    def test_rejects_non_integral_schema_versions(self, invalid_version):
+        with pytest.raises(ValueError, match="schema_version"):
+            dict_to_profile_kwargs({"name": "test", "schema_version": invalid_version})
+
+    def test_rejects_future_schema_version(self):
+        with pytest.raises(ValueError, match="newer than supported"):
+            dict_to_profile_kwargs({"name": "test", "schema_version": PROFILE_SCHEMA_VERSION + 1})
 
     def test_converts_iso_to_datetime(self):
         data = {

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "deepr-research"
-version = "2.49.0"
+version = "2.49.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## What changed

- Normalize and validate expert profile schema versions before migration or direct deserialization.
- Reject invalid, fractional, and future schema versions instead of truncating or silently downgrading them.
- Re-read legacy profiles under the normal save lock before persisting migration output, preventing a stale migration from overwriting a concurrent newer save.
- Add regression coverage for numeric strings, malformed and future schemas, the concurrent-save race, and truthful migration logging.
- Bump the patch release to v2.49.1 and update current-version documentation and the changelog.

## Root cause

Migration compared a normalized integer to the original unnormalized value, while direct deserialization used lossy numeric coercion. Migration persistence also wrote the initially read document without sharing the normal save lock.

## User impact

Legacy numeric-string profiles load correctly. Corrupt or unsupported profile schemas fail closed. Concurrent profile updates are preserved during migration.

## Validation

- 68 focused profile and serializer tests pass.
- Ruff lint and format pass.
- Strict mypy islands pass for 151 source files.
- File-size, complexity, security-rule, paid-API-boundary, and documentation ratchets pass.
- 44 frontend tests, ESLint, npm audit, TypeScript, and Vite production build pass.
- v2.49.1 sdist and wheel build successfully, with packaged frontend assets verified.
- Changed-file pre-commit hooks pass.

The local full-suite coverage run remained responsive but exceeded a 40-minute wrapper before a verdict. Required GitHub CI uses a 90-minute test allowance on Python 3.12, 3.13, and 3.14 and is the merge gate.