### PR TITLE
feat: add OKF 0.2 portability foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,15 @@ still serving legacy `initialize`-era clients on both transports. Operators can
 prove the offline host-interop posture with `deepr mcp conformance` (`$0`, no
 network, no model).
 
-The portability roadmap follows the current published [Agent Plugins 1.0.0
-specification](https://agent-plugins.org/specification) and containment
-contract. OKF export remains a derived view over Deepr's canonical belief and
-provenance stores; the migration target is the current [Open Knowledge Format
-0.2 repository](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf),
-which follows the original [Google Cloud introduction](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/).
-Current OKF 0.2 conformance and Agent Plugin packaging are planned surfaces, not shipped claims; see
-[Supported Surface](docs/SUPPORTED_SURFACE.md) and [Roadmap](ROADMAP.md).
+The portability roadmap follows the published [Agent Plugins 1.0.0 working
+draft](https://agent-plugins.org/specification) and containment contract. OKF
+export remains a derived view over Deepr's canonical belief and
+provenance stores. Export and `$0` validation now target the hard bundle rules
+in the current [Open Knowledge Format 0.2
+specification](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md),
+while import remains untrusted and verification-gated. Agent Plugin packaging
+is still planned; see [Supported Surface](docs/SUPPORTED_SURFACE.md) and
+[Roadmap](ROADMAP.md).
 
 ## Documentation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -482,25 +482,26 @@ what looks appetising.
    2026-07-28 carries bounded runtime requests. None becomes Deepr's authority
    model.
 
-   0. **Pin standards truth and offline fixtures.** Pin the published Agent
-      Plugins 1.0.0 plugin and MCP schemas by canonical identifier and checksum;
-      freeze representative OKF 0.2, Agent Skill, and MCP fixtures; and retain
-      the existing blocking dual-era MCP conformance suite. OKF is a minimal
-      Markdown and YAML specification, not a schema registry, so implement a
-      spec-derived validator instead of inventing a canonical OKF JSON Schema.
-      All validation stays network-free and `$0`.
+   0. **Pin standards truth and offline fixtures.** In progress. The reviewed
+      OKF 0.2 specification revision, checksum, valid bundle, and known-invalid
+      legacy bundle are pinned, and the spec-derived validator runs offline at
+      `$0` without inventing an OKF JSON Schema. Pinning the published working
+      draft Agent Plugins 1.0.0 plugin and MCP schemas, plus representative
+      Agent Skill and MCP fixtures, remains before this foundation gate closes.
+      The existing blocking dual-era MCP conformance suite stays in force.
 
-   1. **Migrate the legacy OKF view to 0.2.** Deepr's current
-      `deepr-okf-profile-v1` export is explicitly nonconformant. Repair it before
-      packaging makes the surface easier to distribute: root `index.md` may
-      declare only `okf_version`, `log.md` uses date-grouped newest-first entries
-      without concept frontmatter, concept frontmatter begins at byte zero,
-      `timestamp` moves to `generated.at`, and provenance moves from a body
-      citations list to `sources`. Preserve permitted unknown extensions and
-      emit `verified`, `status`, `stale_after`, and Attested Computation fields
-      only when canonical Deepr state supports their meaning. Import remains
-      permissive and verification-gated; the belief, event, and edge stores
-      remain authoritative.
+   1. ~~**Migrate the legacy OKF view to 0.2.**~~ **Done 2026-08-20.**
+      `deepr-okf-profile-v2` now restricts root `index.md` frontmatter to
+      `okf_version`, emits a date-grouped newest-first `log.md` without
+      frontmatter, starts concept frontmatter on the first line, replaces
+      `timestamp` with `generated.at`, and maps evidence references into
+      `sources` with stable ids and body footnotes. Unknown types, extensions,
+      omitted optional fields, and broken links remain consumable. `verified`
+      is emitted only for recorded checker assurance; unsupported lifecycle,
+      staleness, and computation claims remain absent. Import is permissive and
+      verification-gated, and the belief, event, and edge stores remain
+      authoritative. The v1 profile schema remains a deprecated compatibility
+      record.
 
    2. **Validate Agent Skills, then ship Deepr as an Agent Plugin.**
       [agent-plugins.org](https://agent-plugins.org/specification) publishes
@@ -2381,73 +2382,11 @@ threat model, evaluation arms, and delivery order are in
 - [ ] **Stage 7, remote surfaces:** expose the stable investigation lifecycle
       over scoped MCP and later A2A only after the CLI and local acceptance gates
       pass. Remote conversation handles do not become investigation authority.
-  - [ ] **Bridge 0, standards truth:** pin published Agent Plugins 1.0.0
-        schemas and representative OKF 0.2, Agent Skill, and MCP 2026-07-28
-        fixtures locally. Build OKF validation from the specification because
-        OKF publishes no schema registry. Keep all conformance checks offline,
-        network-free, and `$0`.
-  - [ ] **Bridge 1, OKF 0.2 migration:** repair reserved files, byte-zero
-        concept frontmatter, `generated.at`, and `sources`; preserve permitted
-        unknown extensions; and prove permissive import, round-trip,
-        regeneration, path containment, and verification-gated absorb. Do this
-        before widening package distribution.
-  - [ ] **Bridge 2, Agent Skill and Agent Plugin packaging:** validate current
-        skill output, then add a schema-pinned stdio-first package containing
-        only Agent Skills and the MCP server. Keep expert data, OKF bundles,
-        credentials, remote routes, and paid authority outside the package.
-        Prove clean install, containment, and reproducibility before host
-        recipes.
-  - [ ] **Bridge 3, contracts and drift audit:** add zero-call host-profile,
-        capability-snapshot, control-evidence, event-page, artifact-metadata,
-        follow-up, and fork-lineage schemas. Resolve the current Grok Build
-        plan-adapter documentation and runtime drift before any Grok execution
-        claim: either restore the execution block or prove the exact admitted
-        skill, agent, MCP, native-tool, filesystem, network, process, output,
-        cancellation, and marginal-cost posture before dispatch.
-  - [ ] **Bridge 4, read-only MCP projection:** expose exact-run status,
-        content-free events after a cursor, and bounded artifact metadata under
-        existing scoped-key ownership. Prove replay equivalence, stable paging,
-        modern per-request negotiation, legacy compatibility, cache metadata,
-        path redaction, malformed-journal failure, cross-run denial, and zero
-        projection writes. Subscriptions may announce cursor movement but never
-        replace canonical reads. An IM-style room is a host view over these
-        events, not Deepr workflow state.
-  - [ ] **Bridge 5, popular host conformance:** prefer the Agent Plugin package
-        for compliant clients; otherwise extend the network-free,
-        token-redacted registration manifest with an observer host profile and
-        exact configuration fragment for OpenClaw, DeepSeek Harness, Grok
-        Build, and Codex. Treat NemoClaw plus OpenShell as a remote reference
-        recipe until scoped HTTP auth, egress, endpoint-cost, and live-evidence
-        gates pass. Generated fragments neither install nor mutate a host. Do
-        not claim direct Grok Bot automation or supported public hosting.
-  - [ ] **Bridge 6, shared parent transaction and remote authority:** put every
-        multi-call or metered lifecycle behind one durable reservation,
-        settlement, reconciliation, cancellation, and maximum-charge contract.
-        Complete scoped HTTP identity, credential aliases, endpoint ownership,
-        rate limits, and independent provider-cost evidence before remote
-        mutation.
-  - [ ] **Bridge 7, lineage-only steering:** add preview-only follow-up and
-        checkpoint-fork requests, then pause, resume, cancel, and remote start
-        only after exact ownership, idempotency, race, audit, argument-hash, and
-        per-key ceiling tests pass. Active plans remain immutable. Learning
-        apply remains a separate scope.
-  - [ ] **Bridge 8, external evidence bundles:** admit bounded, hash-verified,
-        tainted repository and browser artifacts from host-owned workspaces.
-        Deepr does not allocate one computer per expert. Artifact-content reads
-        wait for classification, export policy, size, red-team, and cross-run
-        isolation gates.
-  - [ ] **Bridge 9, optional extensions:** evaluate MCP Tasks only as an adapter
-        over the canonical investigation handle, Skills over MCP only after
-        static skill and plugin packaging stabilizes, and MCP Apps only after a
-        measured projection need. Negotiated multi-round requests may present
-        missing input or approval but cannot create authority.
-  - [ ] Keep actor runtimes, tuple spaces, a general plugin kernel, Temporal,
-        NATS, PostgreSQL task scheduling, Firecracker-per-expert, generated TLA+
-        per research task, and reward-model training out of this phase.
-        Reconsider only against a measured failure of the existing phase state
-        machine, event journal, scoped MCP projection, or held-out quality
-        program. Detailed decision:
-        [external-harness-investigation-bridge.md](docs/design/external-harness-investigation-bridge.md).
+      The dependency-ordered portability work is tracked once in the
+      standards foundation near the top of this roadmap and in the
+      [external harness bridge](docs/design/external-harness-investigation-bridge.md).
+      Stage 7 cannot bypass its package, projection, host-conformance, remote
+      authority, or lineage gates.
 
 - [x] **Live-validation finding, retrieval accounting:** the first local pilot
       counted every fresh-context candidate as a fetched page and could exhaust
@@ -3019,7 +2958,8 @@ Goal: production posture for multi-user and autonomous deployments.
         in `docs/schemas/`.
   - [x] OKF profile: documented mapping from Deepr beliefs/events/edges/gaps to
         OKF concept documents, including which fields are Deepr extensions and
-        which parts are derived views. Published as `deepr-okf-profile-v1`.
+        which parts are derived views. Published as `deepr-okf-profile-v2` for
+        OKF 0.2, with v1 retained as a deprecated compatibility record.
   - [x] Schema registry with backward compatibility guarantees
         (`docs/schemas/registry.json` and `docs/schemas/README.md`).
   - [x] Scheduler JSON contracts for recurring expert maintenance waits and
@@ -3610,7 +3550,7 @@ consumers who will exercise all three. Design:
    manifest counts, bounded claims/gaps, dashboard telemetry, loop-status
    rollup, OKF interchange hints, and an additive compatibility contract.
    JSON Schema is published at `docs/schemas/expert-handoff-v1.json`.
-   `deepr-loop-status-v1`, `deepr-okf-profile-v1`, and
+   `deepr-loop-status-v1`, `deepr-okf-profile-v2` (with deprecated v1), and
    `deepr-mcp-remote-audit-v1`, `deepr-mcp-registration-manifest-v1`,
    `deepr-a2a-task-v1`, `deepr-a2a-host-validation-v1`, and the scheduled
    maintenance schemas in

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,10 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a network-free, `$0` OKF 0.2 conformance validator backed by a pinned
+  official specification revision, checksum, conformant fixture, and
+  known-invalid legacy fixture. Validation enforces only published mechanical
+  rules and continues to accept unknown types, unknown extension fields,
+  omitted optional metadata, and broken links.
+- Published `deepr-okf-profile-v2` for the current OKF 0.2 derived-view
+  mapping. The v1 schema remains available as a deprecated compatibility
+  record.
+
 ### Changed
 
+- Migrated `expert export-okf` to OKF 0.2 structure: concept frontmatter now
+  starts on the first line, the root index declares only `okf_version`, logs
+  are frontmatter-free and newest-first, `generated.at` replaces legacy
+  timestamps, and stored evidence becomes `sources` with stable provenance
+  ids. Recorded checker assurance may emit `verified`; unsupported lifecycle,
+  staleness, and computation claims remain absent. Import now parses full safe
+  YAML and treats every non-reserved Markdown document as an untrusted concept
+  before the existing verification-gated absorb path.
+- Made OKF export a complete transaction over a dedicated generated directory.
+  An exact path and content manifest, bounded parser inputs, portable path
+  checks, sibling staging, link-safe cleanup, and a recoverable directory swap
+  prevent partial publication, stale derived files, and accidental ownership of
+  hand-maintained content. `--force` now explicitly replaces the complete
+  export root.
+- Advanced export-validation reports to `deepr-export-validation-v2` for the
+  OKF 0.2 form-check contract. Existing handoff and Agent Skill validation
+  behavior is unchanged.
 - Refined the external-harness roadmap against OKF 0.2, the published Agent
-  Plugins 1.0.0 specification, Agent Skills, and MCP 2026-07-28. The dependency
+  Plugins 1.0.0 working draft, Agent Skills, and MCP 2026-07-28. The dependency
   order now repairs knowledge interchange before plugin packaging, proves
   read-only MCP projection before control, and gates remote or metered actions
   behind Deepr's canonical identity, evidence, budget, and approval contracts.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1330,7 +1330,9 @@ their schema version, kind, lifecycle state, cost field, timestamps, or metadata
 drift.
 The adjacent loop-status and OKF mapping contracts are published as
 [schemas/loop-status-v1.json](schemas/loop-status-v1.json) and
-[schemas/okf-profile-v1.json](schemas/okf-profile-v1.json). Hosted MCP
+[schemas/okf-profile-v2.json](schemas/okf-profile-v2.json). The v2 OKF profile
+targets OKF 0.2 while keeping exported Markdown derived and verification-gated.
+Hosted MCP
 remote-audit, scheduled maintenance, capacity, and registry contracts are also
 published under [schemas/](schemas/).
 The MCP HTTP transport also has an experimental scoped-key primitive:

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,6 +1,6 @@
 # Supported Surface
 
-Status: v2.49.1 current main, 2026-08-13. This document defines what users and host
+Status: v2.49.2 current main, 2026-08-20. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
 data remains portable if development stops. Unattended metered dispatch remains
 frozen until provider account-control adapters land. The narrow attended absorb
@@ -245,11 +245,19 @@ must not be described as usable capacity.
   payloads preserve per-claim `grounding_assurance` and include verified-claim
   counts by assurance level. The verdict is model judgment; vendor diversity and
   spend gates are deterministic routing requirements.
-- Deepr OKF-profile export and absorb paths. Export is a legacy OKF-style
-  derived view under `deepr-okf-profile-v1`, not a claim of conformance to the
-  current external OKF 0.2 specification. Absorb reads concept Markdown as an
-  ingestion source and still passes every candidate through verified
-  extraction.
+- Deepr OKF 0.2 profile export and absorb paths. Export targets the published
+  hard bundle rules through `deepr-okf-profile-v2`: concept frontmatter starts
+  on the first line with a non-empty `type`, the root index declares
+  `okf_version: "0.2"`, and the reserved log is frontmatter-free and grouped
+  newest first. The `$0` validator uses pinned offline fixtures and accepts
+  unknown concept types, unknown extension keys, omitted optional fields, and
+  broken links as the specification requires. Generated bundles remain
+  derived views over canonical expert state. `sources` comes from stored
+  evidence references, and `verified` appears only for recorded grounding
+  assurance that reflects an actual checker. Absorb treats every non-reserved
+  Markdown file as an untrusted concept ingestion source and still passes each
+  candidate through verified extraction. OKF computation execution and runtime
+  attestation are not shipped.
 - Indirect prompt-injection boundaries for fresh retrieval context, report
   absorption, first-party tool findings, local document review previews,
   campaign context summarization, completed-research review, company-intelligence
@@ -634,15 +642,15 @@ must not be described as usable capacity.
   marginal-cost, or process-safety gates.
 - Multi-account capacity pools are planned after a single-account mechanism is
   complete.
-- Agent Plugin 1.0.0 packaging is planned against the current published
-  specification at <https://agent-plugins.org/specification>. A future package
+- Agent Plugin 1.0.0 packaging is planned against the published working draft
+  at <https://agent-plugins.org/specification>. A future package
   must keep code, skills, MCP declarations, configuration, and secrets inside
   their correct containment and authority boundaries. No Agent Plugin package
-  or conformance claim ships in v2.49.
-- OKF 0.2 migration is planned against
-  <https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf>.
-  Existing Deepr OKF-profile bundles remain derived legacy views, and import
-  remains verification-gated. They are not OKF 0.2 conformance claims.
+  or conformance claim ships yet.
+- OKF 0.2 export and offline form validation ship under
+  `deepr-okf-profile-v2`. Import remains permissive, untrusted, and
+  verification-gated. Runtime computation execution and attestation do not
+  ship.
 - Live hosted-agent registration smoke against a real third-party platform is
   still open.
 - A long-running A2A conversation mapping is not shipped. MCP query and consult

--- a/docs/design/external-harness-investigation-bridge.md
+++ b/docs/design/external-harness-investigation-bridge.md
@@ -140,20 +140,23 @@ complementary, not competing orchestration models.
 | Layer | Normative target | Deepr use | Boundary |
 |---|---|---|---|
 | Knowledge interchange | [OKF 0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) | Export selected expert knowledge and ingest external bundles as untrusted evidence | The canonical belief, event, and edge stores remain authoritative. |
-| Installation and discovery | [Agent Plugins 1.0.0](https://agent-plugins.org/specification), Published | Package Agent Skills and an MCP server for conforming clients | A plugin packages code, skills, and MCP declarations, not canonical expert knowledge or credentials. |
+| Installation and discovery | [Agent Plugins 1.0.0](https://agent-plugins.org/specification), Working Draft | Package Agent Skills and an MCP server for conforming clients | A plugin packages code, skills, and MCP declarations, not canonical expert knowledge or credentials. |
 | Runtime protocol | [MCP 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) | Expose bounded tools, resources, lifecycle projections, and later negotiated extensions | MCP transport state never becomes run, spend, credential, or verification authority. |
 
 OKF 0.2 is a minimal Markdown and YAML specification, not a schema registry.
-Deepr should implement spec-derived validation and frozen interoperability
-fixtures rather than invent a canonical OKF JSON Schema. The current
-`deepr-okf-profile-v1` is a legacy derived view. Its exporter must move concept
-frontmatter to byte zero, restrict root `index.md` frontmatter to
-`okf_version`, replace `timestamp` with `generated.at`, and replace body
-citations with frontmatter `sources` before Deepr claims OKF 0.2 conformance.
-Optional `verified`, lifecycle, staleness, and Attested Computation fields may
-be emitted only when canonical Deepr records support their exact meaning.
-Import stays permissive about optional fields and unknown keys, then passes
-every candidate through Deepr's verification-gated absorb path.
+Deepr implements spec-derived validation and frozen interoperability fixtures
+rather than inventing a canonical OKF JSON Schema. `deepr-okf-profile-v2`
+moves concept frontmatter to the first line, restricts root `index.md`
+frontmatter to `okf_version`, emits a frontmatter-free newest-first log,
+replaces `timestamp` with `generated.at`, and publishes stored evidence as
+frontmatter `sources`. `verified` is emitted only when canonical grounding
+assurance records an actual checker. Lifecycle, staleness, and Attested
+Computation fields remain absent because current canonical state does not
+support their exact OKF meanings. Import stays permissive about optional
+fields, unknown types, unknown keys, and broken links, then passes every
+candidate through Deepr's verification-gated absorb path. The former
+`deepr-okf-profile-v1` schema remains available as a deprecated compatibility
+record, not the current export contract.
 
 Agent Plugins 1.0.0 has a closed root manifest and locally pinned canonical
 schemas. A Deepr package needs root `plugin.json`, optional root `mcp.json`, and
@@ -389,6 +392,10 @@ its predecessor's acceptance gate is recorded.
 
 ### Bridge 0: standards truth and offline fixtures
 
+Status: in progress. The pinned OKF 0.2 revision, checksum, fixtures, and
+spec-derived validator are implemented. Agent Plugin, Agent Skill, and MCP
+schema fixtures remain.
+
 - Pin the Agent Plugins 1.0.0 plugin and MCP schemas locally with their
   canonical identifiers and checksums.
 - Freeze representative OKF 0.2, Agent Skill, Agent Plugin, and MCP fixtures.
@@ -401,6 +408,9 @@ Gate: a clean checkout validates every pinned fixture offline and detects each
 known legacy OKF violation.
 
 ### Bridge 1: OKF 0.2 migration
+
+Status: implemented 2026-08-20 as `deepr-okf-profile-v2`, with the v1 schema
+retained as a deprecated compatibility record.
 
 - Repair reserved files, concept frontmatter placement, `generated.at`, and
   `sources` output while preserving Deepr extensions as unknown permitted keys.

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -52,7 +52,8 @@ and recomputes the full report, including the fixture and linked input hashes.
 | `deepr-metacognitive-monitor-v1` | [metacognitive-monitor-v1.json](metacognitive-monitor-v1.json) | Read-only reviewed proposals from self-model, loop-run, and consult-trace evidence |
 | `deepr-metacognitive-promotion-v1` | [metacognitive-promotion-v1.json](metacognitive-promotion-v1.json) | Preview or applied result for reviewed monitor proposal promotion into gap or eval artifacts |
 | `deepr-loop-status-v1` | [loop-status-v1.json](loop-status-v1.json) | Durable loop status rollup and embedded `ExpertLoopRun` records with optional run context |
-| `deepr-okf-profile-v1` | [okf-profile-v1.json](okf-profile-v1.json) | Mapping from Deepr structured expert state to regenerated OKF Markdown bundles |
+| `deepr-okf-profile-v1` | [okf-profile-v1.json](okf-profile-v1.json) | Deprecated mapping for the legacy Deepr OKF-style bundle |
+| `deepr-okf-profile-v2` | [okf-profile-v2.json](okf-profile-v2.json) | OKF 0.2 mapping from canonical Deepr expert state to regenerated Markdown bundles |
 | `deepr-mcp-remote-audit-v1` | [mcp-remote-audit-v1.json](mcp-remote-audit-v1.json) | Append-only scoped-key remote MCP tool-call audit events |
 | `deepr-mcp-registration-manifest-v1` | [mcp-registration-manifest-v1.json](mcp-registration-manifest-v1.json) | Token-redacted hosted MCP endpoint registration metadata plus optional smoke results |
 | `deepr-a2a-task-v1` | [a2a-task-v1.json](a2a-task-v1.json) | Agent-to-agent task state envelope for A2A create, status, cancel, result responses, and attached task artifacts |

--- a/docs/schemas/okf-profile-v2.json
+++ b/docs/schemas/okf-profile-v2.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/blisspixel/deepr/docs/schemas/okf-profile-v2.json",
+  "title": "Deepr OKF 0.2 Profile v2",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "kind",
+    "okf_version",
+    "contract",
+    "derived_view",
+    "documents",
+    "field_mapping",
+    "extensions"
+  ],
+  "properties": {
+    "schema_version": {"const": "deepr-okf-profile-v2"},
+    "kind": {"const": "deepr.okf.profile"},
+    "okf_version": {"const": "0.2"},
+    "contract": {
+      "type": "object",
+      "required": ["read_only", "cost_usd", "stability", "compatibility"],
+      "properties": {
+        "read_only": {"const": true},
+        "cost_usd": {"const": 0.0},
+        "stability": {"type": "string"},
+        "compatibility": {
+          "type": "object",
+          "required": ["additive_fields", "breaking_changes_require_new_schema_version", "deprecation_policy"],
+          "properties": {
+            "additive_fields": {"const": true},
+            "breaking_changes_require_new_schema_version": {"const": true},
+            "deprecation_policy": {"type": "string"}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "derived_view": {
+      "type": "object",
+      "required": ["authoritative", "canonical_state", "regeneration_command"],
+      "properties": {
+        "authoritative": {"const": false},
+        "canonical_state": {"const": "deepr belief/event/edge store"},
+        "regeneration_command": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "documents": {
+      "type": "object",
+      "required": ["index", "concept", "gaps", "contested", "log", "llms"],
+      "properties": {
+        "index": {"$ref": "#/$defs/document_mapping"},
+        "concept": {"$ref": "#/$defs/document_mapping"},
+        "gaps": {"$ref": "#/$defs/document_mapping"},
+        "contested": {"$ref": "#/$defs/document_mapping"},
+        "log": {"$ref": "#/$defs/document_mapping"},
+        "llms": {"$ref": "#/$defs/document_mapping"}
+      },
+      "additionalProperties": true
+    },
+    "field_mapping": {
+      "type": "object",
+      "required": ["profile", "beliefs", "events", "edges", "gaps", "contested"],
+      "properties": {
+        "profile": {"$ref": "#/$defs/source_mapping"},
+        "beliefs": {"$ref": "#/$defs/source_mapping"},
+        "events": {"$ref": "#/$defs/source_mapping"},
+        "edges": {"$ref": "#/$defs/source_mapping"},
+        "gaps": {"$ref": "#/$defs/source_mapping"},
+        "contested": {"$ref": "#/$defs/source_mapping"}
+      },
+      "additionalProperties": true
+    },
+    "extensions": {
+      "type": "object",
+      "required": ["namespace", "frontmatter_key", "marker"],
+      "properties": {
+        "namespace": {"const": "deepr"},
+        "frontmatter_key": {"const": "deepr"},
+        "marker": {"const": "deepr:okf derived-view regenerable"}
+      },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "document_mapping": {
+      "type": "object",
+      "required": ["path_pattern", "role", "frontmatter", "source"],
+      "properties": {
+        "path_pattern": {"type": "string", "minLength": 1},
+        "role": {"enum": ["root_index", "concept", "update_log", "discovery"]},
+        "frontmatter": {"enum": ["okf_version_only", "required_type", "none", "not_applicable"]},
+        "source": {"type": "string", "minLength": 1},
+        "notes": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "source_mapping": {
+      "type": "object",
+      "required": ["source", "target", "authority"],
+      "properties": {
+        "source": {"type": "string", "minLength": 1},
+        "target": {"type": "string", "minLength": 1},
+        "authority": {"enum": ["canonical", "derived", "ingestion_source"]},
+        "notes": {"type": "string"}
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/docs/schemas/registry.json
+++ b/docs/schemas/registry.json
@@ -147,8 +147,16 @@
       "schema_version": "deepr-okf-profile-v1",
       "kind": "deepr.okf.profile",
       "path": "okf-profile-v1.json",
-      "status": "experimental",
+      "status": "deprecated",
       "compatibility": "additive-within-v1"
+    },
+    {
+      "name": "okf-profile",
+      "schema_version": "deepr-okf-profile-v2",
+      "kind": "deepr.okf.profile",
+      "path": "okf-profile-v2.json",
+      "status": "experimental",
+      "compatibility": "breaking-change-from-v1"
     },
     {
       "name": "mcp-remote-audit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ dependencies = [
     "h2>=4.4.1,<5.0.0",
     "requests>=2.28.0,<3.0.0",
     "aiohttp>=3.14.1,<4.0.0",
+    # OKF 0.2 uses real YAML frontmatter, including nested provenance and
+    # verification families. Keep parsing local and safe instead of treating
+    # the published Markdown contract as a JSON-only subset.
+    "PyYAML>=6.0.3,<7.0.0; python_version != '3.13'",
+    "PyYAML-ft>=8.0.0,<9.0.0; python_version == '3.13'",
     # filelock backs the cross-platform per-(expert, verb) overlap guard
     # (deepr.experts.loop_lock) so scheduled verbs never double-run on one
     # expert. Declared as a direct dependency rather than relying on it being

--- a/src/deepr/cli/commands/semantic/expert_okf.py
+++ b/src/deepr/cli/commands/semantic/expert_okf.py
@@ -131,15 +131,20 @@ def _emit_okf_absorption(profile, corpus, result) -> None:
 @expert.command(name="export-okf")
 @click.argument("name")
 @click.argument("output", type=click.Path(file_okay=False))
-@click.option("--force", is_flag=True, help="Overwrite files that lack the OKF derived-view marker")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Replace the complete dedicated export root even when ownership or content checks fail",
+)
 @click.option("--llms/--no-llms", "include_llms", default=True, show_default=True, help="Emit llms.txt discovery file")
 @click.option("--json", "json_output", is_flag=True, help="Emit the export result as JSON")
 def export_okf(name: str, output: str, force: bool, include_llms: bool, json_output: bool):
-    """Export an expert as a portable OKF Markdown bundle.
+    """Export an expert as a portable OKF 0.2 Markdown bundle.
 
     The export is a regenerated derived view over the structured belief store,
     event log, typed edges, gaps, and contested claims. It never becomes the
-    source of truth and never spends money.
+    source of truth and never spends money. The output is a dedicated generated
+    directory. Do not store hand maintained files inside it.
 
     EXAMPLES:
       deepr expert export-okf "AI Strategy Expert" ./okf/ai-strategy
@@ -147,6 +152,7 @@ def export_okf(name: str, output: str, force: bool, include_llms: bool, json_out
     """
     from deepr.experts.beliefs import BeliefStore
     from deepr.experts.okf import build_okf_bundle, write_okf_bundle
+    from deepr.experts.okf_contract import OKF_VERSION
     from deepr.experts.profile import ExpertStore
 
     store = ExpertStore()
@@ -172,6 +178,7 @@ def export_okf(name: str, output: str, force: bool, include_llms: bool, json_out
         return
 
     print_header(f"OKF export: {profile.name}")
+    print_key_value("OKF version", OKF_VERSION)
     print_key_value("Output", str(result.output_dir))
     print_key_value("Concepts", str(result.concept_count))
     print_key_value("Gaps", str(result.gap_count))

--- a/src/deepr/experts/beliefs.py
+++ b/src/deepr/experts/beliefs.py
@@ -16,6 +16,7 @@ from urllib.parse import urlsplit
 
 from deepr.experts import mutation_audit as audit
 from deepr.experts.belief_edges import EDGE_TYPES, Edge, normalized_edge_temporal_context
+from deepr.experts.maker_checker import strongest_grounding_event
 
 logger = logging.getLogger(__name__)
 
@@ -122,14 +123,12 @@ class Belief:
     # "secondary" (official / first-party tools), or "tertiary" (web / research
     # syntheses; the default, and the retroactive default for legacy beliefs).
     trust_class: str = "tertiary"
-    # Cross-vendor maker-checker assurance (maker_checker.py): "cross_vendor" /
-    # "same_vendor_fresh_context" / "unverified" (default; also could-not-verify).
+    # Maker-checker assurance; see maker_checker.py.
     grounding_assurance: str = "unverified"
-    # Usage salience (docs/design/belief-lifecycle.md): bump only when this belief
-    # is load-bearing on mutating surfaces. Read-side queries stay pure; recent
-    # usage can shield a belief from archival, but absence of usage never condemns it.
+    # Mutation-only usage salience; see docs/design/belief-lifecycle.md.
     retrieval_count: int = 0
     last_retrieved_at: datetime | None = None
+    grounding_verified_at: datetime | None = None
 
     def __post_init__(self):
         if not self.id:
@@ -294,6 +293,7 @@ class Belief:
             "history": self.history,
             "trust_class": self.trust_class,
             "grounding_assurance": self.grounding_assurance,
+            "grounding_verified_at": self.grounding_verified_at.isoformat() if self.grounding_verified_at else None,
             "retrieval_count": self.retrieval_count,
             "last_retrieved_at": self.last_retrieved_at.isoformat() if self.last_retrieved_at else None,
         }
@@ -316,6 +316,7 @@ class Belief:
             # Pre-floor beliefs default tertiary: retroactive honesty
             trust_class=data.get("trust_class", "tertiary"),
             grounding_assurance=data.get("grounding_assurance", "unverified"),
+            grounding_verified_at=_as_utc(value) if (value := data.get("grounding_verified_at")) else None,
             retrieval_count=int(data.get("retrieval_count", 0) or 0),
             last_retrieved_at=(_as_utc(data["last_retrieved_at"]) if data.get("last_retrieved_at") else None),
         )
@@ -749,8 +750,6 @@ class BeliefStore:
             new_evidence: New evidence reference
             reason: Reason for update
 
-        Returns:
-            BeliefChange record or None
         """
         if belief_id not in self.beliefs:
             return None
@@ -811,8 +810,9 @@ class BeliefStore:
         before = audit.belief_snapshot(belief)
         old_claim = belief.claim
         old_confidence = belief.confidence
-
-        # Update belief
+        if new_claim != old_claim:
+            belief.grounding_assurance = "unverified"
+            belief.grounding_verified_at = None
         belief.claim = new_claim
         belief.update_confidence(new_confidence, reason)
         if evidence:
@@ -1265,13 +1265,15 @@ class BeliefStore:
 
         claim_revised = bool(prefer_new_claim and new.claim.strip() and new.claim != existing.claim)
         if claim_revised:
-            # Attribution follows the claim. Keeping the prior source_type and
-            # grounding_assurance on rewritten text would attribute the new
-            # assertion to a source that never made it. Evidence refs are
-            # unioned above, so prior corroboration is not lost.
             existing.claim = new.claim
             existing.source_type = new.source_type
             existing.grounding_assurance = new.grounding_assurance
+            existing.grounding_verified_at = new.grounding_verified_at
+        elif new.claim == existing.claim:
+            existing.grounding_assurance, existing.grounding_verified_at = strongest_grounding_event(
+                (existing.grounding_assurance, existing.grounding_verified_at),
+                (new.grounding_assurance, new.grounding_verified_at),
+            )
 
         existing.history.append(
             {
@@ -1341,6 +1343,7 @@ class BeliefStore:
         existing.decay_rate = new.decay_rate
         existing.trust_class = better_trust
         existing.grounding_assurance = new.grounding_assurance
+        existing.grounding_verified_at = new.grounding_verified_at
         existing.updated_at = changed_at
 
         change = BeliefChange(

--- a/src/deepr/experts/export_validation.py
+++ b/src/deepr/experts/export_validation.py
@@ -14,7 +14,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-EXPORT_VALIDATION_SCHEMA_VERSION = "deepr-export-validation-v1"
+EXPORT_VALIDATION_SCHEMA_VERSION = "deepr-export-validation-v2"
 EXPORT_VALIDATION_KIND = "deepr.expert.export_validation"
 
 ARTIFACT_CLASS_HANDOFF = "handoff_payload"
@@ -42,7 +42,7 @@ def _contract() -> dict[str, Any]:
 
 def _classify(path: Path) -> str:
     if path.is_dir():
-        return ARTIFACT_CLASS_OKF if (path / "index.md").is_file() else ARTIFACT_CLASS_UNKNOWN
+        return ARTIFACT_CLASS_OKF if any(path.rglob("*.md")) else ARTIFACT_CLASS_UNKNOWN
     if path.name.upper() == "SKILL.MD":
         return ARTIFACT_CLASS_SKILL
     if path.suffix.lower() == ".json":
@@ -128,34 +128,26 @@ def _validate_handoff(path: Path) -> list[dict[str, Any]]:
 
 
 def _validate_okf_bundle(path: Path) -> list[dict[str, Any]]:
-    from deepr.experts.okf import OKF_PROFILE_SCHEMA_VERSION, OKF_SCHEMA_VERSION, _split_frontmatter
+    from deepr.experts.okf_contract import OKF_VERSION, validate_okf_bundle
 
-    # index.md presence is what classified this path as an OKF bundle, so
-    # only log.md needs its own presence check here.
-    checks = [_check("log_present", (path / "log.md").is_file(), "log.md")]
-    allowed_versions = {OKF_SCHEMA_VERSION, OKF_PROFILE_SCHEMA_VERSION}
-    markdown_files = sorted(path.rglob("*.md"))
-    unreadable: list[str] = []
-    bad_versions: list[str] = []
-    for markdown_file in markdown_files:
-        try:
-            text = markdown_file.read_text(encoding="utf-8")
-        except (OSError, ValueError):
-            unreadable.append(markdown_file.name)
-            continue
-        fields, _body = _split_frontmatter(text)
-        if str(fields.get("schema_version", "") or "") not in allowed_versions:
-            bad_versions.append(markdown_file.name)
-    checks.append(_check("readable_files", not unreadable, ", ".join(unreadable[:5]) or "all markdown files readable"))
-    checks.append(
+    result = validate_okf_bundle(path)
+    checks = [
         _check(
-            "frontmatter_schema_versions",
-            not bad_versions,
-            f"{len(markdown_files)} markdown file(s) carry a known OKF schema version"
-            if not bad_versions
-            else f"missing or unknown schema_version in: {', '.join(bad_versions[:5])}",
+            "markdown_files_present",
+            bool(result.files),
+            f"{len(result.files)} Markdown file(s) found" if result.files else "bundle contains no Markdown files",
         )
-    )
+    ]
+    if result.violations:
+        detail = "; ".join(
+            f"{violation.path} [{violation.code}]: {violation.detail}" for violation in result.violations[:5]
+        )
+    else:
+        version_detail = (
+            f"declared {result.declared_version}" if result.declared_version else "version declaration omitted"
+        )
+        detail = f"OKF {OKF_VERSION} hard conformance rules pass; {version_detail}"
+    checks.append(_check("okf_0_2_conformance", result.valid, detail))
     return checks
 
 
@@ -211,7 +203,7 @@ def validate_export(path: Path) -> dict[str, Any]:
             _check(
                 "artifact_class",
                 False,
-                "unrecognized export; expected a handoff .json, an OKF bundle directory with index.md, or a SKILL.md",
+                "unrecognized export; expected a handoff .json, an OKF Markdown bundle directory, or a SKILL.md",
             )
         ]
 

--- a/src/deepr/experts/handoff.py
+++ b/src/deepr/experts/handoff.py
@@ -8,7 +8,8 @@ from typing import Any
 from deepr.experts.dashboard_telemetry import build_expert_dashboard_telemetry
 from deepr.experts.loop_status_rollup import build_loop_status_rollup
 from deepr.experts.maker_checker import ASSURANCE_LEVELS, VERIFIED_ASSURANCES, CheckAssurance
-from deepr.experts.okf import OKF_PROFILE_SCHEMA_VERSION, OKF_SCHEMA_VERSION
+from deepr.experts.okf import OKF_PROFILE_SCHEMA_PATH, OKF_PROFILE_SCHEMA_VERSION, OKF_SCHEMA_VERSION
+from deepr.experts.okf_contract import OKF_VERSION
 from deepr.experts.perspective_state import build_perspective_state_packet
 from deepr.security.output_safety import sanitize_host_facing_payload
 
@@ -170,8 +171,9 @@ def build_expert_handoff(
         "loop_status": resolved_loop_status,
         "okf": {
             "schema_version": OKF_SCHEMA_VERSION,
+            "okf_version": OKF_VERSION,
             "profile_schema_version": OKF_PROFILE_SCHEMA_VERSION,
-            "profile_schema_url": "docs/schemas/okf-profile-v1.json",
+            "profile_schema_url": OKF_PROFILE_SCHEMA_PATH,
             "canonical": False,
             "export_command": f"deepr expert export-okf {resolved_name!r} ./okf/{resolved_name}",
             "absorb_command": f"deepr expert absorb-okf {resolved_name!r} ./okf/{resolved_name} --dry-run",

--- a/src/deepr/experts/maker_checker.py
+++ b/src/deepr/experts/maker_checker.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import Any
 
@@ -65,6 +66,31 @@ def is_verified_assurance(value: str | None) -> bool:
     checker corroborate this claim", never "is this claim true".
     """
     return value in VERIFIED_ASSURANCES
+
+
+def strongest_grounding_event(
+    existing: tuple[str, datetime | None],
+    candidate: tuple[str, datetime | None],
+) -> tuple[str, datetime | None]:
+    """Keep the strongest complete checker event for identical claim text."""
+    rank = {
+        CheckAssurance.CROSS_VENDOR.value: 2,
+        CheckAssurance.SAME_VENDOR_FRESH_CONTEXT.value: 1,
+    }
+    existing_assurance, existing_at = existing
+    candidate_assurance, candidate_at = candidate
+    existing_rank = rank.get(existing_assurance, 0) if existing_at is not None else 0
+    candidate_rank = rank.get(candidate_assurance, 0) if candidate_at is not None else 0
+    if candidate_rank > existing_rank:
+        return candidate
+    if (
+        candidate_rank > 0
+        and candidate_rank == existing_rank
+        and candidate_at is not None
+        and (existing_at is None or candidate_at > existing_at)
+    ):
+        return candidate
+    return existing
 
 
 def assurance_short_label(value: str | None) -> str:

--- a/src/deepr/experts/okf.py
+++ b/src/deepr/experts/okf.py
@@ -15,16 +15,28 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from deepr.experts.belief_edges import Edge
 from deepr.experts.beliefs import Belief, BeliefChange, BeliefStore
+from deepr.experts.maker_checker import CheckAssurance, is_verified_assurance
+from deepr.experts.okf_contract import (
+    OKF_VERSION,
+    parse_markdown_frontmatter,
+    read_bounded_markdown_bundle,
+    validate_okf_documents,
+)
+from deepr.experts.okf_publication import publish_okf_directory
 from deepr.experts.perspective import contested as contested_query
 from deepr.experts.record_time import parse_iso
 
 OKF_SCHEMA_VERSION = "deepr-okf-v1"
-OKF_PROFILE_SCHEMA_VERSION = "deepr-okf-profile-v1"
+OKF_PROFILE_SCHEMA_VERSION = "deepr-okf-profile-v2"
+OKF_PROFILE_SCHEMA_PATH = "docs/schemas/okf-profile-v2.json"
 OKF_MARKER = "deepr:okf derived-view regenerable"
+OKF_GENERATOR_ACTOR = "process:deepr-export-okf"
 
-_HTML_BANNER = f"<!-- {OKF_MARKER} -->\n<!-- DERIVED VIEW - do not hand-edit. The belief store is canonical. -->\n"
+_HTML_BANNER = f"<!-- {OKF_MARKER} -->\n<!-- DERIVED VIEW - do not hand-edit. The belief store is canonical. -->"
 _SLUG_CHARS = re.compile(r"[^a-z0-9]+")
 
 
@@ -62,6 +74,7 @@ class OKFWriteResult:
             "contested_count": self.contested_count,
             "as_of": self.as_of,
             "schema_version": OKF_SCHEMA_VERSION,
+            "okf_version": OKF_VERSION,
         }
 
 
@@ -90,14 +103,26 @@ def _aware(value: datetime | None) -> datetime | None:
     return value if value.tzinfo else value.replace(tzinfo=UTC)
 
 
-def _as_of(store: BeliefStore, events: list[BeliefChange]) -> str:
+def _append_aware(timestamps: list[datetime], value: datetime | None) -> None:
+    timestamp = _aware(value)
+    if timestamp is not None:
+        timestamps.append(timestamp)
+
+
+def _as_of(profile: Any, store: BeliefStore, manifest: Any, events: list[BeliefChange]) -> str:
     timestamps: list[datetime] = []
+    for value in (getattr(profile, "created_at", None), getattr(profile, "updated_at", None)):
+        _append_aware(timestamps, value)
     for event in events:
-        if (timestamp := _aware(event.timestamp)) is not None:
-            timestamps.append(timestamp)
+        _append_aware(timestamps, event.timestamp)
     for belief in store.beliefs.values():
-        if (timestamp := _aware(belief.updated_at)) is not None:
-            timestamps.append(timestamp)
+        for value in (belief.updated_at, belief.grounding_verified_at):
+            _append_aware(timestamps, value)
+    for edge in store.edges.values():
+        _append_aware(timestamps, edge.created_at)
+    for gap in list(getattr(manifest, "gaps", []) or []):
+        for value in (getattr(gap, "identified_at", None), getattr(gap, "filled_at", None)):
+            _append_aware(timestamps, value)
     if not timestamps:
         return "never"
     return max(timestamps).isoformat()
@@ -125,53 +150,60 @@ def _frontmatter(fields: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _parse_frontmatter_value(value: str) -> Any:
-    value = value.strip()
-    if not value:
-        return ""
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        return value.strip("\"'")
-
-
 def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
-    lines = text.splitlines()
-    start = 0
-    while start < len(lines):
-        stripped = lines[start].strip()
-        if not stripped or stripped.startswith("<!--"):
-            start += 1
-            continue
-        break
-    if start >= len(lines) or lines[start].strip() != "---":
+    parsed = parse_markdown_frontmatter(text, allow_leading_comments=True)
+    if parsed.error:
         return {}, text
-
-    end = start + 1
-    while end < len(lines) and lines[end].strip() != "---":
-        end += 1
-    if end >= len(lines):
-        return {}, text
-
-    fields: dict[str, Any] = {}
-    for line in lines[start + 1 : end]:
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        fields[key.strip()] = _parse_frontmatter_value(value)
-    return fields, "\n".join(lines[end + 1 :]).strip()
+    return {str(key): value for key, value in parsed.fields.items()}, parsed.body
 
 
 def _doc(fields: dict[str, Any], body: list[str]) -> str:
-    return "\n".join([_HTML_BANNER + _frontmatter(fields), "", *body, ""])
+    return "\n".join([_frontmatter(fields), _HTML_BANNER, "", *body, ""])
 
 
 def _md_escape(value: str) -> str:
-    return value.replace("[", "\\[").replace("]", "\\]")
+    normalized = " ".join(str(value).split())
+    return normalized.replace("[", "\\[").replace("]", "\\]")
+
+
+def _md_code(value: str) -> str:
+    return _md_escape(value).replace("`", "'")
 
 
 def _fmt_num(value: float) -> str:
     return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def _generated(at: str) -> dict[str, str]:
+    generated = {"by": OKF_GENERATOR_ACTOR}
+    if parse_iso(at) is not None:
+        generated["at"] = at
+    return generated
+
+
+def _source_entries(evidence_refs: list[str]) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw_ref in evidence_refs:
+        resource = str(raw_ref).strip()
+        if not resource or resource in seen:
+            continue
+        seen.add(resource)
+        source_id = f"source-{sha256(resource.encode('utf-8')).hexdigest()[:12]}"
+        entries.append({"id": source_id, "resource": resource})
+    return entries
+
+
+def _verification_event(belief: Belief) -> dict[str, str] | None:
+    assurance = str(belief.grounding_assurance or "")
+    verified_at = _aware(belief.grounding_verified_at)
+    if not is_verified_assurance(assurance) or verified_at is None:
+        return None
+    actor = {
+        CheckAssurance.CROSS_VENDOR.value: "process:deepr-cross-vendor-checker",
+        CheckAssurance.SAME_VENDOR_FRESH_CONTEXT.value: "process:deepr-fresh-context-checker",
+    }[assurance]
+    return {"by": actor, "at": verified_at.isoformat()}
 
 
 def _moment(as_of: str) -> datetime | None:
@@ -231,22 +263,6 @@ def _build_index(
     beliefs = _sorted_beliefs(store, as_of)
     gaps = list(getattr(manifest, "gaps", []) or [])
     contested = contested_query(store, expert_name=str(profile.name))
-    fields = {
-        "type": "deepr.okf.index",
-        "title": str(profile.name),
-        "description": str(getattr(profile, "description", "") or ""),
-        "tags": [str(getattr(profile, "domain", "") or "general")],
-        "timestamp": as_of,
-        "deepr": {
-            "schema_version": OKF_SCHEMA_VERSION,
-            "source_expert": str(profile.name),
-            "belief_count": len(beliefs),
-            "edge_count": len(store.edges),
-            "gap_count": len(gaps),
-            "event_count": len(events),
-            "contested_count": int(contested.get("open_count", 0) or 0),
-        },
-    }
     body = [
         f"# {profile.name}",
         "",
@@ -289,7 +305,7 @@ def _build_index(
             f'- `deepr expert contested "{profile.name}"`',
         ]
     )
-    return _doc(fields, body)
+    return "\n".join([_frontmatter({"okf_version": OKF_VERSION}), _HTML_BANNER, "", *body, ""])
 
 
 def _build_concept(
@@ -301,12 +317,13 @@ def _build_concept(
 ) -> str:
     updated_at = _aware(belief.updated_at)
     created_at = _aware(belief.created_at)
-    fields = {
+    sources = _source_entries(belief.evidence_refs)
+    fields: dict[str, Any] = {
         "type": "deepr.okf.concept",
         "title": belief.claim,
         "description": belief.claim,
         "tags": [belief.domain or "general", belief.source_type, belief.trust_class],
-        "timestamp": updated_at.isoformat() if updated_at else as_of,
+        "generated": _generated(as_of),
         "deepr": {
             "schema_version": OKF_SCHEMA_VERSION,
             "source_expert": str(profile.name),
@@ -316,15 +333,21 @@ def _build_concept(
             "trust_class": belief.trust_class,
             "source_type": belief.source_type,
             "evidence_refs": list(belief.evidence_refs),
+            "grounding_assurance": belief.grounding_assurance,
             "contradictions_with": list(belief.contradictions_with),
         },
     }
+    if sources:
+        fields["sources"] = sources
+    if verification := _verification_event(belief):
+        fields["verified"] = verification
+    citation_marks = "".join(f"[^{source['id']}]" for source in sources)
     body = [
-        f"# {belief.claim}",
+        f"# {_md_escape(belief.claim)}",
         "",
         "## Claim",
         "",
-        belief.claim,
+        f"{_md_escape(belief.claim)}{citation_marks}",
         "",
         "## State",
         "",
@@ -336,13 +359,13 @@ def _build_concept(
         f"- Created: {created_at.isoformat() if created_at else ''}",
         f"- Updated: {updated_at.isoformat() if updated_at else ''}",
         "",
-        "## Citations",
+        "## Provenance",
         "",
     ]
-    if belief.evidence_refs:
-        body.extend(f"- `{ref}`" for ref in belief.evidence_refs)
+    if sources:
+        body.extend(f"- `{source['id']}`: `{_md_code(source['resource'])}`" for source in sources)
     else:
-        body.append("- No citation references recorded.")
+        body.append("- No source references recorded.")
 
     edges = sorted(
         store.edges_for(belief.id),
@@ -354,6 +377,9 @@ def _build_concept(
         body.extend(_edge_line(edge, belief.id, paths_by_id, beliefs_by_id) for edge in edges)
     else:
         body.append("- No typed edges recorded.")
+    if sources:
+        body.append("")
+        body.extend(f"[^{source['id']}]: {_md_escape(source['resource'])}" for source in sources)
     body.extend(["", "[Back to index](../index.md)"])
     return _doc(fields, body)
 
@@ -373,7 +399,7 @@ def _build_gaps(profile: Any, manifest: Any, as_of: str) -> str:
         "title": f"{profile.name} knowledge gaps",
         "description": "Open and filled knowledge gaps exported from the Deepr expert manifest.",
         "tags": [str(getattr(profile, "domain", "") or "general"), "gaps"],
-        "timestamp": as_of,
+        "generated": _generated(as_of),
         "deepr": {
             "schema_version": OKF_SCHEMA_VERSION,
             "source_expert": str(profile.name),
@@ -416,7 +442,7 @@ def _build_contested(profile: Any, store: BeliefStore, as_of: str) -> str:
         "title": f"{profile.name} contested claims",
         "description": "Recorded contradiction candidates exported with verification provenance.",
         "tags": [str(getattr(profile, "domain", "") or "general"), "contested"],
-        "timestamp": as_of,
+        "generated": _generated(as_of),
         "deepr": {
             "schema_version": OKF_SCHEMA_VERSION,
             "source_expert": str(profile.name),
@@ -448,35 +474,39 @@ def _build_contested(profile: Any, store: BeliefStore, as_of: str) -> str:
     return _doc(fields, body)
 
 
-def _build_log(profile: Any, events: list[BeliefChange], as_of: str, paths_by_id: dict[str, str]) -> str:
-    fields = {
-        "type": "deepr.okf.log",
-        "title": f"{profile.name} belief change log",
-        "description": "Append-only belief event log exported as a portable Markdown view.",
-        "tags": [str(getattr(profile, "domain", "") or "general"), "log"],
-        "timestamp": as_of,
-        "deepr": {
-            "schema_version": OKF_SCHEMA_VERSION,
-            "source_expert": str(profile.name),
-            "event_count": len(events),
-        },
-    }
-    body = ["# Change Log", ""]
+def _build_log(events: list[BeliefChange], as_of: str, paths_by_id: dict[str, str]) -> str:
+    body = ["# Change Log", "", _HTML_BANNER, ""]
     if not events:
         body.append("No belief events recorded.")
-        return _doc(fields, body)
+        return "\n".join([*body, ""])
 
-    for event in sorted(events, key=lambda change: _aware(change.timestamp) or datetime.min.replace(tzinfo=UTC)):
+    current_date = ""
+    ordered_events = sorted(
+        events,
+        key=lambda change: _aware(change.timestamp) or datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+    for event in ordered_events:
         event_time = _aware(event.timestamp)
-        timestamp = event_time.isoformat() if event_time else ""
+        event_date = (
+            event_time.date().isoformat()
+            if event_time
+            else (_moment(as_of) or datetime.min.replace(tzinfo=UTC)).date().isoformat()
+        )
+        if event_date != current_date:
+            if current_date:
+                body.append("")
+            body.extend([f"## {event_date}", ""])
+            current_date = event_date
         concept_path = paths_by_id.get(event.belief_id)
         belief_ref = f"[`{event.belief_id}`]({concept_path})" if concept_path else f"`{event.belief_id}`"
-        body.append(f"- {timestamp} `{event.change_type}` {belief_ref}: {event.new_claim or event.old_claim}")
+        change_label = _md_escape(str(event.change_type).replace("_", " ").title())
+        body.append(f"* **{change_label}**: {belief_ref} - {_md_escape(event.new_claim or event.old_claim)}")
         if event.reason:
-            body.append(f"  - Reason: {event.reason}")
+            body.append(f"  * Reason: {_md_escape(event.reason)}")
         if event.evidence:
-            body.append(f"  - Evidence: `{event.evidence}`")
-    return _doc(fields, body)
+            body.append(f"  * Evidence: `{_md_code(event.evidence)}`")
+    return "\n".join([*body, ""])
 
 
 def _build_llms(profile: Any, bundle_name: str) -> str:
@@ -499,29 +529,38 @@ def _build_llms(profile: Any, bundle_name: str) -> str:
     )
 
 
-def _iter_markdown_files(path: Path) -> tuple[Path, list[Path]]:
-    root = path.resolve()
-    if root.is_file():
-        return root.parent, [root]
-    if root.is_dir():
-        return root, sorted(root.rglob("*.md"))
-    raise ValueError(f"OKF path not found: {path}")
-
-
 def _is_concept_doc(relative_path: str, fields: dict[str, Any]) -> bool:
-    doc_type = str(fields.get("type", ""))
-    return doc_type.endswith(".concept") or relative_path.startswith("concepts/")
+    return Path(relative_path).name not in {"index.md", "log.md"} and bool(str(fields.get("type", "") or "").strip())
+
+
+def _okf_ingestion_error(violations: tuple[Any, ...]) -> ValueError:
+    detail = "; ".join(
+        f"{violation.path} [{violation.code}]: {violation.detail}"
+        for violation in sorted(
+            violations,
+            key=lambda item: (item.path, item.code, item.detail),
+        )
+    )
+    return ValueError(f"Cannot ingest OKF bundle: {detail}")
 
 
 def build_okf_ingestion_corpus(path: Path) -> OKFIngestionCorpus:
     """Parse OKF concept Markdown into source text for ReportAbsorber."""
-    base, markdown_files = _iter_markdown_files(path)
+    bundle_read = read_bounded_markdown_bundle(path)
+    if bundle_read.violations:
+        raise _okf_ingestion_error(bundle_read.violations)
+    if bundle_read.root is None:
+        raise ValueError(f"Cannot ingest OKF bundle: {path} [path_unreadable]: no bundle root")
+
+    base = bundle_read.root
+    content_validation = validate_okf_documents(dict(bundle_read.documents))
+    if content_validation.violations:
+        raise _okf_ingestion_error(content_validation.violations)
+
     concepts: list[tuple[str, dict[str, Any], str]] = []
     digest = sha256()
 
-    for file_path in markdown_files:
-        text = file_path.read_text(encoding="utf-8", errors="replace")
-        relative_path = file_path.resolve().relative_to(base).as_posix()
+    for relative_path, text in bundle_read.documents:
         fields, body = _split_frontmatter(text)
         if not _is_concept_doc(relative_path, fields):
             continue
@@ -554,8 +593,8 @@ def build_okf_ingestion_corpus(path: Path) -> OKFIngestionCorpus:
                 f"Source file: {relative_path}",
                 "",
                 "Frontmatter:",
-                "```json",
-                json.dumps(fields, indent=2, sort_keys=True),
+                "```yaml",
+                yaml.safe_dump(fields, allow_unicode=True, sort_keys=False).strip(),
                 "```",
                 "",
                 "Body:",
@@ -583,7 +622,7 @@ def build_okf_bundle(
     """Build a deterministic OKF bundle from structured expert state."""
     resolved_manifest = manifest if manifest is not None else profile.get_manifest()
     events = store.iter_events() if store.has_event_log else list(store.changes)
-    as_of = _as_of(store, events)
+    as_of = _as_of(profile, store, resolved_manifest, events)
     beliefs = _sorted_beliefs(store, as_of)
     paths_by_id = {belief.id: _concept_path(belief) for belief in beliefs}
     contested = contested_query(store, expert_name=str(profile.name))
@@ -592,7 +631,7 @@ def build_okf_bundle(
         "index.md": _build_index(profile, store, resolved_manifest, paths_by_id, as_of, events),
         "gaps.md": _build_gaps(profile, resolved_manifest, as_of),
         "contested.md": _build_contested(profile, store, as_of),
-        "log.md": _build_log(profile, events, as_of, paths_by_id),
+        "log.md": _build_log(events, as_of, paths_by_id),
     }
     for belief in beliefs:
         files[paths_by_id[belief.id]] = _build_concept(profile, belief, store, paths_by_id, as_of)
@@ -610,31 +649,27 @@ def build_okf_bundle(
 
 
 def write_okf_bundle(bundle: OKFBundle, output_dir: Path, *, force: bool = False) -> OKFWriteResult:
-    """Write an OKF bundle, refusing to overwrite hand-edited files."""
-    root = output_dir.resolve()
-    root.mkdir(parents=True, exist_ok=True)
+    """Publish a complete, dedicated OKF export root.
 
-    targets: list[tuple[str, Path, str]] = []
-    for relative_path, content in bundle.files.items():
-        target = (root / relative_path).resolve()
-        try:
-            target.relative_to(root)
-        except ValueError as exc:
-            raise ValueError(f"Invalid bundle path: {relative_path}") from exc
-        if target.exists() and OKF_MARKER not in target.read_text(encoding="utf-8", errors="replace") and not force:
-            raise ValueError(
-                f"{target} exists without the OKF derived-view marker. "
-                "Use --force only when you intend to replace a hand-edited file."
-            )
-        targets.append((relative_path, target, content))
+    Existing output must match the exact path and content hashes in its Deepr
+    publication manifest. ``force`` replaces the complete export root, so the
+    caller must not use this destination for hand maintained content.
+    """
+    validation = validate_okf_documents(bundle.files)
+    if not validation.valid:
+        detail = "; ".join(
+            f"{violation.path} [{violation.code}]: {violation.detail}" for violation in validation.violations[:5]
+        )
+        raise ValueError(f"Generated bundle does not conform to OKF {OKF_VERSION}: {detail}")
+    unowned = [relative_path for relative_path, content in bundle.files.items() if OKF_MARKER not in content]
+    if unowned:
+        raise ValueError(f"Generated bundle files lack the Deepr ownership marker: {', '.join(sorted(unowned))}")
 
-    for _, target, content in targets:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding="utf-8")
+    root = publish_okf_directory(bundle.files, output_dir, force=force, okf_version=OKF_VERSION)
 
     return OKFWriteResult(
         output_dir=root,
-        files=[relative_path for relative_path, _, _ in targets],
+        files=sorted(bundle.files),
         concept_count=bundle.concept_count,
         gap_count=bundle.gap_count,
         event_count=bundle.event_count,

--- a/src/deepr/experts/okf_contract.py
+++ b/src/deepr/experts/okf_contract.py
@@ -1,0 +1,582 @@
+"""Offline parser and form-only conformance checks for OKF 0.2.
+
+OKF 0.2 intentionally publishes a Markdown and YAML specification, not a
+JSON Schema. This module implements only its mechanical bundle rules. It does
+not judge the truth, quality, trust tier, or meaning of a concept.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
+
+import yaml
+from yaml.events import MappingEndEvent, MappingStartEvent, SequenceEndEvent, SequenceStartEvent
+
+OKF_VERSION = "0.2"
+OKF_RESERVED_FILENAMES = frozenset({"index.md", "log.md"})
+
+_DATE_HEADING_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*$")
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,}).*$")
+_MAX_FRONTMATTER_CHARS = 256 * 1024
+_MAX_YAML_EVENTS = 10_000
+_MAX_YAML_DEPTH = 64
+OKF_MAX_MARKDOWN_FILES = 10_000
+OKF_MAX_MARKDOWN_FILE_BYTES = 8 * 1024 * 1024
+OKF_MAX_MARKDOWN_TOTAL_BYTES = 64 * 1024 * 1024
+_WINDOWS_DEVICE_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{number}" for number in range(1, 10)}
+    | {f"LPT{number}" for number in range(1, 10)}
+)
+
+
+@dataclass(frozen=True)
+class ParsedFrontmatter:
+    """One Markdown frontmatter parse with errors kept at the boundary."""
+
+    present: bool
+    fields: dict[Any, Any]
+    body: str
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class OKFViolation:
+    """One deterministic OKF form violation."""
+
+    code: str
+    path: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class OKFBundleValidation:
+    """Offline validation result for one bundle or concept document."""
+
+    files: tuple[str, ...]
+    violations: tuple[OKFViolation, ...]
+    declared_version: str | None
+
+    @property
+    def valid(self) -> bool:
+        return not self.violations
+
+
+@dataclass(frozen=True)
+class OKFMarkdownBundleRead:
+    """One bounded, reusable read of an OKF Markdown bundle."""
+
+    root: Path | None
+    files: tuple[str, ...]
+    documents: tuple[tuple[str, str], ...]
+    violations: tuple[OKFViolation, ...]
+
+    @property
+    def valid(self) -> bool:
+        return not self.violations
+
+
+def _bounded_yaml_tree(
+    value: Any,
+    *,
+    active: frozenset[int] = frozenset(),
+    depth: int = 0,
+    node_count: list[int] | None = None,
+) -> Any:
+    node_count = [0] if node_count is None else node_count
+    node_count[0] += 1
+    if node_count[0] > _MAX_YAML_EVENTS:
+        raise ValueError(f"frontmatter expands beyond {_MAX_YAML_EVENTS} YAML nodes")
+    if depth > _MAX_YAML_DEPTH:
+        raise ValueError(f"frontmatter exceeds YAML nesting depth {_MAX_YAML_DEPTH}")
+    if isinstance(value, (tuple, set, frozenset)):
+        raise ValueError(f"frontmatter uses unsupported YAML container {type(value).__name__}")
+    if not isinstance(value, (dict, list)):
+        return value
+    identity = id(value)
+    if identity in active:
+        raise ValueError("cyclic YAML aliases are not accepted")
+    descendants = active | {identity}
+    if isinstance(value, list):
+        return [_bounded_yaml_tree(item, active=descendants, depth=depth + 1, node_count=node_count) for item in value]
+    return {
+        key: _bounded_yaml_tree(item, active=descendants, depth=depth + 1, node_count=node_count)
+        for key, item in value.items()
+    }
+
+
+def _load_bounded_yaml_mapping(raw_frontmatter: str) -> tuple[dict[Any, Any], str | None]:
+    try:
+        depth = 0
+        for event_count, event in enumerate(yaml.parse(raw_frontmatter), start=1):
+            if event_count > _MAX_YAML_EVENTS:
+                raise ValueError(f"frontmatter exceeds {_MAX_YAML_EVENTS} YAML events")
+            if isinstance(event, (MappingStartEvent, SequenceStartEvent)):
+                depth += 1
+                if depth > _MAX_YAML_DEPTH:
+                    raise ValueError(f"frontmatter exceeds YAML nesting depth {_MAX_YAML_DEPTH}")
+            elif isinstance(event, (MappingEndEvent, SequenceEndEvent)):
+                depth -= 1
+        parsed = _bounded_yaml_tree(yaml.safe_load(raw_frontmatter))
+    except (OverflowError, ValueError, yaml.YAMLError) as exc:
+        return {}, f"invalid YAML: {exc}"
+    if parsed is None:
+        return {}, None
+    if not isinstance(parsed, dict):
+        return {}, "frontmatter must be a YAML mapping"
+    return parsed, None
+
+
+def parse_markdown_frontmatter(text: str, *, allow_leading_comments: bool = False) -> ParsedFrontmatter:
+    """Parse YAML frontmatter without executing custom YAML tags.
+
+    OKF concept frontmatter must start on the first line. The compatibility
+    option exists only for reading Deepr's older generated views, which placed
+    derived-view comments before the delimiter.
+    """
+    lines = text.splitlines()
+    start = 0
+    if allow_leading_comments:
+        while start < len(lines):
+            stripped = lines[start].strip()
+            if not stripped or (stripped.startswith("<!--") and stripped.endswith("-->")):
+                start += 1
+                continue
+            break
+
+    if start >= len(lines) or lines[start].strip() != "---":
+        return ParsedFrontmatter(present=False, fields={}, body=text)
+
+    end = start + 1
+    while end < len(lines) and lines[end].strip() != "---":
+        end += 1
+    if end >= len(lines):
+        return ParsedFrontmatter(
+            present=True,
+            fields={},
+            body="",
+            error="frontmatter has no closing --- delimiter",
+        )
+
+    raw_frontmatter = "\n".join(lines[start + 1 : end])
+    if len(raw_frontmatter) > _MAX_FRONTMATTER_CHARS:
+        return ParsedFrontmatter(
+            present=True,
+            fields={},
+            body="",
+            error=f"frontmatter exceeds {_MAX_FRONTMATTER_CHARS} characters",
+        )
+    fields, error = _load_bounded_yaml_mapping(raw_frontmatter)
+    if error:
+        return ParsedFrontmatter(present=True, fields={}, body="", error=error)
+    return ParsedFrontmatter(
+        present=True,
+        fields=fields,
+        body="\n".join(lines[end + 1 :]).strip(),
+    )
+
+
+def _markdown_files(path: Path) -> tuple[Path, list[Path], OKFViolation | None]:
+    resolved = path.resolve(strict=True)
+    if resolved.is_file():
+        return resolved.parent, [resolved], None
+
+    markdown_files: list[Path] = []
+    for candidate in resolved.rglob("*.md"):
+        if len(markdown_files) >= OKF_MAX_MARKDOWN_FILES:
+            violation = OKFViolation(
+                code="markdown_file_count_limit",
+                path=resolved.as_posix(),
+                detail=f"Bundle exceeds the maximum of {OKF_MAX_MARKDOWN_FILES} Markdown files",
+            )
+            return resolved, [], violation
+        markdown_files.append(candidate)
+    return resolved, sorted(markdown_files), None
+
+
+def _relative_file(root: Path, candidate: Path) -> tuple[str | None, OKFViolation | None]:
+    try:
+        resolved = candidate.resolve(strict=True)
+        relative = resolved.relative_to(root).as_posix()
+    except (OSError, RuntimeError, ValueError) as exc:
+        return None, OKFViolation(
+            code="path_outside_bundle",
+            path=candidate.as_posix(),
+            detail=f"Markdown path does not resolve inside the bundle: {exc}",
+        )
+    return relative, None
+
+
+def _preflight_markdown_files(
+    root: Path,
+    markdown_files: list[Path],
+) -> tuple[list[str], list[tuple[str, Path]], list[OKFViolation]]:
+    files: list[str] = []
+    preflight: list[tuple[str, Path]] = []
+    violations: list[OKFViolation] = []
+    total_bytes = 0
+    for markdown_file in markdown_files:
+        relative_path, path_violation = _relative_file(root, markdown_file)
+        if path_violation is not None:
+            violations.append(path_violation)
+            continue
+        if relative_path is None:
+            violations.append(
+                OKFViolation(
+                    "path_unreadable",
+                    markdown_file.as_posix(),
+                    "Markdown path could not be resolved relative to the bundle",
+                )
+            )
+            continue
+        files.append(relative_path)
+        try:
+            file_bytes = markdown_file.stat().st_size
+        except OSError as exc:
+            violations.append(OKFViolation("path_unreadable", relative_path, str(exc)))
+            continue
+        if file_bytes > OKF_MAX_MARKDOWN_FILE_BYTES:
+            violations.append(
+                OKFViolation(
+                    "markdown_file_size_limit",
+                    relative_path,
+                    f"File exceeds the maximum of {OKF_MAX_MARKDOWN_FILE_BYTES} bytes",
+                )
+            )
+        total_bytes += file_bytes
+        preflight.append((relative_path, markdown_file))
+
+    if total_bytes > OKF_MAX_MARKDOWN_TOTAL_BYTES:
+        violations.append(
+            OKFViolation(
+                "markdown_total_size_limit",
+                root.as_posix(),
+                f"Bundle exceeds the maximum of {OKF_MAX_MARKDOWN_TOTAL_BYTES} Markdown bytes",
+            )
+        )
+    return files, preflight, violations
+
+
+def _read_markdown_files(
+    root: Path,
+    preflight: list[tuple[str, Path]],
+) -> tuple[list[tuple[str, str]], list[OKFViolation]]:
+    documents: list[tuple[str, str]] = []
+    violations: list[OKFViolation] = []
+    actual_total_bytes = 0
+    for relative_path, markdown_file in preflight:
+        aggregate_remaining = OKF_MAX_MARKDOWN_TOTAL_BYTES - actual_total_bytes
+        read_limit = min(OKF_MAX_MARKDOWN_FILE_BYTES, aggregate_remaining)
+        try:
+            with markdown_file.open("rb") as handle:
+                raw = handle.read(read_limit + 1)
+        except OSError as exc:
+            violations.append(OKFViolation("utf8_read", relative_path, str(exc)))
+            break
+        if len(raw) > read_limit:
+            if aggregate_remaining < OKF_MAX_MARKDOWN_FILE_BYTES:
+                violation = OKFViolation(
+                    "markdown_total_size_limit",
+                    root.as_posix(),
+                    f"Bundle exceeds the maximum of {OKF_MAX_MARKDOWN_TOTAL_BYTES} Markdown bytes",
+                )
+            else:
+                violation = OKFViolation(
+                    "markdown_file_size_limit",
+                    relative_path,
+                    f"File exceeds the maximum of {OKF_MAX_MARKDOWN_FILE_BYTES} bytes",
+                )
+            violations.append(violation)
+            break
+        actual_total_bytes += len(raw)
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeError as exc:
+            violations.append(OKFViolation("utf8_read", relative_path, str(exc)))
+            break
+        documents.append((relative_path, text))
+    return documents, violations
+
+
+def read_bounded_markdown_bundle(path: Path) -> OKFMarkdownBundleRead:
+    """Enumerate, preflight, and read one Markdown bundle within fixed limits."""
+    try:
+        root, markdown_files, enumeration_violation = _markdown_files(path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        violation = OKFViolation("path_unreadable", path.as_posix(), str(exc))
+        return OKFMarkdownBundleRead(None, (), (), (violation,))
+    if enumeration_violation is not None:
+        return OKFMarkdownBundleRead(root, (), (), (enumeration_violation,))
+
+    files, preflight, violations = _preflight_markdown_files(root, markdown_files)
+    if violations:
+        return OKFMarkdownBundleRead(root, tuple(files), (), tuple(violations))
+    documents, violations = _read_markdown_files(root, preflight)
+    if violations:
+        return OKFMarkdownBundleRead(root, tuple(files), (), tuple(violations))
+    return OKFMarkdownBundleRead(root, tuple(files), tuple(documents), ())
+
+
+def _validate_index(
+    relative_path: str,
+    text: str,
+    parsed: ParsedFrontmatter,
+    *,
+    expected_version: str,
+) -> tuple[list[OKFViolation], str | None]:
+    violations: list[OKFViolation] = []
+    if parsed.error:
+        violations.append(OKFViolation("invalid_reserved_frontmatter", relative_path, parsed.error))
+        return violations, None
+    if relative_path != "index.md" and parsed.present:
+        violations.append(
+            OKFViolation(
+                "nested_index_frontmatter",
+                relative_path,
+                "Only the bundle-root index.md may contain frontmatter",
+            )
+        )
+        return violations, None
+    if not parsed.present:
+        compatibility_parse = parse_markdown_frontmatter(text, allow_leading_comments=True)
+        if compatibility_parse.present:
+            violations.append(
+                OKFViolation(
+                    "index_frontmatter_position",
+                    relative_path,
+                    "Root index.md frontmatter must start on the first line",
+                )
+            )
+        return violations, None
+
+    unknown = sorted(str(key) for key in parsed.fields if key != "okf_version")
+    if unknown:
+        violations.append(
+            OKFViolation(
+                "root_index_frontmatter_keys",
+                relative_path,
+                f"Root index.md frontmatter may contain only okf_version; found: {', '.join(unknown)}",
+            )
+        )
+    raw_version = parsed.fields.get("okf_version")
+    declared_version = raw_version if isinstance(raw_version, str) else None
+    if declared_version != expected_version:
+        violations.append(
+            OKFViolation(
+                "okf_version",
+                relative_path,
+                f"Expected okf_version {expected_version!r}, found {declared_version or '(missing)'!r}",
+            )
+        )
+    return violations, declared_version
+
+
+def _markdown_h2_lines(text: str) -> list[str]:
+    headings: list[str] = []
+    fence_character = ""
+    fence_length = 0
+    for line in text.splitlines():
+        if fence_character:
+            stripped = line.lstrip(" ")
+            if (
+                len(line) - len(stripped) <= 3
+                and stripped.startswith(fence_character * fence_length)
+                and not stripped.rstrip().strip(fence_character)
+            ):
+                fence_character = ""
+                fence_length = 0
+            continue
+        if fence := _FENCE_RE.fullmatch(line):
+            fence_character = fence.group(1)[0]
+            fence_length = len(fence.group(1))
+            continue
+        stripped = line.lstrip(" ")
+        if len(line) - len(stripped) <= 3 and stripped.startswith("## "):
+            headings.append(stripped)
+    return headings
+
+
+def _validate_log(relative_path: str, text: str, parsed: ParsedFrontmatter) -> list[OKFViolation]:
+    violations: list[OKFViolation] = []
+    if parsed.present:
+        detail = parsed.error or "log.md must not contain frontmatter"
+        violations.append(OKFViolation("log_frontmatter", relative_path, detail))
+
+    headings: list[str] = []
+    for heading in _markdown_h2_lines(text):
+        match = _DATE_HEADING_RE.fullmatch(heading)
+        if match is None:
+            violations.append(
+                OKFViolation(
+                    "log_date_heading",
+                    relative_path,
+                    f"Log level-two heading must use YYYY-MM-DD: {heading}",
+                )
+            )
+        else:
+            heading_date = match.group(1)
+            try:
+                date.fromisoformat(heading_date)
+            except ValueError:
+                violations.append(
+                    OKFViolation(
+                        "log_date_heading",
+                        relative_path,
+                        f"Log level-two heading is not a calendar date: {heading_date}",
+                    )
+                )
+            else:
+                headings.append(heading_date)
+    if headings != sorted(headings, reverse=True):
+        violations.append(
+            OKFViolation(
+                "log_date_order",
+                relative_path,
+                "Log date headings must be newest first",
+            )
+        )
+    return violations
+
+
+def _validate_concept(relative_path: str, parsed: ParsedFrontmatter) -> list[OKFViolation]:
+    if not parsed.present:
+        return [
+            OKFViolation(
+                "concept_frontmatter",
+                relative_path,
+                "Concept frontmatter must begin on the first line",
+            )
+        ]
+    if parsed.error:
+        return [OKFViolation("concept_frontmatter", relative_path, parsed.error)]
+    concept_type = parsed.fields.get("type")
+    if not isinstance(concept_type, str) or not concept_type.strip():
+        return [
+            OKFViolation(
+                "concept_type",
+                relative_path,
+                "Concept frontmatter requires a non-empty string type",
+            )
+        ]
+    return []
+
+
+def portable_relative_path_failure(normalized: str) -> str | None:
+    """Return why a normalized bundle path is not portable, if applicable."""
+    raw_parts = normalized.split("/")
+    if not normalized or normalized.endswith("/") or any(part in {"", ".", ".."} for part in raw_parts):
+        return "Document path must name a file without empty, dot, or parent segments"
+    if any(any(ord(character) < 32 or ord(character) == 127 for character in part) for part in raw_parts):
+        return "Document path must not contain control characters"
+    if any(":" in part or part.endswith((" ", ".")) for part in raw_parts):
+        return "Document path must not contain ADS separators or trailing spaces or dots"
+    for part in raw_parts:
+        device_stem = part.rstrip(" .").split(".", 1)[0].upper()
+        if device_stem in _WINDOWS_DEVICE_NAMES:
+            return f"Document path uses reserved Windows device name {device_stem}"
+    windows_path = PureWindowsPath(normalized)
+    pure_path = PurePosixPath(normalized)
+    if pure_path.is_absolute() or windows_path.is_absolute() or windows_path.drive:
+        return "Document path must be relative and remain inside the bundle"
+    return None
+
+
+def validate_okf_documents(
+    documents: Mapping[str, str],
+    *,
+    expected_version: str = OKF_VERSION,
+) -> OKFBundleValidation:
+    """Validate an in-memory bundle before any generated file is written."""
+    files: list[str] = []
+    violations: list[OKFViolation] = []
+    declared_version: str | None = None
+    normalized_paths: dict[str, str] = {}
+    for raw_path, text in sorted(documents.items()):
+        normalized = str(raw_path).replace("\\", "/")
+        pure_path = PurePosixPath(normalized)
+        if path_failure := portable_relative_path_failure(normalized):
+            violations.append(
+                OKFViolation(
+                    "path_outside_bundle",
+                    normalized,
+                    path_failure,
+                )
+            )
+            continue
+        relative_path = pure_path.as_posix()
+        collision_key = relative_path.casefold()
+        if previous := normalized_paths.get(collision_key):
+            violations.append(
+                OKFViolation(
+                    "path_collision",
+                    relative_path,
+                    f"Document path collides with {previous!r} after portable normalization",
+                )
+            )
+            continue
+        normalized_paths[collision_key] = relative_path
+        if pure_path.suffix.lower() != ".md":
+            continue
+        files.append(relative_path)
+        parsed = parse_markdown_frontmatter(text)
+        if pure_path.name == "index.md":
+            index_violations, index_version = _validate_index(
+                relative_path,
+                text,
+                parsed,
+                expected_version=expected_version,
+            )
+            violations.extend(index_violations)
+            if relative_path == "index.md" and index_version is not None:
+                declared_version = index_version
+        elif pure_path.name == "log.md":
+            violations.extend(_validate_log(relative_path, text, parsed))
+        else:
+            violations.extend(_validate_concept(relative_path, parsed))
+
+    return OKFBundleValidation(
+        files=tuple(files),
+        violations=tuple(violations),
+        declared_version=declared_version,
+    )
+
+
+def validate_okf_bundle(path: Path, *, expected_version: str = OKF_VERSION) -> OKFBundleValidation:
+    """Validate the hard OKF 0.2 bundle rules without model or network calls."""
+    bundle_read = read_bounded_markdown_bundle(path)
+    if bundle_read.violations:
+        return OKFBundleValidation(
+            files=bundle_read.files,
+            violations=bundle_read.violations,
+            declared_version=None,
+        )
+
+    content_result = validate_okf_documents(dict(bundle_read.documents), expected_version=expected_version)
+
+    return OKFBundleValidation(
+        files=bundle_read.files,
+        violations=content_result.violations,
+        declared_version=content_result.declared_version,
+    )
+
+
+__all__ = [
+    "OKF_MAX_MARKDOWN_FILES",
+    "OKF_MAX_MARKDOWN_FILE_BYTES",
+    "OKF_MAX_MARKDOWN_TOTAL_BYTES",
+    "OKF_VERSION",
+    "OKFBundleValidation",
+    "OKFMarkdownBundleRead",
+    "OKFViolation",
+    "ParsedFrontmatter",
+    "parse_markdown_frontmatter",
+    "portable_relative_path_failure",
+    "read_bounded_markdown_bundle",
+    "validate_okf_bundle",
+    "validate_okf_documents",
+]

--- a/src/deepr/experts/okf_publication.py
+++ b/src/deepr/experts/okf_publication.py
@@ -1,0 +1,567 @@
+"""Transactional publication for dedicated Deepr OKF export roots.
+
+An OKF export root is a generated artifact, not a mixed-purpose directory. Each
+publication carries an exact manifest of generated relative paths and content
+hashes. Replacement is performed by sibling directory renames so no generated
+file is written or deleted through a previously checked mutable parent path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+from typing import Any
+from uuid import uuid4
+
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
+from deepr.experts.okf_contract import portable_relative_path_failure
+from deepr.utils.atomic_io import atomic_write_text
+
+OKF_PUBLICATION_SCHEMA_VERSION = "deepr-okf-publication-v1"
+OKF_PUBLICATION_MANIFEST = ".deepr-okf-manifest.json"
+_RECOVERY_SCHEMA_VERSION = "deepr-okf-recovery-v1"
+_MAX_MANIFEST_BYTES = 1024 * 1024
+_WINDOWS_DEVICE_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{number}" for number in range(1, 10)}
+    | {f"LPT{number}" for number in range(1, 10)}
+)
+
+
+class OKFPublicationError(ValueError):
+    """An OKF directory could not be published without risking user data."""
+
+
+@dataclass(frozen=True)
+class _PathIdentity:
+    device: int
+    inode: int
+    mode: int
+
+
+@dataclass(frozen=True)
+class _TreeInventory:
+    files: dict[str, Path]
+    directories: frozenset[str]
+    links: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _RecoveryRecord:
+    target: str
+    prior: _PathIdentity
+    staged: _PathIdentity
+
+
+def _lexists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def _is_link_like(path: Path) -> bool:
+    return path.is_symlink() or path.is_junction()
+
+
+def _path_identity(path: Path) -> _PathIdentity:
+    result = os.lstat(path)
+    return _PathIdentity(result.st_dev, result.st_ino, result.st_mode)
+
+
+def _rename_path(source: Path, destination: Path) -> None:
+    os.replace(source, destination)
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return sha256(content).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validated_relative_path(value: Any) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise OKFPublicationError("OKF publication manifest contains an invalid relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise OKFPublicationError(f"OKF publication manifest path escapes its root: {value!r}")
+    if path_failure := portable_relative_path_failure(value):
+        raise OKFPublicationError(f"OKF publication manifest path is not portable: {value!r}: {path_failure}")
+    if value == OKF_PUBLICATION_MANIFEST:
+        raise OKFPublicationError("OKF publication manifest cannot list itself as generated content")
+    return path.as_posix()
+
+
+def _manifest_payload(files: Mapping[str, str], *, okf_version: str) -> tuple[dict[str, Any], str]:
+    entries = []
+    collision_keys: set[str] = set()
+    for raw_path, content in sorted(files.items()):
+        relative_path = _validated_relative_path(raw_path)
+        collision_key = relative_path.casefold()
+        if collision_key in collision_keys:
+            raise OKFPublicationError(f"OKF publication paths collide portably: {relative_path!r}")
+        collision_keys.add(collision_key)
+        entries.append(
+            {
+                "path": relative_path,
+                "sha256": _sha256_bytes(content.encode("utf-8")),
+            }
+        )
+    payload = {
+        "schema_version": OKF_PUBLICATION_SCHEMA_VERSION,
+        "okf_version": okf_version,
+        "files": entries,
+    }
+    return payload, json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _read_manifest_payload(root: Path) -> dict[str, Any]:
+    manifest_path = root / OKF_PUBLICATION_MANIFEST
+    if not _lexists(manifest_path) or _is_link_like(manifest_path) or not manifest_path.is_file():
+        raise OKFPublicationError(
+            "OKF export root is not owned by an exact Deepr publication manifest. "
+            "Use --force only to replace the entire dedicated export root."
+        )
+    if manifest_path.stat().st_size > _MAX_MANIFEST_BYTES:
+        raise OKFPublicationError("OKF publication manifest exceeds the supported size limit")
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise OKFPublicationError(f"OKF publication manifest is unreadable: {exc}") from exc
+    if not isinstance(payload, dict) or set(payload) != {"schema_version", "okf_version", "files"}:
+        raise OKFPublicationError("OKF publication manifest has an unsupported structure")
+    return payload
+
+
+def _manifest_entries(entries: Any) -> dict[str, str]:
+    if not isinstance(entries, list):
+        raise OKFPublicationError("OKF publication manifest files must be a list")
+    expected: dict[str, str] = {}
+    collision_keys: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {"path", "sha256"}:
+            raise OKFPublicationError("OKF publication manifest contains an invalid file entry")
+        relative_path = _validated_relative_path(entry.get("path"))
+        digest = entry.get("sha256")
+        collision_key = relative_path.casefold()
+        if collision_key in collision_keys or not isinstance(digest, str) or len(digest) != 64:
+            raise OKFPublicationError("OKF publication manifest contains a duplicate path or invalid hash")
+        try:
+            int(digest, 16)
+        except ValueError as exc:
+            raise OKFPublicationError("OKF publication manifest contains a non-hexadecimal hash") from exc
+        collision_keys.add(collision_key)
+        expected[relative_path] = digest.lower()
+    return expected
+
+
+def _parse_manifest(root: Path, *, okf_version: str) -> dict[str, str]:
+    payload = _read_manifest_payload(root)
+    if payload.get("schema_version") != OKF_PUBLICATION_SCHEMA_VERSION:
+        raise OKFPublicationError("OKF publication manifest uses an unsupported schema version")
+    if payload.get("okf_version") != okf_version:
+        raise OKFPublicationError("OKF publication manifest targets a different OKF version")
+    return _manifest_entries(payload.get("files"))
+
+
+def _inventory_tree(root: Path) -> _TreeInventory:
+    files: dict[str, Path] = {}
+    directories: set[str] = set()
+    links: set[str] = set()
+
+    def visit(directory: Path, prefix: PurePosixPath) -> None:
+        with os.scandir(directory) as entries:
+            ordered = sorted(entries, key=lambda entry: entry.name.casefold())
+        for entry in ordered:
+            relative = (prefix / entry.name).as_posix()
+            path = Path(entry.path)
+            if entry.is_symlink() or path.is_junction():
+                links.add(relative)
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                directories.add(relative)
+                visit(path, prefix / entry.name)
+                continue
+            if entry.is_file(follow_symlinks=False):
+                files[relative] = path
+                continue
+            links.add(relative)
+
+    visit(root, PurePosixPath())
+    return _TreeInventory(files=files, directories=frozenset(directories), links=frozenset(links))
+
+
+def _validate_owned_root(root: Path, *, okf_version: str) -> None:
+    if _is_link_like(root) or not root.is_dir():
+        raise OKFPublicationError(
+            "Existing OKF output is not a manifest-owned directory. "
+            "Use --force only to replace the entire dedicated export root."
+        )
+    expected = _parse_manifest(root, okf_version=okf_version)
+    inventory = _inventory_tree(root)
+    if inventory.links:
+        detail = ", ".join(sorted(inventory.links)[:5])
+        raise OKFPublicationError(f"OKF export root contains unmanaged link or special entries: {detail}")
+
+    expected_files = set(expected)
+    actual_files = set(inventory.files) - {OKF_PUBLICATION_MANIFEST}
+    unmanaged_files = sorted(actual_files - expected_files)
+    missing_files = sorted(expected_files - actual_files)
+    expected_directories = {
+        parent.as_posix()
+        for relative_path in expected_files
+        for parent in PurePosixPath(relative_path).parents
+        if parent.as_posix() != "."
+    }
+    unmanaged_directories = sorted(set(inventory.directories) - expected_directories)
+    if unmanaged_files or unmanaged_directories:
+        detail = ", ".join([*unmanaged_files, *unmanaged_directories][:5])
+        raise OKFPublicationError(
+            "OKF export root contains unmanaged Markdown or other content. "
+            "It is a dedicated derived export root: " + detail
+        )
+    if missing_files:
+        raise OKFPublicationError(f"OKF export root is missing generated files: {', '.join(missing_files[:5])}")
+
+    modified = [
+        relative_path
+        for relative_path, expected_digest in expected.items()
+        if _sha256_file(inventory.files[relative_path]) != expected_digest
+    ]
+    if modified:
+        raise OKFPublicationError(
+            "OKF export root contains modified generated files. Use --force only to replace the entire root: "
+            + ", ".join(modified[:5])
+        )
+
+
+def _remove_tree_no_follow(path: Path) -> None:
+    if not _lexists(path):
+        return
+    if path.is_symlink():
+        path.unlink()
+        return
+    if path.is_junction():
+        path.rmdir()
+        return
+    mode = os.lstat(path).st_mode
+    if not stat.S_ISDIR(mode):
+        path.unlink()
+        return
+    with os.scandir(path) as entries:
+        children = [Path(entry.path) for entry in entries]
+    for child in children:
+        _remove_tree_no_follow(child)
+    path.rmdir()
+
+
+def _build_staging_directory(parent: Path, root_name: str, files: Mapping[str, str], manifest_text: str) -> Path:
+    staging = Path(tempfile.mkdtemp(prefix=f".{root_name}.staging-", dir=parent))
+    try:
+        for relative_path, content in sorted(files.items()):
+            target = staging.joinpath(*PurePosixPath(relative_path).parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(target, content)
+        atomic_write_text(staging / OKF_PUBLICATION_MANIFEST, manifest_text)
+    except Exception:
+        _remove_tree_no_follow(staging)
+        raise
+    return staging
+
+
+def _restore_prior_root(root: Path, recovery: Path, prior_identity: _PathIdentity) -> None:
+    if _path_identity(recovery) != prior_identity:
+        raise OKFPublicationError("Prior OKF export identity changed before rollback; automatic cleanup was refused")
+    displaced: Path | None = None
+    if _lexists(root):
+        displaced = root.parent / f".{root.name}.failed-{uuid4().hex}"
+        _rename_path(root, displaced)
+    try:
+        _rename_path(recovery, root)
+        if _path_identity(root) != prior_identity:
+            raise OKFPublicationError("Prior OKF export identity changed during rollback")
+    except Exception:
+        if displaced is not None and not _lexists(root) and _lexists(displaced):
+            _rename_path(displaced, root)
+        raise
+    if displaced is not None:
+        _remove_tree_no_follow(displaced)
+
+
+def _identity_payload(identity: _PathIdentity) -> dict[str, int]:
+    return {"device": identity.device, "inode": identity.inode, "mode": identity.mode}
+
+
+def _identity_from_payload(value: Any) -> _PathIdentity:
+    if not isinstance(value, dict) or set(value) != {"device", "inode", "mode"}:
+        raise OKFPublicationError("OKF recovery journal contains an invalid path identity")
+    if any(not isinstance(value[key], int) for key in ("device", "inode", "mode")):
+        raise OKFPublicationError("OKF recovery journal contains a non-integer path identity")
+    return _PathIdentity(value["device"], value["inode"], value["mode"])
+
+
+def _write_recovery_record(path: Path, record: _RecoveryRecord) -> None:
+    payload = {
+        "schema_version": _RECOVERY_SCHEMA_VERSION,
+        "target": record.target,
+        "prior": _identity_payload(record.prior),
+        "staged": _identity_payload(record.staged),
+    }
+    atomic_write_text(path, json.dumps(payload, sort_keys=True) + "\n", fsync=True, overwrite=False)
+
+
+def _read_recovery_record(path: Path) -> _RecoveryRecord:
+    if _is_link_like(path) or not path.is_file() or path.stat().st_size > _MAX_MANIFEST_BYTES:
+        raise OKFPublicationError("OKF recovery journal is not a bounded regular file")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise OKFPublicationError(f"OKF recovery journal is unreadable: {exc}") from exc
+    if not isinstance(payload, dict) or set(payload) != {"schema_version", "target", "prior", "staged"}:
+        raise OKFPublicationError("OKF recovery journal has an unsupported structure")
+    if payload["schema_version"] != _RECOVERY_SCHEMA_VERSION or not isinstance(payload["target"], str):
+        raise OKFPublicationError("OKF recovery journal has an unsupported version or target")
+    return _RecoveryRecord(
+        target=payload["target"],
+        prior=_identity_from_payload(payload["prior"]),
+        staged=_identity_from_payload(payload["staged"]),
+    )
+
+
+def _remove_recovery_journal(path: Path) -> None:
+    if not _lexists(path):
+        return
+    if _is_link_like(path) or not path.is_file():
+        raise OKFPublicationError("OKF recovery journal changed before cleanup")
+    path.unlink()
+
+
+def _reconcile_recovery(root: Path, recovery: Path, journal: Path) -> None:
+    if not _lexists(journal):
+        if _lexists(recovery):
+            raise OKFPublicationError(
+                f"Reserved OKF recovery path already exists without a recovery journal: {recovery}"
+            )
+        return
+    record = _read_recovery_record(journal)
+    if os.path.normcase(record.target) != os.path.normcase(str(root)):
+        raise OKFPublicationError("OKF recovery journal targets a different export root")
+
+    root_identity = _path_identity(root) if _lexists(root) else None
+    recovery_identity = _path_identity(recovery) if _lexists(recovery) else None
+    if recovery_identity is not None and recovery_identity != record.prior:
+        raise OKFPublicationError("Recoverable OKF root identity no longer matches its journal")
+    if recovery_identity is not None and root_identity is None:
+        _rename_path(recovery, root)
+        if _path_identity(root) != record.prior:
+            raise OKFPublicationError("Recoverable OKF root identity changed during restoration")
+        _remove_recovery_journal(journal)
+        return
+    if recovery_identity is not None and root_identity == record.staged:
+        _remove_tree_no_follow(recovery)
+        _remove_recovery_journal(journal)
+        return
+    if recovery_identity is None and root_identity in {record.prior, record.staged}:
+        _remove_recovery_journal(journal)
+        return
+    raise OKFPublicationError("OKF recovery state is ambiguous; automatic mutation was refused")
+
+
+def _install_staging(root: Path, staging: Path, staging_identity: _PathIdentity) -> None:
+    _rename_path(staging, root)
+    if _path_identity(root) != staging_identity:
+        raise OKFPublicationError("Staged OKF export identity changed during publication")
+
+
+def _rollback_publication(
+    root: Path,
+    recovery: Path,
+    journal: Path,
+    prior_identity: _PathIdentity,
+) -> None:
+    if _lexists(recovery):
+        _restore_prior_root(root, recovery, prior_identity)
+    elif not _lexists(root) or _path_identity(root) != prior_identity:
+        raise OKFPublicationError("Prior OKF export could not be located for rollback")
+    _remove_recovery_journal(journal)
+
+
+def _publish_staging(
+    root: Path,
+    staging: Path,
+    recovery: Path,
+    journal: Path,
+    *,
+    force: bool,
+    okf_version: str,
+) -> None:
+    prior_exists = _lexists(root)
+    staging_identity = _path_identity(staging)
+    if not prior_exists:
+        _install_staging(root, staging, staging_identity)
+        return
+
+    prior_identity = _path_identity(root)
+    if not force:
+        _validate_owned_root(root, okf_version=okf_version)
+        if _path_identity(root) != prior_identity:
+            raise OKFPublicationError("OKF export root changed while its publication manifest was verified")
+
+    record = _RecoveryRecord(str(root), prior_identity, staging_identity)
+    _write_recovery_record(journal, record)
+    try:
+        _rename_path(root, recovery)
+        if _path_identity(recovery) != prior_identity:
+            _restore_prior_root(root, recovery, prior_identity)
+            raise OKFPublicationError("OKF export root identity changed during publication")
+        if not force:
+            _validate_owned_root(recovery, okf_version=okf_version)
+        _install_staging(root, staging, staging_identity)
+    except Exception as exc:
+        try:
+            _rollback_publication(root, recovery, journal, prior_identity)
+        except Exception as restore_exc:
+            raise OKFPublicationError(
+                f"OKF publication failed and the prior root could not be restored: {restore_exc}"
+            ) from exc
+        raise
+
+    if _path_identity(recovery) != prior_identity:
+        raise OKFPublicationError("Prior OKF export identity changed before cleanup; cleanup was refused")
+    _remove_tree_no_follow(recovery)
+    _remove_recovery_journal(journal)
+
+
+def _validate_portable_root_name(name: str) -> None:
+    reserved_stem = name.split(".", 1)[0].rstrip(" .").upper()
+    invalid_character = any(ord(character) < 32 or character in '<>:"/\\|?*' for character in name)
+    if (
+        name in {"", ".", ".."}
+        or name.rstrip(" .") != name
+        or reserved_stem in _WINDOWS_DEVICE_NAMES
+        or invalid_character
+    ):
+        raise OKFPublicationError(f"OKF output uses a non-portable directory name: {name!r}")
+
+
+def _real_directory(path: Path) -> None:
+    if _is_link_like(path):
+        raise OKFPublicationError(f"Links are not accepted in the requested OKF output parent: {path}")
+    if not stat.S_ISDIR(os.lstat(path).st_mode):
+        raise OKFPublicationError(f"OKF output parent component is not a directory: {path}")
+
+
+def _parent_components(path: Path) -> list[Path]:
+    current = Path(path.anchor)
+    components = [current]
+    for part in path.parts[1:]:
+        current = current / part
+        components.append(current)
+    return components
+
+
+def _checked_output_parent(requested: Path) -> Path:
+    if ".." in requested.parts:
+        raise OKFPublicationError("OKF output path cannot contain parent traversal components")
+    absolute = requested if requested.is_absolute() else Path.cwd() / requested
+    parent = absolute.parent
+    identities: list[tuple[Path, _PathIdentity]] = []
+    for component in _parent_components(parent):
+        if not _lexists(component):
+            component.mkdir()
+        _real_directory(component)
+        identities.append((component, _path_identity(component)))
+    resolved = parent.resolve(strict=True)
+    if any(_path_identity(component) != identity for component, identity in identities):
+        raise OKFPublicationError("OKF output parent changed while its components were verified")
+    return resolved
+
+
+def _secure_coordination_directory() -> Path:
+    base = Path(tempfile.gettempdir()).resolve(strict=True)
+    directory = base / "deepr-okf-publication-locks"
+    directory.mkdir(mode=0o700, exist_ok=True)
+    _real_directory(directory)
+    if os.name != "nt":
+        result = os.lstat(directory)
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None and result.st_uid != getuid():
+            raise OKFPublicationError("OKF coordination directory is not owned by the current user")
+        if stat.S_IMODE(result.st_mode) & 0o077:
+            directory.chmod(0o700)
+    return directory.resolve(strict=True)
+
+
+def _coordination_paths(root: Path) -> tuple[Path, Path]:
+    directory = _secure_coordination_directory()
+    key = sha256(os.fsencode(os.path.normcase(str(root)))).hexdigest()
+    lock_path = directory / f"{key}.lock"
+    journal_path = directory / f"{key}.recovery.json"
+    if _lexists(lock_path) and (_is_link_like(lock_path) or not lock_path.is_file()):
+        raise OKFPublicationError("OKF coordination lock path is not a regular file")
+    return lock_path, journal_path
+
+
+def publish_okf_directory(
+    files: Mapping[str, str],
+    output_dir: Path,
+    *,
+    force: bool,
+    okf_version: str,
+) -> Path:
+    """Publish a complete OKF directory transaction under a sibling lock.
+
+    Existing output must match its exact publication manifest unless ``force``
+    is set. Force replaces the complete dedicated export root, not individual
+    files. Link entries are renamed with the prior root and removed without
+    traversing their targets.
+    """
+    requested = Path(output_dir)
+    _validate_portable_root_name(requested.name)
+    _, manifest_text = _manifest_payload(files, okf_version=okf_version)
+    parent = _checked_output_parent(requested)
+    root = parent / requested.name
+    lock_path, journal_path = _coordination_paths(root)
+    recovery = parent / f".{root.name}.deepr-okf-recovery"
+    staging: Path | None = None
+    try:
+        with FileLock(str(lock_path), timeout=10, thread_local=False):
+            parent_identity = _path_identity(parent)
+            _reconcile_recovery(root, recovery, journal_path)
+            staging = _build_staging_directory(parent, root.name, files, manifest_text)
+            if _path_identity(parent) != parent_identity:
+                raise OKFPublicationError("OKF output parent changed while staging the publication")
+            _publish_staging(
+                root,
+                staging,
+                recovery,
+                journal_path,
+                force=force,
+                okf_version=okf_version,
+            )
+            staging = None
+    except FileLockTimeout as exc:
+        raise OKFPublicationError(f"Timed out waiting for the OKF export lock for {root}") from exc
+    finally:
+        if staging is not None and _lexists(staging):
+            _remove_tree_no_follow(staging)
+    return root
+
+
+__all__ = [
+    "OKF_PUBLICATION_MANIFEST",
+    "OKF_PUBLICATION_SCHEMA_VERSION",
+    "OKFPublicationError",
+    "publish_okf_directory",
+]

--- a/src/deepr/experts/report_absorber.py
+++ b/src/deepr/experts/report_absorber.py
@@ -47,6 +47,7 @@ import json
 import logging
 import os
 from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
 from math import isfinite
 from typing import TYPE_CHECKING, Any
 
@@ -622,6 +623,7 @@ class ReportAbsorber:
                 flagged.append(GroundingFlag(belief.claim, verdict.checker_vendor, verdict.reason))
         if verdict.supported is True:
             belief.grounding_assurance = verdict.assurance.value
+            belief.grounding_verified_at = datetime.now(UTC)
         elif verdict.refuted:
             flagged.append(GroundingFlag(belief.claim, verdict.checker_vendor, verdict.reason))
             return False

--- a/tests/fixtures/standards/manifest.json
+++ b/tests/fixtures/standards/manifest.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "deepr-standards-fixture-manifest-v1",
+  "standards": [
+    {
+      "name": "Open Knowledge Format",
+      "version": "0.2",
+      "canonical_identifier": "https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/3fcbb9f828c2f23d109c855ee403c3a4c81f3a96/okf/SPEC.md",
+      "retrieved_at": "2026-08-20",
+      "sha256": "5a3311d270bebb16d558010e75064f5b75323f284992641732b1c8097511f948",
+      "fixture_root": "okf-0.2"
+    }
+  ]
+}

--- a/tests/fixtures/standards/okf-0.2/legacy-invalid/concept.md
+++ b/tests/fixtures/standards/okf-0.2/legacy-invalid/concept.md
@@ -1,0 +1,6 @@
+<!-- deepr:okf derived-view regenerable -->
+---
+type: deepr.okf.concept
+timestamp: 2026-08-20T12:00:00Z
+---
+# Legacy concept

--- a/tests/fixtures/standards/okf-0.2/legacy-invalid/index.md
+++ b/tests/fixtures/standards/okf-0.2/legacy-invalid/index.md
@@ -1,0 +1,6 @@
+<!-- deepr:okf derived-view regenerable -->
+---
+type: deepr.okf.index
+timestamp: 2026-08-20T12:00:00Z
+---
+# Legacy index

--- a/tests/fixtures/standards/okf-0.2/legacy-invalid/log.md
+++ b/tests/fixtures/standards/okf-0.2/legacy-invalid/log.md
@@ -1,0 +1,5 @@
+---
+type: deepr.okf.log
+timestamp: 2026-08-20T12:00:00Z
+---
+# Legacy log

--- a/tests/fixtures/standards/okf-0.2/valid/concepts/orders.md
+++ b/tests/fixtures/standards/okf-0.2/valid/concepts/orders.md
@@ -1,0 +1,20 @@
+---
+type: BigQuery Table
+title: Customer Orders
+description: One row per completed customer order.
+tags: [sales, orders]
+generated: { by: process:deepr-fixture, at: 2026-08-20T12:00:00Z }
+verified: { by: process:fixture-review, at: 2026-08-20T13:00:00Z }
+sources:
+  - id: orders-contract
+    resource: https://example.test/orders-contract
+fixture_extension:
+  preserved: true
+---
+# Orders
+
+Each row represents one completed order.[^orders-contract]
+
+This deliberately broken [future link](future.md) remains consumable.
+
+[^orders-contract]: Orders contract

--- a/tests/fixtures/standards/okf-0.2/valid/index.md
+++ b/tests/fixtures/standards/okf-0.2/valid/index.md
@@ -1,0 +1,6 @@
+---
+okf_version: "0.2"
+---
+# Example bundle
+
+* [Orders](concepts/orders.md) - One row per completed order.

--- a/tests/fixtures/standards/okf-0.2/valid/log.md
+++ b/tests/fixtures/standards/okf-0.2/valid/log.md
@@ -1,0 +1,9 @@
+# Example bundle log
+
+## 2026-08-20
+
+* **Update**: Added provenance metadata to [Orders](concepts/orders.md).
+
+## 2026-08-19
+
+* **Creation**: Created the example bundle.

--- a/tests/unit/test_belief_revision.py
+++ b/tests/unit/test_belief_revision.py
@@ -267,6 +267,23 @@ class TestBeliefStore:
         assert change.new_claim == "New claim"
         assert store.beliefs[added.id].claim == "New claim"
 
+    def test_revise_belief_clears_verification_for_changed_claim(self, tmp_path):
+        store = BeliefStore(expert_name="test", storage_dir=tmp_path / "beliefs")
+        checked_at = datetime(2026, 8, 20, tzinfo=UTC)
+        belief = Belief(
+            claim="Old verified claim",
+            confidence=0.8,
+            grounding_assurance="cross_vendor",
+            grounding_verified_at=checked_at,
+        )
+        added, _ = store.add_belief(belief)
+
+        store.revise_belief(added.id, "Changed claim", 0.8, "New evidence")
+
+        revised = store.beliefs[added.id]
+        assert revised.grounding_assurance == "unverified"
+        assert revised.grounding_verified_at is None
+
     def test_archive_belief(self, tmp_path):
         """Test archiving a belief."""
         store = BeliefStore(expert_name="test", storage_dir=tmp_path / "beliefs")

--- a/tests/unit/test_cli/test_expert_okf.py
+++ b/tests/unit/test_cli/test_expert_okf.py
@@ -55,6 +55,7 @@ def test_export_okf_writes_bundle_json(monkeypatch, tmp_path):
     payload = json.loads(result.output)
     assert payload["concept_count"] == 0
     assert payload["schema_version"] == "deepr-okf-v1"
+    assert payload["okf_version"] == "0.2"
     assert (output / "index.md").exists()
     assert (output / "llms.txt").exists()
 
@@ -123,7 +124,7 @@ def test_absorb_okf_local_dry_run_routes_parsed_text_to_absorber(monkeypatch, tm
 
     assert result.exit_code == 0
     payload = json.loads(result.output)
-    assert payload["okf"]["concept_count"] == 1
+    assert payload["okf"]["concept_count"] == 3
     assert payload["absorption"]["dry_run"] is True
     assert captured["model"] == "qwen-profile"
     assert captured["estimated_cost"] == 0.0

--- a/tests/unit/test_experts/test_corroboration_trust.py
+++ b/tests/unit/test_experts/test_corroboration_trust.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from deepr.experts.beliefs import Belief, BeliefStore, ConflictResolution
 from deepr.experts.report_absorber import ReportAbsorber
 
@@ -89,6 +91,89 @@ def test_corroboration_upgrades_trust_class_to_secondary(tmp_path) -> None:
     stored, _ = store.add_belief(second, dedup=True)
     assert stored.trust_class == "secondary"
     assert stored.get_current_confidence() == 0.9
+
+
+def test_exact_claim_corroboration_preserves_strongest_complete_verification(tmp_path) -> None:
+    store = BeliefStore("t", storage_dir=tmp_path / "beliefs")
+    store.conflict_resolution = ConflictResolution.HIGHER_CONFIDENCE
+    older = datetime(2026, 8, 19, tzinfo=UTC)
+    newer = datetime(2026, 8, 20, tzinfo=UTC)
+    store.add_belief(
+        Belief(
+            "Portable claims retain checker provenance",
+            0.7,
+            domain="interop",
+            grounding_assurance="same_vendor_fresh_context",
+            grounding_verified_at=older,
+        )
+    )
+    candidate = Belief(
+        "Portable claims retain checker provenance",
+        0.8,
+        domain="interop",
+        grounding_assurance="cross_vendor",
+        grounding_verified_at=newer,
+    )
+
+    stored, _ = store.add_belief(candidate)
+
+    assert (stored.grounding_assurance, stored.grounding_verified_at) == ("cross_vendor", newer)
+
+
+def test_higher_confidence_does_not_transfer_verification_between_different_claims(tmp_path) -> None:
+    store = BeliefStore("t", storage_dir=tmp_path / "beliefs")
+    store.add_belief(
+        Belief(
+            "The platform supports regulated production workloads in ten regional deployment zones under the current agreement",
+            0.9,
+            domain="capacity",
+            trust_class="secondary",
+        )
+    )
+    checked_at = datetime(2026, 8, 20, tzinfo=UTC)
+    candidate = Belief(
+        "The platform supports regulated staging workloads in ten regional deployment zones under the current agreement",
+        0.7,
+        domain="capacity",
+        trust_class="secondary",
+        grounding_assurance="cross_vendor",
+        grounding_verified_at=checked_at,
+    )
+
+    stored, _ = store.add_belief(candidate)
+
+    assert "production workloads" in stored.claim
+    assert stored.grounding_assurance == "unverified"
+    assert stored.grounding_verified_at is None
+
+
+def test_merge_does_not_transfer_verification_between_different_claims(tmp_path) -> None:
+    store = BeliefStore(
+        "t",
+        storage_dir=tmp_path / "beliefs",
+        conflict_resolution=ConflictResolution.MERGE,
+    )
+    store.add_belief(
+        Belief(
+            "The platform supports regulated production workloads in ten regional deployment zones under the current agreement",
+            0.8,
+            domain="capacity",
+        )
+    )
+    checked_at = datetime(2026, 8, 20, tzinfo=UTC)
+    candidate = Belief(
+        "The platform supports regulated staging workloads in ten regional deployment zones under the current agreement",
+        0.7,
+        domain="capacity",
+        grounding_assurance="cross_vendor",
+        grounding_verified_at=checked_at,
+    )
+
+    stored, _ = store.add_belief(candidate)
+
+    assert "production workloads" in stored.claim
+    assert stored.grounding_assurance == "unverified"
+    assert stored.grounding_verified_at is None
 
 
 def test_report_absorber_respects_trust_class_parameter() -> None:

--- a/tests/unit/test_experts/test_export_validation.py
+++ b/tests/unit/test_experts/test_export_validation.py
@@ -12,7 +12,7 @@ from deepr.experts.export_validation import (
     validate_export,
 )
 from deepr.experts.handoff import HANDOFF_KIND, HANDOFF_SCHEMA_VERSION
-from deepr.experts.okf import OKF_SCHEMA_VERSION
+from deepr.experts.okf_contract import OKF_VERSION
 
 
 def _valid_handoff_payload() -> dict:
@@ -87,32 +87,36 @@ class TestHandoffValidation:
 
 
 class TestOkfValidation:
-    def test_bundle_with_known_frontmatter_passes(self, tmp_path):
+    def test_okf_0_2_bundle_with_unknown_extensions_and_broken_link_passes(self, tmp_path):
         bundle = tmp_path / "okf"
         bundle.mkdir()
-        for name in ("index.md", "log.md"):
-            (bundle / name).write_text(
-                f"---\nschema_version: {OKF_SCHEMA_VERSION}\n---\n\n# {name}\n",
-                encoding="utf-8",
-            )
+        (bundle / "index.md").write_text(f'---\nokf_version: "{OKF_VERSION}"\n---\n# Index\n', encoding="utf-8")
+        (bundle / "log.md").write_text("# Log\n\n## 2026-08-20\n\n* **Creation**: Added concept.\n", encoding="utf-8")
+        (bundle / "concept.md").write_text(
+            "---\ntype: Unregistered Type\nproducer_extension:\n  nested: true\n---\n\nSee [future](missing.md).\n",
+            encoding="utf-8",
+        )
 
         report = validate_export(bundle)
 
         assert report["artifact_class"] == "okf_bundle"
         assert report["status"] == "valid"
 
-    def test_bundle_with_unknown_schema_version_fails(self, tmp_path):
+    def test_legacy_reserved_frontmatter_fails_okf_0_2_conformance(self, tmp_path):
         bundle = tmp_path / "okf"
         bundle.mkdir()
-        (bundle / "index.md").write_text("---\nschema_version: something-else\n---\n\n# index\n", encoding="utf-8")
-        (bundle / "log.md").write_text(f"---\nschema_version: {OKF_SCHEMA_VERSION}\n---\n\n# log\n", encoding="utf-8")
+        (bundle / "index.md").write_text(
+            "---\ntype: deepr.okf.index\ntimestamp: 2026-08-20T00:00:00Z\n---\n\n# Index\n",
+            encoding="utf-8",
+        )
+        (bundle / "log.md").write_text("---\ntype: deepr.okf.log\n---\n\n# Log\n", encoding="utf-8")
 
         report = validate_export(bundle)
 
         checks = _checks_by_name(report)
         assert report["status"] == "invalid"
-        assert checks["frontmatter_schema_versions"]["status"] == "fail"
-        assert "index.md" in checks["frontmatter_schema_versions"]["detail"]
+        assert checks["okf_0_2_conformance"]["status"] == "fail"
+        assert "index.md" in checks["okf_0_2_conformance"]["detail"]
 
 
 class TestSkillValidation:

--- a/tests/unit/test_experts/test_handoff.py
+++ b/tests/unit/test_experts/test_handoff.py
@@ -75,8 +75,9 @@ def test_build_expert_handoff_is_versioned_and_bounded():
     assert len(payload["gaps"]) == 1
     assert payload["decisions"][0]["title"] == "Use handoff payload"
     assert payload["okf"]["canonical"] is False
-    assert payload["okf"]["profile_schema_version"] == "deepr-okf-profile-v1"
-    assert payload["okf"]["profile_schema_url"] == "docs/schemas/okf-profile-v1.json"
+    assert payload["okf"]["okf_version"] == "0.2"
+    assert payload["okf"]["profile_schema_version"] == "deepr-okf-profile-v2"
+    assert payload["okf"]["profile_schema_url"] == "docs/schemas/okf-profile-v2.json"
     assert "deepr_expert_handoff" in payload["recommended_mcp_tools"]
 
 

--- a/tests/unit/test_experts/test_okf.py
+++ b/tests/unit/test_experts/test_okf.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
-import pytest
+from dataclasses import replace
+from datetime import UTC, datetime
 
+import pytest
+from filelock import Timeout as FileLockTimeout
+
+import deepr.experts.okf_contract as okf_contract_module
+import deepr.experts.okf_publication as okf_publication_module
 from deepr.core.contracts import ExpertManifest, Gap
 from deepr.experts.beliefs import Belief, BeliefStore
 from deepr.experts.okf import OKF_MARKER, build_okf_bundle, build_okf_ingestion_corpus, write_okf_bundle
+from deepr.experts.okf_contract import (
+    OKF_VERSION,
+    parse_markdown_frontmatter,
+    validate_okf_bundle,
+    validate_okf_documents,
+)
 from deepr.experts.profile import ExpertProfile
 
 
@@ -52,17 +64,60 @@ def test_okf_bundle_contains_required_views_and_marker(tmp_path):
     concept = bundle.files[next(path for path in bundle.files if path.startswith("concepts/"))]
     assert "`eval:local_compare_latest`" in concept
     assert "deepr.okf.concept" in concept
+    index = parse_markdown_frontmatter(bundle.files["index.md"])
+    assert index.fields == {"okf_version": OKF_VERSION}
+    assert not parse_markdown_frontmatter(bundle.files["log.md"]).present
+    concept_frontmatter = parse_markdown_frontmatter(concept)
+    assert concept_frontmatter.fields["generated"]["by"] == "process:deepr-export-okf"
+    assert concept_frontmatter.fields["sources"][0]["resource"] == "eval:local_compare_latest"
+    assert concept_frontmatter.fields["deepr"]["evidence_refs"] == ["eval:local_compare_latest"]
 
 
 def test_okf_bundle_is_byte_stable_for_unchanged_store(tmp_path):
     store = _store(tmp_path)
     store.add_belief(Belief("Stable belief", 0.8, domain="ai"), check_conflicts=False)
+    profile = _profile()
+    manifest = _manifest()
 
-    first = build_okf_bundle(_profile(), store, manifest=_manifest())
-    second = build_okf_bundle(_profile(), store, manifest=_manifest())
+    first = build_okf_bundle(profile, store, manifest=manifest)
+    second = build_okf_bundle(profile, store, manifest=manifest)
 
     assert first.files == second.files
     assert first.as_of == second.as_of
+
+
+def test_okf_as_of_includes_grounding_verification_event(tmp_path):
+    store = _store(tmp_path)
+    belief = Belief(
+        "Verification is newer than the claim",
+        0.8,
+        updated_at=datetime(2026, 8, 19, 10, 0, tzinfo=UTC),
+        grounding_assurance="cross_vendor",
+        grounding_verified_at=datetime(2099, 8, 20, 12, 30, tzinfo=UTC),
+    )
+    store.beliefs[belief.id] = belief
+
+    bundle = build_okf_bundle(_profile(), store, manifest=_manifest())
+
+    assert bundle.as_of == "2099-08-20T12:30:00+00:00"
+
+
+def test_okf_generated_time_includes_gap_and_edge_changes(tmp_path):
+    store = _store(tmp_path)
+    first, _ = store.add_belief(Belief("First", 0.8, domain="ai"), check_conflicts=False)
+    second, _ = store.add_belief(Belief("Second", 0.8, domain="ai"), check_conflicts=False)
+    edge = store.add_edge(first.id, second.id, "supports")
+    edge.created_at = datetime(2098, 8, 20, tzinfo=UTC)
+    gap = Gap.create("Future gap")
+    gap.identified_at = datetime(2099, 8, 20, tzinfo=UTC)
+
+    bundle = build_okf_bundle(_profile(), store, manifest=_manifest(gap))
+    concept = parse_markdown_frontmatter(bundle.files[f"concepts/ai-{first.id}.md"])
+    gaps = parse_markdown_frontmatter(bundle.files["gaps.md"])
+
+    assert bundle.as_of == "2099-08-20T00:00:00+00:00"
+    assert concept.fields["generated"]["at"] == bundle.as_of
+    assert gaps.fields["generated"]["at"] == bundle.as_of
 
 
 def test_okf_concept_pages_encode_typed_edges_as_relative_links(tmp_path):
@@ -93,7 +148,18 @@ def test_okf_contested_view_surfaces_open_contradictions(tmp_path):
     assert "Open contested claims: 1" in bundle.files["index.md"]
 
 
-def test_write_okf_bundle_refuses_to_overwrite_hand_edited_file(tmp_path):
+def test_okf_log_normalizes_multiline_canonical_event_text(tmp_path):
+    store = _store(tmp_path)
+    store.add_belief(Belief("Claim line\n## 2026-99-99", 0.8, domain="ai"), check_conflicts=False)
+
+    bundle = build_okf_bundle(_profile(), store, manifest=_manifest())
+    validation = validate_okf_documents(bundle.files)
+
+    assert validation.valid, validation.violations
+    assert "Claim line ## 2026-99-99" in bundle.files["log.md"]
+
+
+def test_write_okf_bundle_refuses_root_without_publication_manifest(tmp_path):
     store = _store(tmp_path)
     store.add_belief(Belief("Portable belief", 0.8, domain="ai"), check_conflicts=False)
     bundle = build_okf_bundle(_profile(), store, manifest=_manifest())
@@ -101,7 +167,7 @@ def test_write_okf_bundle_refuses_to_overwrite_hand_edited_file(tmp_path):
     output.mkdir()
     (output / "index.md").write_text("# Hand edited\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="derived-view marker"):
+    with pytest.raises(ValueError, match="exact Deepr publication manifest"):
         write_okf_bundle(bundle, output)
 
     result = write_okf_bundle(bundle, output, force=True)
@@ -109,7 +175,142 @@ def test_write_okf_bundle_refuses_to_overwrite_hand_edited_file(tmp_path):
     assert OKF_MARKER in (output / "index.md").read_text(encoding="utf-8")
 
 
-def test_build_okf_ingestion_corpus_uses_only_concept_documents(tmp_path):
+def test_write_okf_bundle_replaces_complete_dedicated_root(tmp_path):
+    store = _store(tmp_path)
+    stored, _ = store.add_belief(Belief("Obsolete portable belief", 0.8, domain="ai"), check_conflicts=False)
+    output = tmp_path / "okf"
+    write_okf_bundle(build_okf_bundle(_profile(), store, manifest=_manifest()), output)
+    stale_path = output / f"concepts/ai-{stored.id}.md"
+    unrelated_empty = output / "scratch"
+    unrelated_empty.mkdir()
+
+    store.beliefs.clear()
+    with pytest.raises(ValueError, match="dedicated derived export root"):
+        write_okf_bundle(build_okf_bundle(_profile(), store, manifest=_manifest()), output)
+
+    write_okf_bundle(build_okf_bundle(_profile(), store, manifest=_manifest()), output, force=True)
+
+    assert not stale_path.exists()
+    assert not (output / "concepts").exists()
+    assert not unrelated_empty.exists()
+
+
+def test_write_okf_bundle_refuses_unmanaged_markdown_in_export_root(tmp_path):
+    bundle = build_okf_bundle(_profile(), _store(tmp_path), manifest=_manifest())
+    output = tmp_path / "okf"
+    write_okf_bundle(bundle, output)
+    hand_file = output / "notes.md"
+    hand_file.write_text("# Unmanaged\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unmanaged Markdown"):
+        write_okf_bundle(bundle, output)
+
+    assert hand_file.read_text(encoding="utf-8") == "# Unmanaged\n"
+
+
+def test_write_okf_bundle_refuses_nonconformant_generated_content_before_writing(tmp_path):
+    store = _store(tmp_path)
+    bundle = build_okf_bundle(_profile(), store, manifest=_manifest())
+    invalid = replace(
+        bundle,
+        files={
+            **bundle.files,
+            "concepts/broken.md": "<!-- misplaced -->\n---\ntype: Reference\n---\nBroken\n",
+        },
+    )
+    output = tmp_path / "invalid-okf"
+
+    with pytest.raises(ValueError, match=r"does not conform to OKF 0\.2"):
+        write_okf_bundle(invalid, output)
+
+    assert not output.exists()
+
+
+def test_write_okf_bundle_rejects_windows_absolute_path_before_writing(tmp_path):
+    bundle = build_okf_bundle(_profile(), _store(tmp_path), manifest=_manifest())
+    invalid = replace(
+        bundle,
+        files={**bundle.files, "C:/outside.md": "---\ntype: Reference\n---\nBroken\n"},
+    )
+    output = tmp_path / "invalid-okf"
+
+    with pytest.raises(ValueError, match="path_outside_bundle"):
+        write_okf_bundle(invalid, output)
+
+    assert not output.exists()
+
+
+def test_write_okf_bundle_requires_marker_on_every_generated_file(tmp_path):
+    bundle = build_okf_bundle(_profile(), _store(tmp_path), manifest=_manifest())
+    invalid = replace(bundle, files={**bundle.files, "metadata.json": "{}\n"})
+    output = tmp_path / "invalid-okf"
+
+    with pytest.raises(ValueError, match="lack the Deepr ownership marker"):
+        write_okf_bundle(invalid, output)
+
+    assert not output.exists()
+
+
+def test_write_okf_bundle_translates_lock_timeout(tmp_path, monkeypatch):
+    class _BlockedLock:
+        def __enter__(self):
+            raise FileLockTimeout("blocked.lock")
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(okf_publication_module, "FileLock", lambda *_args, **_kwargs: _BlockedLock())
+    bundle = build_okf_bundle(_profile(), _store(tmp_path), manifest=_manifest())
+
+    with pytest.raises(ValueError, match="Timed out waiting for the OKF export lock"):
+        write_okf_bundle(bundle, tmp_path / "okf")
+
+
+def test_written_bundle_passes_offline_okf_0_2_conformance(tmp_path):
+    store = _store(tmp_path)
+    store.add_belief(
+        Belief(
+            "Verified portable belief",
+            0.8,
+            domain="ai",
+            evidence_refs=["https://example.test/evidence"],
+            grounding_assurance="cross_vendor",
+            grounding_verified_at=datetime(2026, 8, 20, 12, 30, tzinfo=UTC),
+        ),
+        check_conflicts=False,
+    )
+    output = tmp_path / "okf"
+    write_okf_bundle(build_okf_bundle(_profile(), store, manifest=_manifest()), output)
+
+    result = validate_okf_bundle(output)
+    concept = next((output / "concepts").glob("*.md"))
+    fields = parse_markdown_frontmatter(concept.read_text(encoding="utf-8")).fields
+
+    assert result.valid, result.violations
+    assert result.declared_version == OKF_VERSION
+    assert fields["verified"]["by"] == "process:deepr-cross-vendor-checker"
+    assert fields["verified"]["at"] == "2026-08-20T12:30:00+00:00"
+
+
+def test_okf_does_not_invent_verification_time_for_legacy_assurance(tmp_path):
+    store = _store(tmp_path)
+    stored, _ = store.add_belief(
+        Belief(
+            "Legacy verified belief",
+            0.8,
+            domain="ai",
+            grounding_assurance="cross_vendor",
+        ),
+        check_conflicts=False,
+    )
+
+    bundle = build_okf_bundle(_profile(), store, manifest=_manifest())
+    concept = parse_markdown_frontmatter(bundle.files[f"concepts/ai-{stored.id}.md"])
+
+    assert "verified" not in concept.fields
+
+
+def test_build_okf_ingestion_corpus_uses_all_non_reserved_concept_documents(tmp_path):
     store = _store(tmp_path)
     store.add_belief(
         Belief(
@@ -126,12 +327,67 @@ def test_build_okf_ingestion_corpus_uses_only_concept_documents(tmp_path):
 
     corpus = build_okf_ingestion_corpus(output)
 
-    assert corpus.concept_count == 1
+    assert corpus.concept_count == 3
     assert corpus.report_id.startswith("okf:okf:")
     assert "OKF import must verify claims before persistence" in corpus.report_text
-    assert '"evidence_refs": [' in corpus.report_text
+    assert "sources:" in corpus.report_text
     assert "[Back to index](../index.md)" in corpus.report_text
-    assert "gaps.md" not in corpus.files
+    assert "gaps.md" in corpus.files
+    assert "contested.md" in corpus.files
+
+
+def test_build_okf_ingestion_corpus_accepts_mixed_yaml_mapping_keys(tmp_path):
+    concept = tmp_path / "concept.md"
+    concept.write_text(
+        "---\ntype: Reference\nextension:\n  1: one\n  text: two\n  2026-08-20: dated\n---\nBody\n",
+        encoding="utf-8",
+    )
+
+    corpus = build_okf_ingestion_corpus(tmp_path)
+
+    assert corpus.concept_count == 1
+    assert "1: one" in corpus.report_text
+    assert "2026-08-20: dated" in corpus.report_text
+
+
+def test_build_okf_ingestion_corpus_rejects_bounds_before_parsing(tmp_path, monkeypatch):
+    (tmp_path / "concept.md").write_text(
+        "---\ntype: Reference\n---\n" + ("x" * 64),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(okf_contract_module, "OKF_MAX_MARKDOWN_FILE_BYTES", 32)
+
+    with pytest.raises(ValueError) as error:
+        build_okf_ingestion_corpus(tmp_path)
+
+    assert str(error.value) == (
+        "Cannot ingest OKF bundle: concept.md [markdown_file_size_limit]: File exceeds the maximum of 32 bytes"
+    )
+
+
+def test_build_okf_ingestion_corpus_rejects_hard_form_violations_as_one_error(tmp_path):
+    (tmp_path / "valid.md").write_text("---\ntype: Custom Type\nextension: allowed\n---\nValid\n", encoding="utf-8")
+    (tmp_path / "malformed.md").write_text("---\ntype: [unterminated\n---\nBody\n", encoding="utf-8")
+    (tmp_path / "log.md").write_text("---\ntype: Reference\n---\n# Log\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as error:
+        build_okf_ingestion_corpus(tmp_path)
+
+    assert str(error.value).startswith("Cannot ingest OKF bundle: log.md [log_frontmatter]")
+    assert "malformed.md [concept_frontmatter]" in str(error.value)
+
+
+def test_build_okf_ingestion_corpus_preserves_extensions_and_broken_links(tmp_path):
+    (tmp_path / "concept.md").write_text(
+        "---\ntype: Custom Type\nextension:\n  enabled: true\n---\nSee [missing](missing.md).\n",
+        encoding="utf-8",
+    )
+
+    corpus = build_okf_ingestion_corpus(tmp_path)
+
+    assert corpus.concept_count == 1
+    assert "extension:" in corpus.report_text
+    assert "[missing](missing.md)" in corpus.report_text
 
 
 def test_build_okf_ingestion_corpus_rejects_bundle_without_concepts(tmp_path):

--- a/tests/unit/test_experts/test_okf_contract.py
+++ b/tests/unit/test_experts/test_okf_contract.py
@@ -1,0 +1,259 @@
+"""Offline conformance tests for the published OKF 0.2 form contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import deepr.experts.okf_contract as okf_contract
+from deepr.experts.okf_contract import (
+    OKF_VERSION,
+    parse_markdown_frontmatter,
+    read_bounded_markdown_bundle,
+    validate_okf_bundle,
+    validate_okf_documents,
+)
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[2] / "fixtures" / "standards"
+
+
+def _violation_codes(result) -> set[str]:
+    return {violation.code for violation in result.violations}
+
+
+def test_fixture_manifest_pins_the_reviewed_okf_spec_revision():
+    manifest = json.loads((FIXTURE_ROOT / "manifest.json").read_text(encoding="utf-8"))
+    okf = manifest["standards"][0]
+
+    assert manifest["schema_version"] == "deepr-standards-fixture-manifest-v1"
+    assert okf["version"] == OKF_VERSION
+    assert okf["canonical_identifier"].endswith("3fcbb9f828c2f23d109c855ee403c3a4c81f3a96/okf/SPEC.md")
+    assert okf["sha256"] == "5a3311d270bebb16d558010e75064f5b75323f284992641732b1c8097511f948"
+
+
+def test_pinned_okf_0_2_fixture_is_conformant_and_preserves_nested_yaml():
+    fixture = FIXTURE_ROOT / "okf-0.2" / "valid"
+
+    result = validate_okf_bundle(fixture)
+    parsed = parse_markdown_frontmatter((fixture / "concepts" / "orders.md").read_text(encoding="utf-8"))
+
+    assert result.valid, result.violations
+    assert result.declared_version == OKF_VERSION
+    assert parsed.fields["fixture_extension"] == {"preserved": True}
+    assert parsed.fields["verified"]["by"] == "process:fixture-review"
+
+
+def test_pinned_legacy_fixture_detects_reserved_file_and_frontmatter_placement_violations():
+    result = validate_okf_bundle(FIXTURE_ROOT / "okf-0.2" / "legacy-invalid")
+
+    assert not result.valid
+    assert {
+        "concept_frontmatter",
+        "index_frontmatter_position",
+        "log_frontmatter",
+    } <= _violation_codes(result)
+
+
+def test_index_is_optional_and_unknown_concept_fields_do_not_fail(tmp_path):
+    (tmp_path / "concept.md").write_text(
+        "---\ntype: Custom Type\nunknown:\n  nested: [one, two]\n---\n\nSee [missing](missing.md).\n",
+        encoding="utf-8",
+    )
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert result.valid, result.violations
+    assert result.declared_version is None
+
+
+def test_concept_requires_frontmatter_on_first_line_and_non_empty_type(tmp_path):
+    (tmp_path / "comment-first.md").write_text(
+        "<!-- generated -->\n---\ntype: Reference\n---\nBody\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "missing-type.md").write_text("---\ntitle: Missing type\n---\nBody\n", encoding="utf-8")
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert _violation_codes(result) == {"concept_frontmatter", "concept_type"}
+
+
+def test_malformed_or_unsafe_yaml_fails_closed(tmp_path):
+    (tmp_path / "malformed.md").write_text("---\ntype: [unterminated\n---\nBody\n", encoding="utf-8")
+    (tmp_path / "unsafe.md").write_text(
+        "---\ntype: !!python/object/apply:os.system ['echo unsafe']\n---\nBody\n",
+        encoding="utf-8",
+    )
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert not result.valid
+    assert _violation_codes(result) == {"concept_frontmatter"}
+
+
+def test_yaml_aliases_and_pathological_scalars_fail_closed(tmp_path):
+    (tmp_path / "alias.md").write_text(
+        "---\ntype: Reference\nloop: &loop [*loop]\n---\nBody\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "large-integer.md").write_text(
+        f"---\ntype: Reference\nvalue: {'9' * 5_000}\n---\nBody\n",
+        encoding="utf-8",
+    )
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert not result.valid
+    assert _violation_codes(result) == {"concept_frontmatter"}
+
+
+def test_bounded_noncyclic_yaml_alias_is_accepted(tmp_path):
+    alias_path = tmp_path / "alias.md"
+    alias_path.write_text(
+        "---\ntype: Reference\nshared: &shared [one, two]\ncopy: *shared\n---\nBody\n",
+        encoding="utf-8",
+    )
+
+    result = validate_okf_bundle(tmp_path)
+    parsed = parse_markdown_frontmatter(alias_path.read_text(encoding="utf-8"))
+
+    assert result.valid, result.violations
+    assert parsed.error is None
+    assert parsed.fields["copy"] == ["one", "two"]
+
+
+@pytest.mark.parametrize(
+    "extension",
+    [
+        "!!pairs\n  - key: value",
+        "!!omap\n  - key: value",
+        "!!set\n  ? key",
+    ],
+    ids=["pairs", "ordered-map", "set"],
+)
+def test_non_json_yaml_containers_fail_closed(extension):
+    document = f"---\ntype: Reference\nextension: {extension}\n---\nBody\n"
+
+    parsed = parse_markdown_frontmatter(document)
+    result = validate_okf_documents({"concept.md": document})
+
+    assert parsed.error is not None
+    assert "unsupported YAML container" in parsed.error
+    assert _violation_codes(result) == {"concept_frontmatter"}
+
+
+def test_bounded_markdown_reader_rejects_per_file_limit_before_read(tmp_path, monkeypatch):
+    document = "---\ntype: Reference\n---\n" + ("x" * 64)
+    (tmp_path / "large.md").write_text(document, encoding="utf-8")
+    monkeypatch.setattr(okf_contract, "OKF_MAX_MARKDOWN_FILE_BYTES", len(document.encode("utf-8")) - 1)
+    monkeypatch.setattr(okf_contract, "OKF_MAX_MARKDOWN_TOTAL_BYTES", len(document.encode("utf-8")) * 2)
+    monkeypatch.setattr(Path, "open", lambda *_args, **_kwargs: pytest.fail("oversized file was opened"))
+
+    result = read_bounded_markdown_bundle(tmp_path)
+
+    assert not result.valid
+    assert {violation.code for violation in result.violations} == {"markdown_file_size_limit"}
+    assert result.documents == ()
+
+
+def test_bounded_markdown_reader_rejects_aggregate_limit_before_read(tmp_path, monkeypatch):
+    first = "---\ntype: Reference\n---\nFirst\n"
+    second = "---\ntype: Reference\n---\nSecond\n"
+    (tmp_path / "first.md").write_text(first, encoding="utf-8")
+    (tmp_path / "second.md").write_text(second, encoding="utf-8")
+    total_bytes = len(first.encode("utf-8")) + len(second.encode("utf-8"))
+    monkeypatch.setattr(okf_contract, "OKF_MAX_MARKDOWN_FILE_BYTES", total_bytes)
+    monkeypatch.setattr(okf_contract, "OKF_MAX_MARKDOWN_TOTAL_BYTES", total_bytes - 1)
+    monkeypatch.setattr(Path, "open", lambda *_args, **_kwargs: pytest.fail("oversized bundle was opened"))
+
+    result = read_bounded_markdown_bundle(tmp_path)
+
+    assert not result.valid
+    assert {violation.code for violation in result.violations} == {"markdown_total_size_limit"}
+    assert result.documents == ()
+
+
+def test_bounded_markdown_reader_rejects_file_count_limit(tmp_path, monkeypatch):
+    (tmp_path / "first.md").write_text("---\ntype: Reference\n---\nFirst\n", encoding="utf-8")
+    (tmp_path / "second.md").write_text("---\ntype: Reference\n---\nSecond\n", encoding="utf-8")
+    monkeypatch.setattr(okf_contract, "OKF_MAX_MARKDOWN_FILES", 1)
+
+    result = read_bounded_markdown_bundle(tmp_path)
+
+    assert not result.valid
+    assert {violation.code for violation in result.violations} == {"markdown_file_count_limit"}
+    assert result.documents == ()
+
+
+def test_nested_index_frontmatter_and_log_order_fail(tmp_path):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "index.md").write_text('---\nokf_version: "0.2"\n---\n# Nested\n', encoding="utf-8")
+    (tmp_path / "log.md").write_text(
+        "# Log\n\n## 2026-08-19\n\n* Older\n\n## 2026-08-20\n\n* Newer\n",
+        encoding="utf-8",
+    )
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert _violation_codes(result) == {"nested_index_frontmatter", "log_date_order"}
+
+
+def test_log_rejects_impossible_dates_and_ignores_fenced_headings(tmp_path):
+    (tmp_path / "log.md").write_text(
+        "# Log\n\n```markdown\n## Not a log date\n```\n\n   ## 2026-02-29\n\n* Impossible\n",
+        encoding="utf-8",
+    )
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert _violation_codes(result) == {"log_date_heading"}
+
+
+def test_root_index_rejects_non_target_version(tmp_path):
+    (tmp_path / "index.md").write_text('---\nokf_version: "0.1"\n---\n# Index\n', encoding="utf-8")
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert not result.valid
+    assert result.declared_version == "0.1"
+    assert _violation_codes(result) == {"okf_version"}
+
+
+def test_root_index_requires_version_to_be_a_string(tmp_path):
+    (tmp_path / "index.md").write_text("---\nokf_version: 0.2\n---\n# Index\n", encoding="utf-8")
+
+    result = validate_okf_bundle(tmp_path)
+
+    assert not result.valid
+    assert result.declared_version is None
+    assert _violation_codes(result) == {"okf_version"}
+
+
+def test_in_memory_validation_rejects_paths_outside_bundle():
+    result = validate_okf_documents(
+        {
+            "../outside.md": "---\ntype: Reference\n---\nBody\n",
+            "C:/outside.md": "---\ntype: Reference\n---\nBody\n",
+            "concepts/NUL.md": "---\ntype: Reference\n---\nBody\n",
+            "concepts/claim.md:stream": "---\ntype: Reference\n---\nBody\n",
+            "concepts/./claim.md": "---\ntype: Reference\n---\nBody\n",
+        }
+    )
+
+    assert not result.valid
+    assert _violation_codes(result) == {"path_outside_bundle"}
+
+
+def test_in_memory_validation_rejects_portable_path_collisions():
+    result = validate_okf_documents(
+        {
+            "concepts/Claim.md": "---\ntype: Reference\n---\nFirst\n",
+            "concepts\\claim.md": "---\ntype: Reference\n---\nSecond\n",
+        }
+    )
+
+    assert not result.valid
+    assert _violation_codes(result) == {"path_collision"}

--- a/tests/unit/test_experts/test_okf_publication.py
+++ b/tests/unit/test_experts/test_okf_publication.py
@@ -1,0 +1,344 @@
+"""Security tests for transactional OKF directory publication."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+import deepr.experts.okf_publication as publication
+from deepr.experts.okf_publication import OKF_PUBLICATION_MANIFEST, publish_okf_directory
+
+_OKF_VERSION = "0.2"
+
+
+def _publish(files: dict[str, str], root: Path, *, force: bool = False) -> Path:
+    return publish_okf_directory(files, root, force=force, okf_version=_OKF_VERSION)
+
+
+def _make_directory_link(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=True)
+        return
+    except OSError as symlink_error:
+        if os.name != "nt":
+            pytest.skip(f"Directory symlinks are unavailable: {symlink_error}")
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode:
+        pytest.skip(f"Directory links are unavailable: {result.stderr or result.stdout}")
+
+
+def test_publication_manifest_binds_exact_paths_and_content_hashes(tmp_path):
+    root = tmp_path / "okf"
+    files = {
+        "concepts/claim.md": "claim\n",
+        "index.md": "index\n",
+    }
+
+    _publish(files, root)
+
+    manifest = json.loads((root / OKF_PUBLICATION_MANIFEST).read_text(encoding="utf-8"))
+    assert manifest == {
+        "schema_version": "deepr-okf-publication-v1",
+        "okf_version": _OKF_VERSION,
+        "files": [
+            {
+                "path": relative_path,
+                "sha256": sha256(content.encode("utf-8")).hexdigest(),
+            }
+            for relative_path, content in sorted(files.items())
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "C:/claim.md",
+        "concept.md:stream",
+        "NUL.md",
+        "concepts/claim. ",
+        "concepts/claim.",
+        "concepts/control\x1f.md",
+    ],
+)
+def test_publication_rejects_nonportable_generated_paths(tmp_path, relative_path):
+    root = tmp_path / "okf"
+
+    with pytest.raises(ValueError, match="path is not portable"):
+        _publish({relative_path: "generated\n"}, root)
+
+    assert not root.exists()
+
+
+def test_modified_generated_file_requires_force(tmp_path):
+    root = tmp_path / "okf"
+    _publish({"index.md": "generated\n"}, root)
+    (root / "index.md").write_text("hand modified\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="modified generated files"):
+        _publish({"index.md": "replacement\n"}, root)
+
+    assert (root / "index.md").read_text(encoding="utf-8") == "hand modified\n"
+    _publish({"index.md": "replacement\n"}, root, force=True)
+    assert (root / "index.md").read_text(encoding="utf-8") == "replacement\n"
+
+
+def test_marker_text_does_not_authenticate_unmanaged_markdown(tmp_path):
+    root = tmp_path / "okf"
+    root.mkdir()
+    notes = root / "notes.md"
+    notes.write_text("<!-- deepr:okf derived-view regenerable -->\nprivate notes\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="exact Deepr publication manifest"):
+        _publish({"index.md": "generated\n"}, root)
+
+    assert notes.exists()
+    _publish({"index.md": "generated\n"}, root, force=True)
+    assert not notes.exists()
+
+
+def test_unmanaged_markdown_in_owned_root_requires_force(tmp_path):
+    root = tmp_path / "okf"
+    _publish({"index.md": "generated\n"}, root)
+    notes = root / "notes.md"
+    notes.write_text("private notes\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unmanaged Markdown"):
+        _publish({"index.md": "replacement\n"}, root)
+
+    assert notes.read_text(encoding="utf-8") == "private notes\n"
+    _publish({"index.md": "replacement\n"}, root, force=True)
+    assert not notes.exists()
+
+
+def test_generated_files_are_written_only_to_sibling_staging_directory(tmp_path, monkeypatch):
+    root = tmp_path / "okf"
+    written_paths: list[Path] = []
+    lock_paths: list[Path] = []
+    original_write = publication.atomic_write_text
+    original_lock = publication.FileLock
+
+    def record_write(path, content, *args, **kwargs):
+        target = Path(path)
+        written_paths.append(target)
+        return original_write(target, content, *args, **kwargs)
+
+    def record_lock(path, *args, **kwargs):
+        lock_paths.append(Path(path))
+        return original_lock(path, *args, **kwargs)
+
+    monkeypatch.setattr(publication, "atomic_write_text", record_write)
+    monkeypatch.setattr(publication, "FileLock", record_lock)
+
+    _publish({"concepts/claim.md": "claim\n", "index.md": "index\n"}, root)
+
+    assert written_paths
+    assert all(root != target and root not in target.parents for target in written_paths)
+    assert all(target.relative_to(tmp_path).parts[0].startswith(".okf.staging-") for target in written_paths)
+    assert lock_paths and all(tmp_path not in lock_path.parents for lock_path in lock_paths)
+
+
+def test_publish_failure_restores_exact_prior_root(tmp_path, monkeypatch):
+    root = tmp_path / "okf"
+    _publish({"index.md": "prior\n"}, root)
+    prior_manifest = (root / OKF_PUBLICATION_MANIFEST).read_bytes()
+    original_rename = publication._rename_path
+    failed = False
+
+    def fail_staging_publish(source: Path, destination: Path) -> None:
+        nonlocal failed
+        if not failed and ".staging-" in source.name and destination == root:
+            failed = True
+            raise OSError("injected publication failure")
+        original_rename(source, destination)
+
+    monkeypatch.setattr(publication, "_rename_path", fail_staging_publish)
+
+    with pytest.raises(OSError, match="injected publication failure"):
+        _publish({"index.md": "replacement\n"}, root)
+
+    assert failed
+    assert (root / "index.md").read_text(encoding="utf-8") == "prior\n"
+    assert (root / OKF_PUBLICATION_MANIFEST).read_bytes() == prior_manifest
+    assert not (tmp_path / ".okf.deepr-okf-recovery").exists()
+
+
+def test_prior_root_identity_is_verified_before_cleanup(tmp_path, monkeypatch):
+    root = tmp_path / "okf"
+    _publish({"index.md": "prior\n"}, root)
+    original_identity = publication._path_identity
+    backup_checks = 0
+
+    def change_cleanup_identity(path: Path):
+        nonlocal backup_checks
+        identity = original_identity(path)
+        if path.name == ".okf.deepr-okf-recovery":
+            backup_checks += 1
+            if backup_checks == 2:
+                return publication._PathIdentity(identity.device, identity.inode + 1, identity.mode)
+        return identity
+
+    monkeypatch.setattr(publication, "_path_identity", change_cleanup_identity)
+
+    with pytest.raises(ValueError, match="identity changed before cleanup"):
+        _publish({"index.md": "replacement\n"}, root)
+
+    recovery = tmp_path / ".okf.deepr-okf-recovery"
+    assert backup_checks == 2
+    assert (recovery / "index.md").read_text(encoding="utf-8") == "prior\n"
+    assert (root / "index.md").read_text(encoding="utf-8") == "replacement\n"
+    _, journal = publication._coordination_paths(root)
+    publication._remove_recovery_journal(journal)
+
+
+def test_next_locked_run_recovers_interrupted_directory_swap(tmp_path, monkeypatch):
+    root = tmp_path / "okf"
+    recovery = tmp_path / ".okf.deepr-okf-recovery"
+    _publish({"index.md": "prior\n"}, root)
+    original_rename = publication._rename_path
+
+    def interrupt_staging_publish(source: Path, destination: Path) -> None:
+        if ".staging-" in source.name and destination == root:
+            raise KeyboardInterrupt
+        original_rename(source, destination)
+
+    monkeypatch.setattr(publication, "_rename_path", interrupt_staging_publish)
+    with pytest.raises(KeyboardInterrupt):
+        _publish({"index.md": "interrupted\n"}, root)
+
+    assert not root.exists()
+    assert (recovery / "index.md").read_text(encoding="utf-8") == "prior\n"
+
+    monkeypatch.setattr(publication, "_rename_path", original_rename)
+    _publish({"index.md": "replacement\n"}, root)
+
+    assert (root / "index.md").read_text(encoding="utf-8") == "replacement\n"
+    assert not recovery.exists()
+
+
+def test_next_locked_run_finishes_cleanup_after_install_interruption(tmp_path, monkeypatch):
+    root = tmp_path / "okf"
+    recovery = tmp_path / ".okf.deepr-okf-recovery"
+    _publish({"index.md": "prior\n"}, root)
+    original_remove = publication._remove_tree_no_follow
+    interrupted = False
+
+    def interrupt_recovery_cleanup(path: Path) -> None:
+        nonlocal interrupted
+        if not interrupted and path == recovery:
+            interrupted = True
+            raise KeyboardInterrupt
+        original_remove(path)
+
+    monkeypatch.setattr(publication, "_remove_tree_no_follow", interrupt_recovery_cleanup)
+    with pytest.raises(KeyboardInterrupt):
+        _publish({"index.md": "installed\n"}, root)
+
+    assert interrupted
+    assert (root / "index.md").read_text(encoding="utf-8") == "installed\n"
+    assert (recovery / "index.md").read_text(encoding="utf-8") == "prior\n"
+
+    monkeypatch.setattr(publication, "_remove_tree_no_follow", original_remove)
+    _publish({"index.md": "replacement\n"}, root)
+
+    assert (root / "index.md").read_text(encoding="utf-8") == "replacement\n"
+    assert not recovery.exists()
+
+
+@pytest.mark.parametrize("root_name", ["CON", "report.", "report ", "report:stream"])
+def test_nonportable_export_root_names_are_rejected(tmp_path, root_name):
+    with pytest.raises(ValueError, match="non-portable directory name"):
+        _publish({"index.md": "generated\n"}, tmp_path / root_name)
+
+
+def test_requested_parent_link_is_rejected_before_resolution(tmp_path):
+    actual_parent = tmp_path / "actual"
+    actual_parent.mkdir()
+    linked_parent = tmp_path / "linked"
+    _make_directory_link(linked_parent, actual_parent)
+
+    with pytest.raises(ValueError, match="requested OKF output parent"):
+        _publish({"index.md": "generated\n"}, linked_parent / "okf")
+
+    assert not (actual_parent / "okf").exists()
+
+
+def test_coordination_lock_substitution_is_rejected_without_touching_target(tmp_path):
+    root = tmp_path / "okf"
+    outside = tmp_path / "outside-lock"
+    outside.mkdir()
+    protected = outside / "protected.txt"
+    protected.write_text("keep\n", encoding="utf-8")
+    lock_path, _ = publication._coordination_paths(root)
+    _make_directory_link(lock_path, outside)
+    try:
+        with pytest.raises(ValueError, match="coordination lock path"):
+            _publish({"index.md": "generated\n"}, root)
+    finally:
+        publication._remove_tree_no_follow(lock_path)
+
+    assert protected.read_text(encoding="utf-8") == "keep\n"
+    assert not root.exists()
+
+
+def test_recovery_journal_substitution_is_rejected_without_touching_target(tmp_path):
+    root = tmp_path / "okf"
+    outside = tmp_path / "outside-journal"
+    outside.mkdir()
+    protected = outside / "protected.txt"
+    protected.write_text("keep\n", encoding="utf-8")
+    _, journal_path = publication._coordination_paths(root)
+    _make_directory_link(journal_path, outside)
+    try:
+        with pytest.raises(ValueError, match="recovery journal"):
+            _publish({"index.md": "generated\n"}, root)
+    finally:
+        publication._remove_tree_no_follow(journal_path)
+
+    assert protected.read_text(encoding="utf-8") == "keep\n"
+    assert not root.exists()
+
+
+def test_force_removes_symlink_entry_without_touching_external_target(tmp_path):
+    root = tmp_path / "okf"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    protected = outside / "protected.txt"
+    protected.write_text("keep\n", encoding="utf-8")
+    _publish({"index.md": "prior\n"}, root)
+    link = root / "external"
+    _make_directory_link(link, outside)
+
+    with pytest.raises(ValueError, match="link or special entries"):
+        _publish({"index.md": "replacement\n"}, root)
+
+    _publish({"index.md": "replacement\n"}, root, force=True)
+
+    assert not os.path.lexists(link)
+    assert protected.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_force_replaces_root_symlink_without_touching_external_target(tmp_path):
+    root = tmp_path / "okf"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    protected = outside / "protected.txt"
+    protected.write_text("keep\n", encoding="utf-8")
+    _make_directory_link(root, outside)
+
+    _publish({"index.md": "generated\n"}, root, force=True)
+
+    assert root.is_dir()
+    assert not root.is_symlink()
+    assert not root.is_junction()
+    assert protected.read_text(encoding="utf-8") == "keep\n"

--- a/tests/unit/test_experts/test_report_absorber.py
+++ b/tests/unit/test_experts/test_report_absorber.py
@@ -13,6 +13,7 @@ assert:
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1068,6 +1069,7 @@ class TestGroundingCheck:
 
     @pytest.mark.asyncio
     async def test_supported_claim_gets_assurance_stamped(self, tmp_path):
+        checked_after = datetime.now(UTC)
         content = _claims_json({"statement": "X is true", "confidence": 0.9, "evidence": ["e1"]})
         checker = _checker(CheckVerdict(True, CheckAssurance.CROSS_VENDOR, "xai", "stated"))
         absorber = _grounding_absorber(content, tmp_path, checker)
@@ -1075,6 +1077,8 @@ class TestGroundingCheck:
         assert result.grounding_flagged == []
         bel = next(iter(absorber.belief_store.beliefs.values()))
         assert bel.grounding_assurance == "cross_vendor"
+        assert bel.grounding_verified_at is not None
+        assert bel.grounding_verified_at >= checked_after
 
     @pytest.mark.asyncio
     async def test_string_evidence_reaches_checker_as_one_excerpt(self, tmp_path):
@@ -1248,10 +1252,19 @@ async def test_commit_failure_reports_durable_partial_state(tmp_path, monkeypatc
 
 
 def test_belief_grounding_assurance_roundtrips():
-    b = Belief(claim="x", confidence=0.5, grounding_assurance="cross_vendor")
+    verified_at = datetime(2026, 8, 20, 12, 30, tzinfo=UTC)
+    b = Belief(
+        claim="x",
+        confidence=0.5,
+        grounding_assurance="cross_vendor",
+        grounding_verified_at=verified_at,
+    )
     assert b.to_dict()["grounding_assurance"] == "cross_vendor"
-    assert Belief.from_dict(b.to_dict()).grounding_assurance == "cross_vendor"
+    restored = Belief.from_dict(b.to_dict())
+    assert restored.grounding_assurance == "cross_vendor"
+    assert restored.grounding_verified_at == verified_at
     assert b.to_claim().grounding_assurance == "cross_vendor"
     # Legacy beliefs (no field) default to unverified.
     legacy = Belief.from_dict({"claim": "y", "confidence": 0.5})
     assert legacy.grounding_assurance == "unverified"
+    assert legacy.grounding_verified_at is None

--- a/tests/unit/test_schemas/test_published_contracts.py
+++ b/tests/unit/test_schemas/test_published_contracts.py
@@ -418,10 +418,11 @@ def test_loop_status_schema_validates_rollup_payload(tmp_path):
     assert payload["runs"][0]["stop_reason"] == "verifier_passed"
 
 
-def test_okf_profile_schema_validates_mapping_payload():
+def test_okf_0_2_profile_schema_validates_mapping_payload():
     payload: dict[str, Any] = {
-        "schema_version": "deepr-okf-profile-v1",
+        "schema_version": "deepr-okf-profile-v2",
         "kind": "deepr.okf.profile",
+        "okf_version": "0.2",
         "contract": {
             "read_only": True,
             "cost_usd": 0.0,
@@ -429,7 +430,7 @@ def test_okf_profile_schema_validates_mapping_payload():
             "compatibility": {
                 "additive_fields": True,
                 "breaking_changes_require_new_schema_version": True,
-                "deprecation_policy": "Additive fields only within v1.",
+                "deprecation_policy": "Additive fields only within v2.",
             },
         },
         "derived_view": {
@@ -440,37 +441,43 @@ def test_okf_profile_schema_validates_mapping_payload():
         "documents": {
             "index": {
                 "path_pattern": "index.md",
-                "frontmatter_type": "deepr.okf.index",
+                "role": "root_index",
+                "frontmatter": "okf_version_only",
                 "source": "expert profile, belief store, manifest summary",
             },
             "concept": {
                 "path_pattern": "concepts/{domain}-{belief_id}.md",
-                "frontmatter_type": "deepr.okf.concept",
+                "role": "concept",
+                "frontmatter": "required_type",
                 "source": "beliefs plus typed edges",
             },
             "gaps": {
                 "path_pattern": "gaps.md",
-                "frontmatter_type": "deepr.okf.gaps",
+                "role": "concept",
+                "frontmatter": "required_type",
                 "source": "expert manifest gaps",
             },
             "contested": {
                 "path_pattern": "contested.md",
-                "frontmatter_type": "deepr.okf.contested",
+                "role": "concept",
+                "frontmatter": "required_type",
                 "source": "contradicts edges",
             },
             "log": {
                 "path_pattern": "log.md",
-                "frontmatter_type": "deepr.okf.log",
+                "role": "update_log",
+                "frontmatter": "none",
                 "source": "belief event log",
             },
             "llms": {
                 "path_pattern": "llms.txt",
-                "frontmatter_type": "none",
+                "role": "discovery",
+                "frontmatter": "not_applicable",
                 "source": "bundle discovery hints",
             },
         },
         "field_mapping": {
-            "profile": {"source": "ExpertProfile", "target": "index frontmatter and body", "authority": "derived"},
+            "profile": {"source": "ExpertProfile", "target": "index body", "authority": "derived"},
             "beliefs": {"source": "BeliefStore.beliefs", "target": "concept documents", "authority": "derived"},
             "events": {"source": "BeliefStore event log", "target": "log.md", "authority": "derived"},
             "edges": {"source": "BeliefStore.edges", "target": "concept relations", "authority": "derived"},
@@ -483,7 +490,7 @@ def test_okf_profile_schema_validates_mapping_payload():
             "marker": "deepr:okf derived-view regenerable",
         },
     }
-    schema = _load_schema("okf-profile-v1.json")
+    schema = _load_schema("okf-profile-v2.json")
 
     _validate(schema, payload)
     assert payload["derived_view"]["authoritative"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -898,6 +898,8 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "pyyaml", marker = "python_full_version != '3.13.*'" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
     { name = "requests" },
     { name = "rich" },
 ]
@@ -1024,6 +1026,8 @@ requires-dist = [
     { name = "python-docx", marker = "extra == 'docs'", specifier = ">=0.8.11,<2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "python-socketio", marker = "extra == 'web'", specifier = ">=5.10.0,<6.0.0" },
+    { name = "pyyaml", marker = "python_full_version != '3.13.*'", specifier = ">=6.0.3,<7.0.0" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'", specifier = ">=8.0.0,<9.0.0" },
     { name = "requests", specifier = ">=2.28.0,<3.0.0" },
     { name = "rich", specifier = ">=13.0.0,<16.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0" },


### PR DESCRIPTION
## Summary

- migrate Deepr's derived OKF export to the OKF 0.2 mechanical contract
- add pinned offline fixtures, bounded validation, and verification-gated ingestion
- publish the v2 profile while retaining v1 compatibility
- make dedicated export-root publication transactional and recoverable
- refine the external harness roadmap around the standards-first dependency order

## Verification

- 297 integrated focused tests passed before the final direct path-contract regressions
- 66 final OKF contract, publication, and integration tests passed
- Ruff lint and format passed
- blocking strict type islands passed across 151 source files
- file-size, complexity, security, paid-boundary, and documentation ratchets passed
- source distribution and wheel built successfully