### PR TITLE
fix: refuse silent writes that destroy expert state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -554,10 +554,10 @@ what looks appetising.
 
 **Refinements worth doing alongside, none of them blocking:**
 
-- **`stage_contract` at the stage.** Brief, viva, and profile now refuse empty
-  or uncited inputs before a model call or write. Status also requires cited
-  findings on every position. Remaining: graph / practice still report more
-  than they gate.
+- **`stage_contract` at the stage.** Brief, viva, profile, graph, and practice
+  now refuse empty or uncited inputs before a model call or write. Status also
+  requires cited findings on every position. Remaining: mid-call consult
+  failover still cannot wrap a chat client.
 - **Consult failover.** `--plan a,b,c` now skips a safety-blocked or exhausted
   name and uses the next eligible backend. Mid-call failover is still only on
   study and brief, because a consult builds a chat client rather than a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,10 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Empty or ungrounded briefs no longer write over a previous brief, close the
-  position ledger as not-restated, or exit 0 on `--json`. `expert brief`
-  refuses before any write. `expert viva` refuses a parseable brief that
-  holds no positions.
+- `expert cleanup --apply` no longer deletes a v2 expert that sourced, studied,
+  or briefed but never absorbed. Unreadable `beliefs.json` is treated as data,
+  not emptiness.
+- A present but unreadable position ledger is no longer treated as a new
+  expert. `expert brief` refuses before the model call instead of overwriting
+  the torn history.
+- `expert graph` and `expert practice` now refuse the same way status already
+  reports: they do not write an unformed graph or a practice with no cited
+  brief. `--show` is read-only. An unreadable `self.json` is not replaced.
+- `expert source` uses the acquire exit code and reports failed fetches.
+  A lock-skipped absorb exits 2. `expert retain` refuses non-UTF-8 sources
+  instead of hashing replacement characters. Fleet health counts only active
+  corpus sources.
+- Empty, ungrounded, or uncited briefs no longer write over a previous brief,
+  close the position ledger as not-restated, or exit 0 on `--json`.
+  `expert brief` refuses before any write. `expert viva` refuses a parseable
+  brief that holds no positions.
 - `get_current_confidence` can evaluate decay at a requested instant. Digest,
   OKF, and perspective history no longer apply today's decay to a past record.
   Naive stored timestamps no longer crash decay.

--- a/src/deepr/cli/commands/semantic/expert_cleanup.py
+++ b/src/deepr/cli/commands/semantic/expert_cleanup.py
@@ -6,7 +6,8 @@ while its beliefs and loop-runs landed in a display-named directory
 docs/design/... / paths.py). This command:
 
   1. MERGES each split into the single canonical (slug) directory, and
-  2. DELETES genuinely-empty experts (no beliefs, conversations, or documents).
+  2. DELETES genuinely-empty experts (no beliefs, corpus, brief, or other
+     durable artifacts).
 
 Dry-run by default. ``--apply`` backs up the whole experts root first, then
 acts (with a confirmation unless ``-y``). Never deletes an expert that has data.
@@ -61,6 +62,10 @@ class CleanupPlan:
     conflicts: list[str] = field(default_factory=list)
 
 
+_V2_DATA_DIRS = ("corpus", "noticed", "hold", "attend", "met", "graph", "became")
+"""The v2 loop never writes beliefs. These directories *are* the expert."""
+
+
 def _belief_count(expert_dir: Path) -> int:
     bf = expert_dir / "beliefs" / "beliefs.json"
     if not bf.exists():
@@ -68,7 +73,9 @@ def _belief_count(expert_dir: Path) -> int:
     try:
         data = json.loads(bf.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
-        return 0
+        # Present and unreadable is data. Counting it as 0 made cleanup
+        # delete the only surviving claim store.
+        return 1
     store = data.get("beliefs", data) if isinstance(data, dict) else data
     return len(store.values() if isinstance(store, dict) else store)
 
@@ -79,12 +86,18 @@ def _nonempty_subdir(expert_dir: Path, name: str) -> bool:
 
 
 def _has_data(expert_dir: Path) -> bool:
-    """An expert has data if it holds beliefs, conversations, or documents."""
-    return (
-        _belief_count(expert_dir) > 0
-        or _nonempty_subdir(expert_dir, "conversations")
-        or _nonempty_subdir(expert_dir, "documents")
-    )
+    """An expert has data if any durable artifact would be lost by deleting it.
+
+    Study never writes beliefs. A sourced, studied, briefed expert that has
+    never absorbed still has a corpus, a study, a brief, and a self-account.
+    Treating only v1 leftovers as data made ``--apply`` rmtree those experts.
+    """
+    if _belief_count(expert_dir) > 0:
+        return True
+    self_account = expert_dir / "self.json"
+    if self_account.is_file() and self_account.stat().st_size > 0:
+        return True
+    return any(_nonempty_subdir(expert_dir, name) for name in ("conversations", "documents", *_V2_DATA_DIRS))
 
 
 def build_plan(root: Path) -> CleanupPlan:
@@ -171,7 +184,10 @@ def _render_plan(plan: CleanupPlan) -> None:
         for legacy, canonical in plan.merges:
             console.print(f"  {legacy.name}  ->  {canonical.name}/")
     if plan.deletions:
-        console.print(f"\n[bold]Delete {len(plan.deletions)} empty expert(s)[/bold] (no beliefs/conversations/docs):")
+        console.print(
+            f"\n[bold]Delete {len(plan.deletions)} empty expert(s)[/bold] "
+            "(no beliefs, corpus, brief, or other durable artifacts):"
+        )
         for d in plan.deletions:
             console.print(f"  [red]{d.name}[/red]")
     if not plan.merges and not plan.deletions:

--- a/src/deepr/cli/commands/semantic/expert_graph.py
+++ b/src/deepr/cli/commands/semantic/expert_graph.py
@@ -95,13 +95,18 @@ def _load_profile(name: str) -> Any:
 
 
 def _corpus_entries(expert_name: str) -> list[Any]:
-    """The retained sources, so an edge can only point at a real passage."""
-    try:
-        from deepr.experts.corpus_store import CorpusStore
+    """The retained sources, so an edge can only point at a real passage.
 
+    An unreadable corpus is not "no sources". Swallowing that used to persist
+    an unformed graph over a previous formed one.
+    """
+    from deepr.experts.corpus_store import CorpusStore
+
+    try:
         return list(CorpusStore(expert_name).active_entries())
-    except Exception:
-        return []
+    except Exception as exc:
+        click.echo(f"Error: could not read the retained corpus: {exc}", err=True)
+        sys.exit(2)
 
 
 def _render_human(graph: Any, *, path: Path) -> None:
@@ -185,19 +190,28 @@ def expert_graph(name: str, out: str | None, write_markdown: bool, as_json: bool
       deepr expert graph "My Expert" --markdown
     """
     from deepr.experts.consult_context import load_brief, load_study
+    from deepr.experts.stage_contract import STAGE_GRAPH, evaluate_stage, get_stage
 
     profile = _load_profile(name)
     directory = canonical_expert_dir(profile.name)
     study = load_study(part_in(directory, "noticed"))
     brief = load_brief(part_in(directory, "hold_current"))
 
-    if study is None and brief is None:
-        click.echo(
-            f"Error: {profile.name} has neither a study nor a brief, so there is no chain to record. "
-            f'Run: deepr expert study "{profile.name}"',
-            err=True,
-        )
-        sys.exit(2)
+    artifacts = {
+        "noticed/current.json": study.to_dict() if study is not None else None,
+        "hold/current.json": brief.to_dict() if brief is not None else None,
+    }
+    graph_stage = get_stage(STAGE_GRAPH)
+    if graph_stage is not None:
+        state = evaluate_stage(graph_stage, artifacts)
+        if state.blockers:
+            reason = state.blockers[0].reason
+            fix = state.blockers[0].fix
+            click.echo(
+                f'Error: {profile.name} cannot form an evidence graph: {reason}. Run: deepr {fix} "{profile.name}"',
+                err=True,
+            )
+            sys.exit(2)
 
     built_at = datetime.now(UTC).isoformat()
     graph = build_graph(
@@ -207,6 +221,15 @@ def expert_graph(name: str, out: str | None, write_markdown: bool, as_json: bool
         corpus_entries=_corpus_entries(profile.name),
         at=built_at,
     )
+
+    formed = graph_stage is None or graph_stage.succeeds_when is None or graph_stage.succeeds_when(graph.to_dict())
+    if not formed:
+        click.echo(
+            f"Error: no position reaches a source through a finding, so nothing was written. "
+            f'Run: deepr expert study "{profile.name}" and deepr expert brief "{profile.name}"',
+            err=True,
+        )
+        sys.exit(2)
 
     path = Path(out) if out else canonical_graph_path(profile.name)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/deepr/cli/commands/semantic/expert_maintenance.py
+++ b/src/deepr/cli/commands/semantic/expert_maintenance.py
@@ -91,7 +91,7 @@ def _with_absorb_overlap_guard(command):
                 click.echo(json.dumps(payload, indent=2))
             else:
                 print_warning(f"Another absorb is already running for {name!r}; skipped before model construction.")
-            return None
+            sys.exit(2)
 
     return guarded
 

--- a/src/deepr/cli/commands/semantic/expert_practice.py
+++ b/src/deepr/cli/commands/semantic/expert_practice.py
@@ -140,7 +140,7 @@ def _parse_json(text: str) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _render(practice: ResearchPractice, changed: dict[str, int], *, path: Path) -> None:
+def _render(practice: ResearchPractice, changed: dict[str, int], *, path: Path, wrote: bool = True) -> None:
     stats = practice.stats()
     console.print()
     print_key_value(
@@ -166,7 +166,50 @@ def _render(practice: ResearchPractice, changed: dict[str, int], *, path: Path) 
             console.print(f"  - {item}")
 
     console.print()
-    print_success(f"Written to {path}")
+    if wrote:
+        print_success(f"Written to {path}")
+
+
+def _show_practice(profile: Any, path: Path, *, as_json: bool) -> None:
+    if not path.exists():
+        click.echo(f"{profile.name} has no research practice recorded yet.", err=True)
+        sys.exit(2)
+    stored = _read_json(path)
+    if not stored:
+        click.echo(
+            f"Error: {profile.name}'s practice file exists but is unreadable, so nothing was shown.",
+            err=True,
+        )
+        sys.exit(2)
+    practice = ResearchPractice.from_dict(stored)
+    if as_json:
+        click.echo(json.dumps(practice.to_dict(), indent=2))
+        return
+    print_header(f"Practice: {profile.name}")
+    _render(practice, {"answered": 0, "abandoned": 0, "opened": 0}, path=path, wrote=False)
+
+
+def _refuse_if_practice_blocked(expert_name: str) -> None:
+    from deepr.experts.consult_context import load_brief
+    from deepr.experts.stage_contract import STAGE_PRACTICE, evaluate_stage, get_stage
+
+    brief = load_brief(hold_current_path(expert_name))
+    practice_stage = get_stage(STAGE_PRACTICE)
+    if practice_stage is None:
+        return
+    state = evaluate_stage(
+        practice_stage,
+        {"hold/current.json": brief.to_dict() if brief is not None else None},
+    )
+    if not state.blockers:
+        return
+    reason = state.blockers[0].reason
+    fix = state.blockers[0].fix
+    click.echo(
+        f'Error: {expert_name} cannot keep a practice: {reason}. Run: deepr {fix} "{expert_name}"',
+        err=True,
+    )
+    sys.exit(2)
 
 
 @expert.command(name="practice")
@@ -204,41 +247,52 @@ def expert_practice(
       deepr expert practice "My Expert" --plan claude --markdown
     """
     profile = _load_profile(name)
-    at = datetime.now(UTC).isoformat()
+    path = canonical_practice_path(profile.name)
 
+    if show:
+        _show_practice(profile, path, as_json=as_json)
+        return
+
+    _refuse_if_practice_blocked(profile.name)
+
+    at = datetime.now(UTC).isoformat()
     practice = _load_practice(profile.name)
     _seed_from_artifacts(practice, profile.name, at=at)
     changed = {"answered": 0, "abandoned": 0, "opened": 0}
 
-    if not show:
-        try:
-            backend = build_study_backend(profile=profile, local=local, plan=plan, plan_model=plan_model, model=model)
-        except StudyBackendError as exc:
-            click.echo(f"Error: {exc}", err=True)
-            sys.exit(2)
+    try:
+        backend = build_study_backend(profile=profile, local=local, plan=plan, plan_model=plan_model, model=model)
+    except StudyBackendError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
 
-        if not as_json:
-            print_header(f"Practice: {profile.name}")
-            print_key_value("Capacity", backend.cost_note)
+    if not as_json:
+        print_header(f"Practice: {profile.name}")
+        print_key_value("Capacity", backend.cost_note)
 
-        card = _read_json(self_path(profile.name))
-        prompt = build_practice_prompt(
-            expert_name=str(card.get("chosen_name") or profile.name),
-            standpoint=str(card.get("standpoint") or ""),
-            practice=practice,
-            material=_material(profile.name),
+    card = _read_json(self_path(profile.name))
+    prompt = build_practice_prompt(
+        expert_name=str(card.get("chosen_name") or profile.name),
+        standpoint=str(card.get("standpoint") or ""),
+        practice=practice,
+        material=_material(profile.name),
+    )
+    try:
+        raw = asyncio.run(backend.completion(prompt))
+    except Exception as exc:
+        click.echo(f"Error: the model call failed: {type(exc).__name__}: {exc}", err=True)
+        sys.exit(2)
+
+    parsed = _parse_json(raw)
+    if not parsed:
+        click.echo(
+            "Error: the model returned no usable practice update, so nothing was written.",
+            err=True,
         )
-        try:
-            raw = asyncio.run(backend.completion(prompt))
-        except Exception as exc:
-            click.echo(f"Error: the model call failed: {type(exc).__name__}: {exc}", err=True)
-            sys.exit(2)
+        sys.exit(2)
 
-        changed = apply_practice_update(practice, _parse_json(raw), at=at)
-    else:
-        practice.updated_at = at
+    changed = apply_practice_update(practice, parsed, at=at)
 
-    path = canonical_practice_path(profile.name)
     path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_json(path, practice.to_dict(), fsync=True)
 
@@ -248,6 +302,4 @@ def expert_practice(
     if as_json:
         click.echo(json.dumps(practice.to_dict(), indent=2))
     else:
-        if show:
-            print_header(f"Practice: {profile.name}")
         _render(practice, changed, path=path)

--- a/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
+++ b/src/deepr/cli/commands/semantic/expert_profile_card_cmd.py
@@ -95,8 +95,12 @@ def _load_prior(expert_name: str) -> ExpertProfile | None:
     try:
         return ExpertProfile.from_dict(json.loads(path.read_text(encoding="utf-8")))
     except (json.JSONDecodeError, OSError, TypeError, ValueError):
-        print_warning("Existing profile could not be read; writing a fresh one and losing its shift history.")
-        return None
+        click.echo(
+            "Error: existing profile could not be read, so nothing was written. "
+            "Shift history would have been lost. Repair self.json first.",
+            err=True,
+        )
+        sys.exit(2)
 
 
 def _material(expert_name: str) -> tuple[str, str, int]:

--- a/src/deepr/cli/commands/semantic/expert_source.py
+++ b/src/deepr/cli/commands/semantic/expert_source.py
@@ -215,9 +215,22 @@ def expert_source(
         acquire_sources(expert_name=profile.name, urls=urls, corpus=store, fetch_page=default_fetch_page())
     )
     after = len(store.active_entries())
+    _emit_source_acquire(profile.name, report, before=before, after=after, plan_backend=plan_backend)
 
+
+def _emit_source_acquire(expert_name: str, report: Any, *, before: int, after: int, plan_backend: str | None) -> None:
+    """Report acquire outcomes and exit with the acquire contract's code."""
     console.print()
     print_key_value("Retained", f"{after - before} new source(s), {after} in the corpus")
-    if failures := getattr(report, "failures", None):
-        print_warning(f"{len(failures)} fetch(es) failed and were skipped.")
-    print_success(f'Next: deepr expert study "{profile.name}" --plan {plan_backend or "grok"}')
+    if report.failed:
+        print_warning(f"{len(report.failed)} fetch(es) failed and were skipped.")
+    for item in report.limitations:
+        print_warning(item)
+    if report.exit_code == 2:
+        click.echo("Error: nothing usable was retained.", err=True)
+        sys.exit(2)
+    if report.exit_code == 1:
+        print_warning("Partial acquire: some URLs were not retained.")
+    else:
+        print_success(f'Next: deepr expert study "{expert_name}" --plan {plan_backend or "grok"}')
+    sys.exit(report.exit_code)

--- a/src/deepr/cli/commands/semantic/expert_study.py
+++ b/src/deepr/cli/commands/semantic/expert_study.py
@@ -56,13 +56,18 @@ def canonical_position_ledger_path(expert_name: str) -> Path:
 
 
 def _live_positions(expert_name: str) -> list[Any]:
-    """Positions this expert currently holds, for the brief to restate or revise."""
-    from deepr.experts.position_ledger import load_ledger
+    """Positions this expert currently holds, for the brief to restate or revise.
+
+    An unreadable ledger is not "no priors". Treating it as empty made a
+    re-brief invent new questions and then overwrite the torn history.
+    """
+    from deepr.experts.position_ledger import LedgerUnreadableError, load_ledger
 
     try:
         return list(load_ledger(canonical_position_ledger_path(expert_name), expert_name=expert_name).live)
-    except Exception:
-        return []
+    except LedgerUnreadableError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
 
 
 def _record_positions(expert_name: str, brief: Any, result: Any) -> dict[str, int]:
@@ -72,7 +77,7 @@ def _record_positions(expert_name: str, brief: Any, result: Any) -> dict[str, in
     is bad; taking down a brief that a study just paid for is worse, and the
     brief itself is still written either way.
     """
-    from deepr.experts.position_ledger import load_ledger, record_brief
+    from deepr.experts.position_ledger import LedgerUnreadableError, load_ledger, record_brief
     from deepr.experts.record_time import utc_now
     from deepr.utils.atomic_io import atomic_write_json
 
@@ -91,6 +96,8 @@ def _record_positions(expert_name: str, brief: Any, result: Any) -> dict[str, in
         changed = record_brief(ledger, list(brief.positions), at=utc_now(), corpus_fingerprint=fingerprint)
         atomic_write_json(path, ledger.to_dict(), fsync=True)
         return changed
+    except LedgerUnreadableError:
+        raise
     except Exception:
         return {}
 
@@ -216,7 +223,18 @@ def expert_retain(
     """
     profile = _load_profile(name)
     path = Path(source)
-    text = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        click.echo(
+            "Error: source is not valid UTF-8. Convert it first; replacing bytes "
+            "would hash a different text than the file on disk.",
+            err=True,
+        )
+        sys.exit(2)
+    except OSError as exc:
+        click.echo(f"Error: cannot read source: {exc}", err=True)
+        sys.exit(2)
     if len(text) > _MAX_SOURCE_CHARS:
         click.echo(f"Error: source exceeds {_MAX_SOURCE_CHARS} chars; split it first", err=True)
         sys.exit(2)
@@ -655,6 +673,10 @@ def expert_brief(
         )
         sys.exit(2)
 
+    # Read priors before any backend or model call. An unreadable ledger must
+    # not become "no priors" after a paid synthesis.
+    prior_positions = _live_positions(profile.name)
+
     try:
         backend = build_study_backend(profile=profile, local=local, plan=plan, model=model)
     except StudyBackendError as exc:
@@ -676,8 +698,6 @@ def expert_brief(
     # produced seven differently-worded questions and restated none of the nine
     # already held, so every thread closed and reopened and survival could
     # never accumulate.
-    prior_positions = _live_positions(profile.name)
-
     brief = asyncio.run(
         build_brief(
             expert_name=profile.name,
@@ -689,12 +709,20 @@ def expert_brief(
         )
     )
 
-    # A brief with no positions is a failed brief. Check before any write:
-    # recording an empty brief would close every live ledger thread as
-    # not_restated, and --json used to return 0 after writing the empty file.
-    if not brief.positions:
-        reason = brief.limitations[0] if brief.limitations else "no positions were produced"
-        click.echo(f"Error: the brief holds no positions, so it is not consultable. {reason}", err=True)
+    # A brief with no cited positions is a failed brief. Check before any
+    # write: recording an empty or uncited brief would close every live
+    # ledger thread as not_restated, and --json used to return 0 after
+    # writing the empty file. Status already requires every position to cite
+    # a finding; the command has to refuse the same way.
+    from deepr.experts.stage_contract import STAGE_BRIEF, get_stage
+
+    brief_stage = get_stage(STAGE_BRIEF)
+    if brief_stage is None or brief_stage.succeeds_when is None or not brief_stage.succeeds_when(brief.to_dict()):
+        reason = brief.limitations[0] if brief.limitations else "no cited positions were produced"
+        click.echo(
+            f"Error: the brief is not consultable (every position must cite a finding). {reason}",
+            err=True,
+        )
         sys.exit(2)
 
     # Record what changed before writing the new brief. Every run used to
@@ -704,7 +732,13 @@ def expert_brief(
     # versions; brief.json stays the current view, because every reader in the
     # system loads it and changing its shape to serve one new reader would
     # break all of them.
-    changed = _record_positions(profile.name, brief, result)
+    from deepr.experts.position_ledger import LedgerUnreadableError
+
+    try:
+        changed = _record_positions(profile.name, brief, result)
+    except LedgerUnreadableError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
 
     payload = json.dumps(brief.to_dict(), indent=2, sort_keys=True)
     atomic_write_json(canonical_brief_path(profile.name), brief.to_dict(), sort_keys=True, fsync=True)

--- a/src/deepr/experts/expert_health.py
+++ b/src/deepr/experts/expert_health.py
@@ -583,8 +583,9 @@ def assess_expert(
         index = expert_dir / "corpus" / "index.jsonl"
         if index.exists():
             try:
-                lines = [line for line in index.read_text(encoding="utf-8").splitlines() if line.strip()]
-                health.sources = len(lines)
+                from deepr.experts.corpus_store import active_source_count
+
+                health.sources = active_source_count(index.read_text(encoding="utf-8"))
             except OSError:
                 pass
 

--- a/src/deepr/experts/position_ledger.py
+++ b/src/deepr/experts/position_ledger.py
@@ -64,6 +64,14 @@ REASON_SOURCE_RETRACTED = "retracted_by_source"
 _REASONS = (REASON_REVISED, REASON_NOT_RESTATED, REASON_OPERATOR_RETIRED, REASON_SOURCE_RETRACTED)
 
 
+class LedgerUnreadableError(ValueError):
+    """The ledger file exists but cannot be used as a ledger.
+
+    Missing is empty. Present-and-broken is not: treating a torn history as a
+    new expert is how a re-brief used to wipe thread identity.
+    """
+
+
 @dataclass
 class PositionVersion:
     """One statement of one position, and when the store held it."""
@@ -317,11 +325,18 @@ def record_brief(
 
 
 def load_ledger(path: Path, *, expert_name: str = "") -> PositionLedger:
-    """Read the ledger, or an empty one when there is none yet."""
+    """Read the ledger, or an empty one when there is none yet.
+
+    An existing file that will not parse is not an empty ledger. Returning a
+    blank one used to let the next brief atomically replace months of
+    versions.
+    """
+    if not path.exists():
+        return PositionLedger(expert_name=expert_name)
     try:
         return PositionLedger.from_dict(json.loads(path.read_text(encoding="utf-8")))
-    except (json.JSONDecodeError, OSError, TypeError, ValueError):
-        return PositionLedger(expert_name=expert_name)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+        raise LedgerUnreadableError(f"position ledger at {path} is unreadable: {exc}") from exc
 
 
 def find_thread(ledger: PositionLedger, question: str) -> str:

--- a/tests/unit/test_cli/test_expert_cleanup.py
+++ b/tests/unit/test_cli/test_expert_cleanup.py
@@ -42,6 +42,27 @@ def test_plan_deletes_empty_expert(tmp_path):
     assert tmp_path / "empty_expert" in plan.deletions
 
 
+def test_plan_does_not_delete_a_v2_expert_with_no_beliefs(tmp_path):
+    """Study never writes beliefs. The corpus and brief *are* the expert."""
+    expert = tmp_path / "v2_expert"
+    _write(expert / "profile.json", {"name": "V2 Expert"})
+    (expert / "corpus").mkdir()
+    (expert / "corpus" / "index.jsonl").write_text("{}\n", encoding="utf-8")
+    _write(expert / "hold" / "current.json", {"positions": [{"question": "Q"}]})
+    plan = build_plan(tmp_path)
+    assert expert not in plan.deletions
+
+
+def test_plan_does_not_delete_an_unreadable_belief_store(tmp_path):
+    expert = tmp_path / "torn_expert"
+    _write(expert / "profile.json", {"name": "Torn Expert"})
+    beliefs = expert / "beliefs" / "beliefs.json"
+    beliefs.parent.mkdir(parents=True)
+    beliefs.write_text("{not json", encoding="utf-8")
+    plan = build_plan(tmp_path)
+    assert expert not in plan.deletions
+
+
 def test_plan_does_not_delete_when_beliefs_in_split_display_dir(tmp_path):
     # The canonical slug dir is empty, but its display twin holds the beliefs;
     # the expert must NOT be deleted (data lives in the split dir).

--- a/tests/unit/test_cli/test_expert_graph_command.py
+++ b/tests/unit/test_cli/test_expert_graph_command.py
@@ -1,0 +1,105 @@
+"""`deepr expert graph` must not persist a pile of nodes as a formed graph."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from deepr.cli.commands.semantic.experts import expert
+from deepr.experts.study_contracts import LensOutcome, StudyFinding, StudyResult
+
+
+def _study_result() -> StudyResult:
+    result = StudyResult(expert_name="Subject")
+    result.outcomes = [
+        LensOutcome(
+            lens="contention",
+            axis="interrogation",
+            status="ok",
+            findings=[
+                StudyFinding(
+                    lens="contention",
+                    axis="interrogation",
+                    kind="disputes",
+                    title="Sources disagree",
+                    payload={"claim": "c"},
+                    grounded_anchor_count=2,
+                    corpus_shas=["sha-a", "sha-b"],
+                    finding_id="contention-1",
+                )
+            ],
+        )
+    ]
+    return result
+
+
+def _patch_home(tmp_path, monkeypatch):
+    from deepr.experts import paths
+
+    home = tmp_path / "experts"
+
+    def locate(name: str):
+        return home / name
+
+    monkeypatch.setattr(paths, "canonical_expert_dir", locate)
+    monkeypatch.setattr("deepr.cli.commands.semantic.expert_graph.canonical_expert_dir", locate)
+
+    class FakeProfile:
+        name = "Subject"
+
+    class FakeStore:
+        def load(self, name):
+            return FakeProfile() if name == "Subject" else None
+
+    monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+    return home / "Subject"
+
+
+class TestGraphRefusesToWriteAFailedArtifact:
+    def test_no_brief_does_not_write(self, tmp_path, monkeypatch):
+        directory = _patch_home(tmp_path, monkeypatch)
+        study_path = directory / "noticed" / "current.json"
+        study_path.parent.mkdir(parents=True)
+        study_path.write_text(json.dumps(_study_result().to_dict()), encoding="utf-8")
+
+        result = CliRunner().invoke(expert, ["graph", "Subject"])
+        assert result.exit_code == 2
+        assert "cannot form an evidence graph" in result.output
+        assert not (directory / "graph" / "evidence.json").exists()
+
+    def test_unformed_graph_does_not_overwrite_a_formed_one(self, tmp_path, monkeypatch):
+        directory = _patch_home(tmp_path, monkeypatch)
+        study = _study_result()
+        (directory / "noticed").mkdir(parents=True)
+        (directory / "noticed" / "current.json").write_text(json.dumps(study.to_dict()), encoding="utf-8")
+        (directory / "hold").mkdir(parents=True)
+        (directory / "hold" / "current.json").write_text(
+            json.dumps(
+                {
+                    "positions": [
+                        {
+                            "question": "Does X hold?",
+                            "stance": "it holds",
+                            "reasoning": "r",
+                            "would_change_my_mind": "a counterexample",
+                            "supported_by": [study.findings[0].finding_id or "contention-1"],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        graph_path = directory / "graph" / "evidence.json"
+        graph_path.parent.mkdir(parents=True)
+        graph_path.write_text(json.dumps({"stats": {"is_formed": True}, "keep": True}), encoding="utf-8")
+
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_graph._corpus_entries",
+            lambda name: [],
+        )
+
+        result = CliRunner().invoke(expert, ["graph", "Subject", "--json"])
+        assert result.exit_code == 2
+        assert "nothing was written" in result.output
+        assert json.loads(graph_path.read_text(encoding="utf-8"))["keep"] is True

--- a/tests/unit/test_cli/test_expert_maintenance.py
+++ b/tests/unit/test_cli/test_expert_maintenance.py
@@ -298,7 +298,7 @@ class TestBackendFlagGuard:
 
         r = CliRunner().invoke(expert, ["absorb", "Busy Expert", "job123", "--json", "-y"])
 
-        assert r.exit_code == 0
+        assert r.exit_code == 2
         assert json.loads(r.output) == {
             "status": "skipped",
             "reason": "overlap_locked",
@@ -322,7 +322,7 @@ class TestBackendFlagGuard:
             ["absorb", "Busy Expert", "job123", "--dry-run", "--json", "-y"],
         )
 
-        assert r.exit_code == 0
+        assert r.exit_code == 2
         assert json.loads(r.output)["reason"] == "overlap_locked"
 
     def test_sync_rejects_checker_plan_without_grounding_before_store_work(self, monkeypatch):

--- a/tests/unit/test_cli/test_expert_practice_command.py
+++ b/tests/unit/test_cli/test_expert_practice_command.py
@@ -1,0 +1,83 @@
+"""`deepr expert practice --show` must not mutate disk."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from deepr.cli.commands.semantic.experts import expert
+
+
+def _patch_home(tmp_path, monkeypatch):
+    from deepr.experts import paths
+
+    home = tmp_path / "experts"
+    monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: home / name)
+
+    class FakeProfile:
+        name = "Subject"
+
+    class FakeStore:
+        def load(self, name):
+            return FakeProfile() if name == "Subject" else None
+
+    monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+    return home / "Subject"
+
+
+class TestPracticeShowIsReadOnly:
+    def test_show_does_not_create_a_file(self, tmp_path, monkeypatch):
+        directory = _patch_home(tmp_path, monkeypatch)
+        directory.mkdir(parents=True)
+
+        result = CliRunner().invoke(expert, ["practice", "Subject", "--show"])
+        assert result.exit_code == 2
+        assert "no research practice" in result.output
+        assert not (directory / "attend" / "practice.json").exists()
+
+    def test_show_does_not_rewrite_an_existing_file(self, tmp_path, monkeypatch):
+        directory = _patch_home(tmp_path, monkeypatch)
+        path = directory / "attend" / "practice.json"
+        path.parent.mkdir(parents=True)
+        original = {
+            "expert": "Subject",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "pursuits": [{"question": "Q", "status": "open"}],
+            "watches": [],
+            "interests": [],
+        }
+        path.write_text(json.dumps(original), encoding="utf-8")
+
+        result = CliRunner().invoke(expert, ["practice", "Subject", "--show", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(path.read_text(encoding="utf-8"))["updated_at"] == "2026-01-01T00:00:00+00:00"
+
+    def test_show_refuses_an_unreadable_file(self, tmp_path, monkeypatch):
+        directory = _patch_home(tmp_path, monkeypatch)
+        path = directory / "attend" / "practice.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json", encoding="utf-8")
+
+        result = CliRunner().invoke(expert, ["practice", "Subject", "--show"])
+        assert result.exit_code == 2
+        assert "unreadable" in result.output
+        assert path.read_text(encoding="utf-8") == "{not json"
+
+
+class TestPracticeRequiresACitedBrief:
+    def test_update_refuses_without_a_brief(self, tmp_path, monkeypatch):
+        directory = _patch_home(tmp_path, monkeypatch)
+        directory.mkdir(parents=True)
+
+        called: list[object] = []
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_practice.build_study_backend",
+            lambda **kwargs: called.append(kwargs) or (_ for _ in ()).throw(AssertionError("backend")),
+        )
+
+        result = CliRunner().invoke(expert, ["practice", "Subject", "--local"])
+        assert result.exit_code == 2
+        assert "cannot keep a practice" in result.output
+        assert called == []
+        assert not (directory / "attend" / "practice.json").exists()

--- a/tests/unit/test_cli/test_expert_profile_command.py
+++ b/tests/unit/test_cli/test_expert_profile_command.py
@@ -218,6 +218,23 @@ class TestRefusalsBeforeWriting:
         assert "left alone" in r.output
         assert json.loads(card.read_text(encoding="utf-8"))["shifts"]
 
+    def test_an_unreadable_profile_is_not_replaced(self, profile, expert_home, monkeypatch):
+        _write_brief(expert_home, "Subject")
+        card = expert_home / "Subject" / "self.json"
+        card.write_text("{not json", encoding="utf-8")
+        called: list[object] = []
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_profile_card_cmd.build_study_backend",
+            lambda **kwargs: called.append(kwargs) or (_ for _ in ()).throw(AssertionError("backend")),
+        )
+
+        r = CliRunner().invoke(expert, ["profile", "Subject"])
+
+        assert r.exit_code == 2
+        assert "could not be read" in r.output
+        assert card.read_text(encoding="utf-8") == "{not json"
+        assert called == []
+
     def test_an_unbriefed_expert_is_refused(self, profile, expert_home, monkeypatch):
         _stub_backend(monkeypatch, _reply())
         r = CliRunner().invoke(expert, ["profile", "Subject"])

--- a/tests/unit/test_cli/test_expert_source_command.py
+++ b/tests/unit/test_cli/test_expert_source_command.py
@@ -1,0 +1,82 @@
+"""`deepr expert source` must honor acquire exit codes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from deepr.cli.commands.semantic.experts import expert
+from deepr.experts.corpus_acquire import AcquiredSource, AcquireResult
+
+
+def _patch_source(tmp_path, monkeypatch, report: AcquireResult):
+    from deepr.experts import paths
+
+    home = tmp_path / "experts"
+    monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: home / name)
+
+    class FakeProfile:
+        name = "Subject"
+
+    class FakeStore:
+        def load(self, name):
+            return FakeProfile() if name == "Subject" else None
+
+    class FakeCorpus:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def active_entries(self):
+            return []
+
+    monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+    monkeypatch.setattr("deepr.experts.corpus_store.CorpusStore", FakeCorpus)
+    monkeypatch.setattr(
+        "deepr.cli.commands.semantic.expert_source.build_study_backend",
+        lambda **kwargs: SimpleNamespace(cost_note="$0"),
+    )
+
+    async def fake_build_plan(*_args, **_kwargs):
+        plan = SimpleNamespace(queries=[SimpleNamespace(arm="descriptive", text="q")])
+        return plan, "test"
+
+    async def fake_search(*_args, **_kwargs):
+        return SimpleNamespace(
+            hits=[SimpleNamespace(url="https://example.org/a")],
+            distinct_hosts={"example.org"},
+            stopped_early="",
+        )
+
+    async def fake_acquire(**_kwargs):
+        return report
+
+    monkeypatch.setattr("deepr.cli.commands.semantic.expert_source._build_plan", fake_build_plan)
+    monkeypatch.setattr("deepr.experts.corpus_search.run_search_plan", fake_search)
+    monkeypatch.setattr("deepr.experts.corpus_acquire.acquire_sources", fake_acquire)
+    monkeypatch.setattr("deepr.experts.corpus_acquire.default_fetch_page", lambda: None)
+    return home
+
+
+class TestSourceHonorsAcquireExitCode:
+    def test_nothing_usable_exits_2(self, tmp_path, monkeypatch):
+        report = AcquireResult(expert_name="Subject")
+        report.sources = [AcquiredSource(url="https://example.org/a", status="fetch_failed", detail="timeout")]
+        _patch_source(tmp_path, monkeypatch, report)
+
+        result = CliRunner().invoke(expert, ["source", "Subject", "topic", "--local"])
+        assert result.exit_code == 2
+        assert "nothing usable" in result.output
+        assert "failed" in result.output
+
+    def test_partial_acquire_exits_1(self, tmp_path, monkeypatch):
+        report = AcquireResult(expert_name="Subject")
+        report.sources = [
+            AcquiredSource(url="https://example.org/a", status="retained", sha256="aa", origin_key="url:example.org"),
+            AcquiredSource(url="https://example.org/b", status="fetch_failed", detail="404"),
+        ]
+        _patch_source(tmp_path, monkeypatch, report)
+
+        result = CliRunner().invoke(expert, ["source", "Subject", "topic", "--local"])
+        assert result.exit_code == 1
+        assert "Partial acquire" in result.output

--- a/tests/unit/test_cli/test_expert_study_roundtrip.py
+++ b/tests/unit/test_cli/test_expert_study_roundtrip.py
@@ -224,6 +224,155 @@ class TestBriefRefusesEmptyResult:
 
         result = CliRunner().invoke(expert, ["brief", "Subject", "--json"])
         assert result.exit_code == 2
-        assert "holds no positions" in result.output
+        assert "not consultable" in result.output
         assert json.loads(existing.read_text(encoding="utf-8"))["positions"][0]["question"] == "Q"
         assert json.loads(history.read_text(encoding="utf-8"))["versions"][0]["thread_id"] == "t1"
+
+    def test_uncited_positions_do_not_write_or_close_the_ledger(self, tmp_path, monkeypatch):
+        """Status already requires a citation; the command used to write anyway."""
+        from click.testing import CliRunner
+
+        from deepr.cli.commands.semantic.experts import expert
+        from deepr.experts import paths
+        from deepr.experts.brief_contracts import ExpertBrief, Position
+
+        home = tmp_path / "experts"
+        monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: home / name)
+
+        class FakeProfile:
+            name = "Subject"
+            domain = "d"
+
+        class FakeStore:
+            def load(self, name):
+                return FakeProfile() if name == "Subject" else None
+
+        monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+
+        existing = home / "Subject" / "hold" / "current.json"
+        existing.parent.mkdir(parents=True)
+        existing.write_text(
+            json.dumps({"positions": [{"question": "Q", "stance": "s", "supported_by": ["f1"]}]}),
+            encoding="utf-8",
+        )
+        history = home / "Subject" / "hold" / "history.json"
+        history.write_text(
+            json.dumps(
+                {
+                    "expert": "Subject",
+                    "versions": [
+                        {
+                            "thread_id": "t1",
+                            "version_id": "v1",
+                            "question": "Q",
+                            "stance": "s",
+                            "recorded_at": "2026-01-01T00:00:00+00:00",
+                            "superseded_at": "9999-12-31T23:59:59.999999+00:00",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        _write(home / "Subject" / "noticed" / "current.json", json.dumps(_study().to_dict()))
+
+        async def uncited_brief(**_kwargs):
+            brief = ExpertBrief(expert_name="Subject")
+            brief.positions = [Position(question="New Q", stance="it holds", reasoning="", would_change_my_mind="x")]
+            return brief
+
+        monkeypatch.setattr("deepr.experts.brief.build_brief", uncited_brief)
+
+        class FakeBackend:
+            capacity_source = "local:x"
+            model = "x"
+            cost_note = "$0"
+            completion = staticmethod(lambda prompt: "")
+
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_study.build_study_backend",
+            lambda **kwargs: FakeBackend(),
+        )
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_study.CorpusStore",
+            lambda name: type("C", (), {"active_entries": staticmethod(lambda: [])})(),
+        )
+
+        result = CliRunner().invoke(expert, ["brief", "Subject", "--json"])
+        assert result.exit_code == 2
+        assert "not consultable" in result.output
+        assert json.loads(existing.read_text(encoding="utf-8"))["positions"][0]["supported_by"] == ["f1"]
+        assert json.loads(history.read_text(encoding="utf-8"))["versions"][0]["thread_id"] == "t1"
+
+    def test_unreadable_ledger_refuses_before_the_model_call(self, tmp_path, monkeypatch):
+        from click.testing import CliRunner
+
+        from deepr.cli.commands.semantic.experts import expert
+        from deepr.experts import paths
+
+        home = tmp_path / "experts"
+        monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: home / name)
+
+        class FakeProfile:
+            name = "Subject"
+            domain = "d"
+
+        class FakeStore:
+            def load(self, name):
+                return FakeProfile() if name == "Subject" else None
+
+        monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+
+        history = home / "Subject" / "hold" / "history.json"
+        history.parent.mkdir(parents=True)
+        history.write_text("{not json", encoding="utf-8")
+        _write(home / "Subject" / "noticed" / "current.json", json.dumps(_study().to_dict()))
+
+        called: list[object] = []
+        monkeypatch.setattr(
+            "deepr.cli.commands.semantic.expert_study.build_study_backend",
+            lambda **kwargs: called.append(kwargs) or (_ for _ in ()).throw(AssertionError("backend built")),
+        )
+
+        result = CliRunner().invoke(expert, ["brief", "Subject"])
+        assert result.exit_code == 2
+        assert "unreadable" in result.output
+        assert history.read_text(encoding="utf-8") == "{not json"
+        assert called == []
+
+
+class TestRetainRefusesNonUtf8:
+    def test_latin1_source_is_not_hashed_as_replacement_text(self, tmp_path, monkeypatch):
+        from click.testing import CliRunner
+
+        from deepr.cli.commands.semantic.experts import expert
+        from deepr.experts import paths
+
+        home = tmp_path / "experts"
+        monkeypatch.setattr(paths, "canonical_expert_dir", lambda name: home / name)
+
+        class FakeProfile:
+            name = "Subject"
+
+        class FakeStore:
+            def load(self, name):
+                return FakeProfile() if name == "Subject" else None
+
+        monkeypatch.setattr("deepr.experts.profile.ExpertStore", FakeStore)
+
+        source = tmp_path / "note.txt"
+        source.write_bytes("caf\xe9".encode("latin-1"))
+
+        added: list[str] = []
+
+        class FakeCorpus:
+            def add(self, text, **_kwargs):
+                added.append(text)
+                raise AssertionError("must not hash replaced text")
+
+        monkeypatch.setattr("deepr.cli.commands.semantic.expert_study.CorpusStore", lambda name: FakeCorpus())
+
+        result = CliRunner().invoke(expert, ["retain", "Subject", str(source)])
+        assert result.exit_code == 2
+        assert "UTF-8" in result.output
+        assert added == []

--- a/tests/unit/test_experts/test_expert_health.py
+++ b/tests/unit/test_experts/test_expert_health.py
@@ -264,6 +264,15 @@ class TestAssessFromDisk:
         (tmp_path / "study.json").write_text("{not json", encoding="utf-8")
         assert assess_expert("E", tmp_path).grade == "F"
 
+    def test_a_header_only_corpus_is_not_a_source(self, tmp_path):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        (corpus / "index.jsonl").write_text(
+            '{"schema_version": "deepr-expert-corpus-v1", "expert": "E"}\n',
+            encoding="utf-8",
+        )
+        assert assess_expert("E", tmp_path).sources == 0
+
 
 class TestConsultRecencyComesFromRealTraces:
     """The shape was guessed wrong once and silently graded everything A.

--- a/tests/unit/test_experts/test_position_ledger.py
+++ b/tests/unit/test_experts/test_position_ledger.py
@@ -10,12 +10,18 @@ a new version, revised is not a replacement, and not-restated is not a
 retirement.
 """
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from deepr.experts.position_ledger import (
     REASON_NOT_RESTATED,
     REASON_REVISED,
+    LedgerUnreadableError,
     PositionLedger,
+    load_ledger,
     record_brief,
 )
 from deepr.experts.record_time import END_OF_TIME, utc_now
@@ -296,3 +302,26 @@ class TestSurvivalCountsEveryCorpusItWasReachedFrom:
         for version in payload["versions"]:
             version.pop("corroborated_over", None)
         assert PositionLedger.from_dict(payload).survived(thread) == 1
+
+
+class TestLoadLedgerDoesNotInventAnEmptyHistory:
+    def test_a_missing_file_is_an_empty_ledger(self, tmp_path: Path) -> None:
+        ledger = load_ledger(tmp_path / "hold" / "history.json", expert_name="E")
+        assert ledger.versions == []
+        assert ledger.expert_name == "E"
+
+    def test_a_present_unreadable_file_is_not_an_empty_ledger(self, tmp_path: Path) -> None:
+        path = tmp_path / "history.json"
+        path.write_text("{not json", encoding="utf-8")
+        with pytest.raises(LedgerUnreadableError, match="unreadable"):
+            load_ledger(path, expert_name="E")
+        assert path.read_text(encoding="utf-8") == "{not json"
+
+    def test_a_readable_file_round_trips(self, tmp_path: Path) -> None:
+        path = tmp_path / "history.json"
+        original = PositionLedger(expert_name="E")
+        record_brief(original, [_position("Q")], at=JAN)
+        path.write_text(json.dumps(original.to_dict()), encoding="utf-8")
+        restored = load_ledger(path, expert_name="E")
+        assert len(restored.live) == 1
+        assert restored.live[0].question == "Q"


### PR DESCRIPTION
Cleanup no longer deletes a sourced v2 expert. An unreadable position ledger or self-account is not treated as empty. Graph and practice refuse before writing a failed artifact. Source and absorb report failure with a non-zero exit.

All changes are covered by unit regressions. No provider calls.
