### PR TITLE
Restore plan adapter safety and roadmap truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         # `--ignore-vuln <ID>` rather than by disabling the gate.
         run: |
           uv sync --frozen --extra dev --extra full
+          uv pip install "pip==26.2"
           pip-audit --skip-editable
 
       - name: Generate SBOM (pinned dependency bill of materials)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ subscription quota, with no automatic fallback to a paid API.
   <img src="assets/expert-hub.png" width="100%" alt="Deepr Expert Hub showing the 25-expert flagship roster with portraits, standpoints, positions, studied findings, and retained sources" />
 </p>
 
-The flagship view keeps the selected 25 experts in focus while preserving the
-complete roster. Each card exposes the expert's standpoint, positions, studied
-findings, retained sources, and readiness from durable state.
+The pictured maintainer fleet keeps its selected 25 flagship experts in focus
+while preserving its complete roster. Flagship membership is user-curated local
+state, not a 25-expert clean-install guarantee. Each card exposes the expert's
+standpoint, positions, studied findings, retained sources, and readiness from
+durable state.
 
 ## Turn evidence into reusable judgment
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -388,13 +388,14 @@ No production provider account-control verifier ships in v2.49, so a funded
 wallet does not enable a call against an open postpaid account. The transaction
 is complete; provider-side execution authority remains deliberately absent.
 
-The Expert Hub now leads with an explicit 25-expert flagship roster while
-preserving the complete standard roster. Cards report presentation structure
-from durable expert state: portraits, standpoints, positions, studied
-findings, and retained sources. The readiness label checks only those
+The pictured maintainer fleet now leads with an explicit 25-expert flagship
+roster while preserving its complete standard roster. Flagship membership is
+user-curated local state, not a clean-install count. Cards report presentation
+structure from durable expert state: portraits, standpoints, positions,
+studied findings, and retained sources. The readiness label checks only those
 structural facts and does not pretend to judge whether an expert is correct or
-good. Sparse flagship experts were enriched through owned local models and
-retained public source packs at `$0` model-provider cost.
+good. Sparse maintainer flagship experts were enriched through owned local
+models and retained public source packs at `$0` model-provider cost.
 
 **Shipped in v2.48.0 (see docs/CHANGELOG.md):** expert consultation is now
 local Ollama by default or an explicit safety-eligible prepaid plan. Metered
@@ -926,6 +927,13 @@ provenance, prepaid overage posture, or full metered accounting is unproven.
 This supersedes older current-main and live transport statements below.
 Explicit `--plan` never bypasses the safety gate.
 
+**Plan-quota enforcement re-audit (2026-08-21):** Codex, Grok Build, and
+Antigravity again carry explicit production execution blocks. Their hardened
+argument builders remain defense-in-depth and future conformance fixtures, not
+proof of native-tool confinement, subscription billing posture, or execution
+authority. Claude Code remains the sole executable plan adapter under the
+fresh paid-extra-usage-off proof described above.
+
 **v2.36 capability correction:** references below to explicit metered expert
 profile, curriculum, refresh, gap-fill, compiled-sync, corpus-calibration, or
 chat execution describe earlier implementation history, not current usable
@@ -999,15 +1007,15 @@ the gate for that version is proven.
 | Target | Focus | Why this order | Gate to call it done |
 | --- | --- | --- | --- |
 | **v2.43.x** (shipped) | Approach contract and offline dual-era MCP conformance | Host interop must be provable offline before more remote surface | `mcp conformance` and doctor preflight shipped; paid remained frozen |
-| **v2.44** (shipped) | Retained expert corpus, study lenses, anchored findings, coverage, and notebook views | Experts needed re-readable evidence before they could hold an inspectable view | Content-addressed corpus and `$0` study proposal path shipped |
+| **v2.44 development** (included in v2.45.0) | Retained expert corpus, study lenses, anchored findings, coverage, and notebook views | Experts needed re-readable evidence before they could hold an inspectable view | Content-addressed corpus and `$0` study proposal path shipped with v2.45.0; no separate v2.44 tag exists |
 | **v2.45** (shipped) | Honest corpus measurements, source cards, acquisition planning, and consult context | Retrieval counts and source repetition could not stand in for evidence quality | Independence, grounding, comparison, and scheduler failure states became observable |
 | **v2.46** (shipped) | Durable positions, self-account, viva, perspective graph, stage contracts, and key quarantine | An expert needed a standpoint and history before broader presentation or authority | Position and perspective state shipped; metered keys became absent by default |
 | **v2.47** (shipped, grant superseded) | Expert v2 web surface, local portraits, and the original attended `$2` grant | The new expert state needed a real interface; attended spend needed a first narrow proof | Twelve read-only v2 routes and local portrait path shipped; the grant was replaced in v2.49 |
 | **v2.48** (shipped) | Local-first consult plus the 2026-08-13 provider model and pricing refresh | Consultation must not inherit metered authority; estimates must follow current official catalogs | Consult blocks API paths; GPT-5.6, Grok 4.6, Claude 5, and current Gemini posture registered |
 | **v2.49** (shipped) | Persistent metered-spend wallet, independent job ceilings, and a curated flagship expert roster | Operators need chosen total exposure without a universal $2 research limit; the main roster must show developed experts | Wallet and verified provider boundaries both apply; no refill or overdraft; 25 explicit flagship experts have inspectable structure |
-| **v2.50** | Standards foundation: OKF 0.2 migration, Agent Skill validation, then Agent Plugin 1.0.0 packaging | Format truth must precede distribution, and distribution must precede host-specific adapters | Offline pinned fixtures pass; OKF remains derived and verification-gated; package containment and secret absence are proven |
-| **v2.51** | Versioned external-harness contracts plus read-only MCP investigation projection | Hosts need replayable observation before they receive control authority | Stateless `run_id` and cursor reads reproduce the canonical lifecycle and deny cross-run access |
-| **v2.52** | Agent Plugin install proof plus fixture-validated OpenClaw, DeepSeek Harness, Grok Build, and Codex profiles | Portable packaging is primary; host fragments are compatibility paths | Every advertised host claim names exact versions, tools, transport, and validation evidence |
+| **v2.50** (implemented on main, unreleased) | Standards foundation: OKF 0.2 migration, Agent Skill validation, Agent Plugin 1.0.0 packaging, and clean offline installation proof | Format truth must precede distribution, and distribution must precede host-specific adapters | Offline pinned fixtures pass; OKF remains derived and verification-gated; package containment, reproducible installation, and secret absence are proven |
+| **v2.51** | Versioned host, capability, control, event, and artifact contracts plus read-only MCP investigation projection | Hosts need bounded, replayable, owner-scoped observation before they receive control authority | Stateless `run_id` and cursor reads reproduce the canonical lifecycle, remain content-free, and deny cross-run access |
+| **v2.52** | Fixture-validated OpenClaw, DeepSeek Harness, Grok Build, Codex, and manual Grok Bot profiles | Portable packaging is primary; host fragments are compatibility paths and Bot lifecycle automation remains unavailable | Every advertised host claim names exact versions, tools, transport, runtime dependency, and validation evidence |
 | **v2.53** | Shared durable parent transaction, maximum-charge contract, scoped HTTP authority, then NemoClaw remote-isolation proof | Remote mutation and isolation depend on spend, identity, credential, and endpoint truth | Retry and crash tests cannot overshoot the parent ceiling or duplicate effects; NemoClaw remains reference-only until live evidence passes |
 | **v2.54** | Lineage-only follow-up, fork, pause, resume, cancel, and separately approved remote start | Control follows observation and authority, never precedes them | Every transition is idempotent, hash-bound, race-tested, and reconstructible from the canonical journal |
 | **v2.55** | External workspace evidence bundles and selectively negotiated MCP extensions | Computer-produced evidence and protocol convenience arrive only after core boundaries hold | Tainted artifacts remain evidence-only; each Tasks, Skills-over-MCP, or Apps adapter removes a measured limitation without becoming authority |
@@ -1020,7 +1028,7 @@ remains `$0.00` unless both the attended v2.49 wallet path and provider-proof ga
 overshoot is the design standard, not a closed story.
 
 0. **No Surprise Bills: spend caps that cannot be overshot (governing money
-   invariant, outranks every feature; spans v2.44-v2.51).** The July 2026
+   invariant, outranks every feature and every version).** The July 2026
    incident is the standard to design against: it was initially detected at
    $37.99, and the canonical July ledger now shows $38.52 settled against a
    $10/month budget. The budget display had shown $0.00 and no paid artifact for
@@ -1117,7 +1125,7 @@ overshoot is the design standard, not a closed story.
      paid-overage-off authority.
 1. **Graph commit apply path for compiled expert memory** (largely shipped through v2.43; residual polish only) - finish the write boundary after the shipped compiler envelopes. Already done: `deepr-source-pack-manifest-v1`, `deepr-source-note-v1`, explicit `deepr expert sync --compile-claims`, `deepr-semantic-claim-extraction-v1`, `deepr-claim-verification-v1`, verifier-supplied typed candidate edges in claim verification, compiler-side `candidate_only` recall context on claim-verification decisions, `deepr-graph-commit-envelope-v1` as an apply-gated no-write envelope for verified factual decisions and candidate-to-candidate typed edges, `deepr-graph-commit-envelope-v2` with verifier-gated `promote_gap` operations, `deepr-graph-commit-envelope-v3` with verifier-gated `promote_exploration_agenda` operations, `deepr-graph-commit-envelope-v4` with verifier-gated `promote_hypothesis` operations, `deepr-graph-commit-envelope-v5` with verifier-gated `promote_concept` operations, `deepr-graph-commit-envelope-v6` with verifier-gated `promote_stance` operations, `deepr-graph-commit-envelope-v7` with verifier-gated `promote_original_idea` operations, `deepr-graph-commit-envelope-v8` with structured temporal qualifiers on verifier-supplied typed edge operations, explicit `deepr expert apply-graph-commit` for idempotent factual belief, typed-edge, temporal edge qualifier, gap-promotion, exploration-agenda, hypothesis, concept, stance, and original-idea writes, `deepr-graph-commit-apply-v1` apply results, local `candidate_only` recall, generated `deepr-expert-memory-card-v1` / `EXPERT.md` views, store-backed `candidate_only` recall routing for ready claim-verification candidates, optional sync-side verifier plus staged graph-commit sidecar artifacts for replayable review, concrete budget-gated `SemanticClaimVerifier` wiring for local, explicit plan-quota, and metered API `expert sync --compile-claims`, sync-side graph-commit apply for compiled claims with compatibility `--apply-compiled-claims`, sync apply regression coverage for verified gap, exploration-agenda, hypothesis, concept, stance, and original-idea promotions through an injected metacognition tracker, sync-level replay coverage proving tracker-state already-applied results still report `synced` without duplicate state writes, fail-closed cadence behavior when the apply result sidecar cannot be written, default compiled sync migration away from legacy absorb with `--stage-compiled-claims` as the explicit no-write staging path, and first-class temporal edge qualifier persistence through claim verification, graph-commit envelopes, and idempotent apply. Original ideas now surface in memory cards, handoff payloads, consult context, and read-only recall as labeled perspective state, never as verified external facts. Temporal edge qualifiers now surface in read-side perspective deltas, belief explanations, the continuity memory-quality metric, the `deepr_temporal_edges` MCP filter surface, and generated expert digests. It must preserve the agentic boundary: deterministic code owns schema, spend, provenance, idempotency, locks, and writes; calibrated model judgment owns support, contradiction, deduplication, temporal scope, edge type, temporal edge meaning, gap quality, agenda quality, hypothesis quality, concept quality, stance quality, and original-idea quality. Why: graph mutation is the point where bad meaning becomes durable, so it needs one narrow, replayable, auditable commit point.
    - [x] Live-validation closure (2026-07-11): a compiled video-expert sync produced seven verifier decisions, four ready and three insufficient, but the aggregate blocked verification status incorrectly vetoed all four valid operations. Graph envelopes now select only verifier-ready operations, retain every rejected candidate and reason, and permit atomic apply when top-level artifact integrity is sound. Top-level schema, kind, model-response, and selected-operation failures still block the whole apply set. Regression coverage preserves the observed 4-ready/3-blocked shape through sync and apply.
-2. **Longitudinal expert value proof (target v2.44)** - prove that a compiled, maintained
+2. **Longitudinal expert value proof (required for v3.0)** - prove that a compiled, maintained
    expert improves repeated decisions compared with fresh frontier research and
    simpler memory baselines. Shipped foundations include purpose and outcome
    contracts, `deepr-expert-value-review-v1`,
@@ -1145,9 +1153,9 @@ overshoot is the design standard, not a closed story.
    [expert-purpose-and-value-loop.md](docs/design/expert-purpose-and-value-loop.md).
    Why: the differentiator is not that Deepr remembers more; it is that
    operator-accepted, current, reusable state measurably helps over time.
-3. **Temporal knowledge graph completion and memory quality (target v2.45)** - first-class temporal edge qualifiers now surface in read-side perspective deltas, belief explanations, expert-memory quality checks, the host-agent `deepr_temporal_edges` filter surface, regenerated expert digests, and `deepr eval continuity` generated-view checks after default compiled sync applies verified graph commits and persists verifier-supplied temporal edge context. Semantic recall now has a first-class local `$0` construction path: `deepr expert refresh-semantic-recall --local-embedding-model` embeds missing or stale belief claims through a local Ollama embedding model on the existing local client seam, and `deepr expert semantic-recall --local-embedding-model` computes the query embedding locally so indexed vector recall works without any caller-side embedding pipeline; both paths are explicit, no-metered-fallback, and stay `candidate_only`. Compiled-sync claim verification can now use that index: `deepr expert sync --compile-claims --recall-embedding-model MODEL` embeds ready claim statements through the local `$0` embedder and routes verifier recall context through indexed belief vectors, degrading to lexical routing instead of blocking the gated verification call when the local embedder fails, and the persisted claim-verification sidecar records the exact recall packets the verifier prompt used so the per-candidate `method` field stays honest on the durable artifact. `deepr eval recall NAME --cases PATH` now provides that `$0` evidence surface: it compares lexical and indexed-vector routing on operator-labeled cases (local or precomputed query embeddings) and reports hit rate, mean reciprocal rank, and per-metric winners as routing evidence only. `deepr eval recall NAME --cases PATH --record-cases` now accumulates those operator-labeled cases in a runtime-local `deepr-recall-eval-case-library-v1` library, `deepr eval recall NAME --query TEXT --relevant-belief-id ID --record-cases` captures one reviewed case without a scratch JSON file, and `deepr eval recall NAME` can rerun against that accumulated set without touching graph state, beliefs, or vectors. Consult traces now preserve selected stored-belief ids and trace mining emits review-required `deepr-recall-eval-case-candidate-v1` drafts when a failed-check, low-context, or middle-context candidate has selected belief context; they are not auto-recorded as labels. Claim-verification decisions now use the same candidate contract for duplicate, contradiction, or temporal-scope memory blocks that had recall context, preserving candidate belief ids for operator review without asserting relevance. Recall eval reports now include a conservative scheduler-preference eligibility block: vector routing is eligible only after enough labeled cases, required vector metric wins, and complete current vectors for the requested model. Claim verification can now consume an explicit recall route preference block and try vector-only recall first while preserving lexical fallback when the preference is absent, ineligible, or produces no vector hits, and `deepr expert sync --compile-claims --recall-embedding-model MODEL --recall-preference-report PATH` validates a local recall eval report for the same expert and model before threading only its scheduler-preference block into the verifier prompt. A `$0` regression now validates that an accumulated recall case library can generate an eligible report before sync accepts only its scheduler-preference block, and sync now revalidates eligible reports for case count, required vector metric wins, an evaluated vector route, no ineligible reasons, and complete current vector coverage instead of trusting a hand-edited `eligible: true` flag. Next: keep default lexical-first routing unless an operator supplies a vetted report, and run live/operator validation on accumulated libraries before considering any scheduler default. Compiler claim verification can carry caller-supplied or store-backed recall context, and sync can run the budget-gated verifier, persist compiler and apply sidecars, and use `--stage-compiled-claims` for no-write envelope staging, but recall stays subordinate to the graph: recall finds candidates; the belief graph and verifier decide. Why: the expert should answer "what changed," "why do you believe it," "what is your current take," "what is contested," "what are you watching," and "what would change your mind," which no chunk store can answer.
+3. **Temporal knowledge graph completion and memory quality (continuing evidence track)** - first-class temporal edge qualifiers now surface in read-side perspective deltas, belief explanations, expert-memory quality checks, the host-agent `deepr_temporal_edges` filter surface, regenerated expert digests, and `deepr eval continuity` generated-view checks after default compiled sync applies verified graph commits and persists verifier-supplied temporal edge context. Semantic recall now has a first-class local `$0` construction path: `deepr expert refresh-semantic-recall --local-embedding-model` embeds missing or stale belief claims through a local Ollama embedding model on the existing local client seam, and `deepr expert semantic-recall --local-embedding-model` computes the query embedding locally so indexed vector recall works without any caller-side embedding pipeline; both paths are explicit, no-metered-fallback, and stay `candidate_only`. Compiled-sync claim verification can now use that index: `deepr expert sync --compile-claims --recall-embedding-model MODEL` embeds ready claim statements through the local `$0` embedder and routes verifier recall context through indexed belief vectors, degrading to lexical routing instead of blocking the gated verification call when the local embedder fails, and the persisted claim-verification sidecar records the exact recall packets the verifier prompt used so the per-candidate `method` field stays honest on the durable artifact. `deepr eval recall NAME --cases PATH` now provides that `$0` evidence surface: it compares lexical and indexed-vector routing on operator-labeled cases (local or precomputed query embeddings) and reports hit rate, mean reciprocal rank, and per-metric winners as routing evidence only. `deepr eval recall NAME --cases PATH --record-cases` now accumulates those operator-labeled cases in a runtime-local `deepr-recall-eval-case-library-v1` library, `deepr eval recall NAME --query TEXT --relevant-belief-id ID --record-cases` captures one reviewed case without a scratch JSON file, and `deepr eval recall NAME` can rerun against that accumulated set without touching graph state, beliefs, or vectors. Consult traces now preserve selected stored-belief ids and trace mining emits review-required `deepr-recall-eval-case-candidate-v1` drafts when a failed-check, low-context, or middle-context candidate has selected belief context; they are not auto-recorded as labels. Claim-verification decisions now use the same candidate contract for duplicate, contradiction, or temporal-scope memory blocks that had recall context, preserving candidate belief ids for operator review without asserting relevance. Recall eval reports now include a conservative scheduler-preference eligibility block: vector routing is eligible only after enough labeled cases, required vector metric wins, and complete current vectors for the requested model. Claim verification can now consume an explicit recall route preference block and try vector-only recall first while preserving lexical fallback when the preference is absent, ineligible, or produces no vector hits, and `deepr expert sync --compile-claims --recall-embedding-model MODEL --recall-preference-report PATH` validates a local recall eval report for the same expert and model before threading only its scheduler-preference block into the verifier prompt. A `$0` regression now validates that an accumulated recall case library can generate an eligible report before sync accepts only its scheduler-preference block, and sync now revalidates eligible reports for case count, required vector metric wins, an evaluated vector route, no ineligible reasons, and complete current vector coverage instead of trusting a hand-edited `eligible: true` flag. Next: keep default lexical-first routing unless an operator supplies a vetted report, and run live/operator validation on accumulated libraries before considering any scheduler default. Compiler claim verification can carry caller-supplied or store-backed recall context, and sync can run the budget-gated verifier, persist compiler and apply sidecars, and use `--stage-compiled-claims` for no-write envelope staging, but recall stays subordinate to the graph: recall finds candidates; the belief graph and verifier decide. Why: the expert should answer "what changed," "why do you believe it," "what is your current take," "what is contested," "what are you watching," and "what would change your mind," which no chunk store can answer.
    Cycle 103 update (2026-07-09): recall eval reports now carry `deepr-recall-operator-validation-v1`, an additive operator-facing block that says whether an accumulated-library run is ready for explicit sync preference and records that default routing remains lexical-first until an operator supplies a vetted saved report. Cycle 104 update (2026-07-09): `deepr eval recall-libraries` now emits `deepr-recall-library-inventory-v1`, a read-only inventory of accumulated recall libraries that flags invalid files and identifies which experts have enough operator-labeled cases for route-evidence evals before any explicit sync preference report is considered. Cycle 105 update (2026-07-09): `deepr eval recall-libraries --validation-plan --local-embedding-model MODEL` now emits `deepr-recall-library-validation-plan-v1`, a read-only command plan for ready accumulated libraries that does not execute retrieval, write state, or authorize default routing. Cycle 106 update (2026-07-09): `deepr-recall-eval-report-v2` replaces the three-case point-estimate eligibility gate with standard IR metrics, a 30-case operating floor, deterministic 95 percent paired bootstrap intervals, sync-side recomputation, a live model-specific belief/vector state-digest check, and exact top-k, expert-domain, and minimum-score binding for every eligible preference artifact. Default routing remains lexical-first. Design: [semantic-recall-evidence.md](docs/design/semantic-recall-evidence.md).
-4. **Protocol-native expert collaboration over MCP and A2A (target v2.52; after v2.44-v2.51)** - design:
+4. **Protocol-native expert collaboration over MCP and A2A (target v2.55; after v2.51-v2.54)** - design:
    [remote-expert-conversations.md](docs/design/remote-expert-conversations.md),
    [bounded-expert-deliberation.md](docs/design/bounded-expert-deliberation.md),
    and [ADR 0005](docs/decisions/0005-protocol-neutral-expert-conversation-handles.md).
@@ -1381,7 +1389,7 @@ These features work but APIs or behavior may change:
 - Docker deployment option
 - Cloud deployment templates (AWS, Azure, GCP)
 - `uv`-managed toolchain (`uv.lock` + `.python-version` for reproducible dev/CI/container environments; setuptools build backend preserved for `pip install` compatibility)
-- Pre-commit hooks (ruff lint+format, trailing whitespace, debug statement detection); CI also runs mypy (type-check baseline) and pip-audit (dependency audit) as non-blocking gates ratcheting toward blocking (Phase E)
+- Pre-commit hooks (ruff lint+format, trailing whitespace, debug statement detection); CI runs whole-tree mypy as an advisory baseline, strict package islands as a blocking gate, and pip-audit as a blocking dependency audit
 - Coverage configuration with 80% minimum threshold (`fail_under = 80`; branch coverage enabled - stricter than the prior 80% line gate, ratcheting toward 95)
 - Context discovery with semantic search (`deepr search`, `--context` flag)
 - Distributed tracing with MetadataEmitter, spans, cost attribution
@@ -1533,7 +1541,7 @@ The gate targets below are firm commitments, not a soft "raise it when convenien
   checklist moved into `docs/MCP_A2A_INTEROP_CHECKLIST.md`, refreshed against
   current official MCP, A2A, and agentic AI security guidance, and linked from
   the docs index.
-- [ ] Supply chain (remaining): switch CI installs to `uv sync --frozen`; add a scheduled `uv lock --upgrade` behind review; (if publishing) OIDC trusted publishing + GitHub build-provenance attestation
+- [~] Supply chain: CI installs use `uv sync --frozen`. Remaining work is a scheduled reviewed `uv lock --upgrade` and, if publishing is enabled, OIDC trusted publishing plus GitHub build-provenance attestation.
 - [ ] Align tracing with OpenTelemetry semantic conventions; evaluate `structlog` for the logging surface
 - [ ] Extract a reusable CI workflow + Copier/template repo so sibling projects (recon, distillr, primr) inherit the same standard from day zero
 
@@ -2060,11 +2068,10 @@ over-reach for a solo project; Letta/MemOS already own the "OS" label).
         digests.
   - [x] Optionally emit `llms.txt` discovery instructions pointing hosts to the
         exported OKF bundle and to the Deepr MCP tools for live queries.
-  - [ ] Migrate and validate the generated profile against the current OKF 0.2
-        specification before claiming external conformance. The present
-        `timestamp`, citations section, reserved-file frontmatter, and marker
-        placement reflect the legacy Deepr profile and are not an OKF 0.2
-        conformance proof.
+  - [x] Migrated and validated generated profiles against OKF 0.2 through
+        `deepr-okf-profile-v2`: reserved files, frontmatter placement,
+        `generated.at`, and `sources` now conform while Deepr extensions remain
+        explicit. The v1 profile remains a deprecated compatibility contract.
 - [ ] Skill auto-generation from research artifacts:
   - [ ] `expert skill make "Topic" --from-report artifact.md` generates skill with tools and triggers
   - [ ] Dependency tracking between generated skills
@@ -3093,7 +3100,10 @@ Why this matters: a $20-300/month plan with quota windows or monthly credit pool
 
 Platform requirement: adapter discovery, auth-profile inspection, and path handling must work on Windows, macOS, and Linux. Explicit plan execution currently ships only where Deepr can contain detached descendants before vendor code runs: Windows Job Objects and the Linux child-subreaper supervisor. Other POSIX systems fail before launch rather than ship a process-tree escape. macOS execution remains gated until it has an equivalent ownership primitive.
 
-Current truth in the product: local Ollama and budget-gated API research work.
+Current truth in the product: local Ollama execution works. Bounded API preview,
+wallet accounting, and reservation infrastructure exist, but production metered
+dispatch remains blocked without authenticated provider-side account-control
+proof.
 Explicit plan commands execute only when the selected adapter clears auth,
 native-tool, marginal-cost, process-ownership, and paired-ledger gates. Claude
 Code is the sole eligible adapter and additionally requires a fresh provider
@@ -3240,7 +3250,7 @@ A mock panel (business buyer, indie hacker, enterprise AI architect, research sc
     A follow-up with `qwen3.6:27b` then spent the full local output allowance in a separate reasoning field and returned empty visible content. Fixed in the same validation cycle with Ollama's supported local-only `reasoning_effort: none` request control. Reasoning-only responses remain one-call, no-fallback typed truncations or failures with a visible diagnostic, and their private reasoning is never used as the council answer.
   - [x] The same local council trace stored its initial collaboration block before runtime enrichment, so its durable output omitted both trace ids and capacity, incorrectly allowed metered fallback, and recorded the default automatic `max_experts=3` beside an explicit four-expert roster. Fixed 2026-07-11 by preallocating one trace id, attaching the returned local, plan, or API collaboration contract before the single append-only write, and exposing the public trace reference only after that write. Trace input now distinguishes automatic from explicit selection, preserves the requested automatic cap separately, and records the effective explicit roster size. Regressions compare durable and returned collaboration metadata for API, local, plan, and truncated synthesis paths without model calls.
   - [ ] Separate consult model completion from semantic acceptance. Live local portfolio councils on 2026-07-11 exposed both failure modes: a broad four-expert run ended `truncated` with partial dissent, while a compact relevant-roster retry ended `completed` but violated supplied project boundaries, returned no structured agreements or disagreements, and offered non-binary activities as `$0` tests. Add a bounded versioned repository-evidence packet, explicit role and relevance metadata, a structured decision/test/dissent result contract, deterministic checks only for that form, and human-anchored or measured-calibrated review for meaning. An unaccepted result remains a proposal artifact and cannot write beliefs, roadmaps, routing policy, or project state. The 2026-07-12 `deepr-deliberation-eval-v1` fixture report now proves eleven structural boundaries at `$0` and labels meaning `unreviewed`; it does not satisfy the remaining semantic-review gate. True multi-round deliberation stays gated on that review.
-  - [x] Explicit Antigravity absorb printed the same automation-policy warning once inside the capacity selection reason and again as a standalone warning. Fixed 2026-07-11 by emitting the adapter note only when the already-rendered selection reason does not contain it; the explicit-only and never-auto-routed safety posture is unchanged.
+  - [x] Explicit Antigravity absorb printed the same automation-policy warning once inside the capacity selection reason and again as a standalone warning. Fixed 2026-07-11 by emitting the adapter note only when the already-rendered selection reason does not contain it. That historical explicit-only posture was later superseded by the current production execution block.
   - [x] Two overlapping explicit absorb runs for the durable-loop expert admitted the exact claim `A minimum viable expert loop requires durable state.` under different belief ids. The second process had loaded its belief snapshot before the first process committed, so within-run semantic dedup could not see the concurrent write. Fixed 2026-07-11 for the observed same-verb race with one non-blocking per-expert guard across CLI and MCP absorb. A colliding command exits `$0` before expert store, backend, or model construction. Dry-run previews use the same guard because a metered preview can settle profile cost even when it writes no beliefs.
   - [ ] Replace verb-specific write guards with one per-expert knowledge-mutation transaction shared by absorb, sync, topic learn, gap-fill, and graph-commit apply. It must reload current state after acquisition and commit idempotently so different write verbs cannot overwrite one another from stale process snapshots.
   - [ ] Interactive local consult, absorb, and sync need phase-level progress with elapsed time, current bounded phase, cancellation state, and a durable trace reference. Busy-before-dispatch waits are now defensive, but a healthy multi-minute local generation still appears silent between dispatch and completion. Live scheduled-sync dogfood on 2026-07-12 made the ambiguity concrete: after 17 silent minutes over two due topics, the host could prove only that `engine.sync` still awaited Ollama under the configured one-hour local-call allowance. Stopping the local service unwound to a durable `$0` `tool_failure`, rejected both topic changes, and left their `last_synced` fields null, but the operator could not distinguish slow healthy generation from a stuck response without external process and socket inspection. Add periodic phase heartbeats plus explicit cancellation before calling this unattended path complete; do not shorten the generous local timeout merely to make slow owned hardware look failed.
@@ -3364,244 +3374,10 @@ v2.49.2 plus the unreleased fixes listed in the changelog. This roadmap keeps
 only active work and future criteria; completed
 items move to the changelog at release.
 
-## Version Plan (logical order, not a calendar)
-
-Versions are sequenced by dependency and risk, never by dates - this is a
-spare-time project with no SLA, and pretending otherwise would be the kind
-of false promise the rest of this roadmap avoids. Each release has a
-*theme* (the question it answers), its contents come from the phases above,
-and the order encodes a deliberate logic:
-
-**capability -> evidence -> capacity -> verified loops/interchange -> reach -> contract.**
-
-Close the loops while the surface is small; measure before making claims;
-make tokens cheap before running them routinely; make loop state and portable
-knowledge exports dependable before inviting always-on consumers; open the
-remote door only when what is behind it is measured, affordable, resumable, and
-portable; and promise stability last, because a contract freezes everything
-underneath it.
-
-### v2.14 - The perspective release ("why do you believe that?")
-
-Completes the epistemic core while the belief store is still easy to
-migrate. Design: [docs/design/temporal-knowledge-graph.md](docs/design/temporal-knowledge-graph.md).
-
-1. [x] Belief event log (shipped: append-only `events.jsonl` dual-written with the legacy window; `what_changed` reads the log when present and is exact with no truncation; legacy stores keep the honest caveat)
-2. [x] Typed edges + migration (shipped: `Edge` store with canonical-key dedup + provenance accumulation, symmetric `contradicts`, idempotent migration of legacy `contradictions_with` lists, contested/detected write paths route through `add_edge` with the legacy field mirrored for one release; `supports` edges now written for same-polarity related beliefs in the 0.35-0.7 similarity band - the free heuristic family, advisory structure only, never a confidence input)
-3. [x] `explain_belief` (`deepr expert why` + MCP `deepr_explain_belief`, tool 26) - the third temporal query, shipped: belief resolution by id or query-coverage text match, evidence roots, confidence trajectory from the event log (legacy fallback), depth-bounded cycle-safe walk over supports/derived_from chains, direct-neighbor contradictions with status. Read-side, cost-$0. Live-validated day one (the symmetric text matcher rejected a real query against the exact belief it described - fixed to query-coverage scoring with prefix tolerance).
-4. [x] `deepr_temporal_edges` - read-only MCP query over typed edge qualifiers, with `valid_at`, `observed_since`, `observed_until`, `edge_type`, `belief_ref`, and bounded `limit` filters. Host agents can ask for the time-scoped relationship set directly instead of first resolving one belief through `explain_belief`.
-5. [x] Regenerated expert digest (`deepr expert digest`, shipped): compile pass over beliefs + typed edges + contradictions into a browsable Markdown view - $0, no LLM (synthesis at compile time over structured truth), byte-stable for an unchanged store (the "as of" stamp derives from the latest belief event, not the clock), open contradictions surfaced with the adjudication pointer, temporal edge qualifiers rendered with valid time, observed time, scope, provenance, and missing-endpoint honesty, and a derived-view marker the CLI checks before overwriting (a digest without the marker may have been hand-edited - the regeneration invariant made executable)
-6. Loop-closer completion: autonomous gap-fill execution (route-gaps
-   advises -> executes within budget), auto re-research from reflection
-   follow-ups, absorb-time contradiction flags in the health-check menu
-
-### v2.15 - The evidence release ("prove it")
-
-Turns claims into measurements before any wider exposure. Design:
-[docs/design/calibration-and-trust.md](docs/design/calibration-and-trust.md).
-
-1. [x] Source-trust floors (shipped 2026-06-11 - see the panel-findings entry; deterministic read-time ceilings, retroactive, regression-tested through every write path)
-2. [x] Belief lifecycle substrate (shipped 2026-06-12, design:
-   [docs/design/belief-lifecycle.md](docs/design/belief-lifecycle.md)):
-   bi-temporal valid time on events, lossless snapshot archival +
-   restore, usage-salience counters (protective-only), health-check
-   archive candidates + `--archive-stale` consolidation pass - all $0,
-   grounded in the memory-systems corpus review (monotonic accumulation
-   is the literature's root failure mode)
-3. [~] Calibration harness + published `docs/CALIBRATION.md`; absorb threshold
-   derived from the measured curve. Shipped 2026-06-13 ($0, tested): the
-   measurement engine (reliability curve, ECE, numpy Platt scaling, derived
-   threshold), `deepr eval calibrate --from`, and the FActScore/SAFE-shaped
-   grading orchestrator (`grade_corpus`). Paid `--corpus` run executed
-   2026-06-14 (~$0.69, gpt-5 grader): it reproduced **saturation** - 100%
-   grounded, no derivable threshold. An adversarial over-reach probe
-   (`tests/data/calibration-hard/`, ~$0.04 extraction-only check) then showed
-   *why*: the extractor defuses planted traps by attributing/qualifying (78/78
-   grounded), so the saturation is **extraction faithfulness, not a measurement
-   gap**. Conclusion (don't chase this): confidence-vs-grounding calibration is
-   degenerate here because extraction is good; the trust story is carried by the
-   continuity metrics + absorb verdict transparency, not a calibration curve.
-   The cheap probe before the expensive grade is the frugal-validation discipline
-   working - it caught a doomed full run for $0.04. Details in docs/CALIBRATION.md.
-4. [x] Entailment-shaped contradiction screen at absorb (2026-06-14): the
-   lexical heuristic routes, a cheap model entailment verdict concludes, so the
-   brittle check no longer mints phrasing-level false contested beliefs
-   (`verify_contradictions` default on; refuted -> absorbed, confirmed ->
-   `model_confirmed`, failure -> conservative). The atomicity half is **CUT** -
-   atomic decomposition stays the extraction model's job; a deterministic
-   atomicity monitor is the brittle-rule anti-pattern (tried/removed 2026-06-14).
-   Boundary in [docs/design/checks-deterministic-vs-agentic.md](docs/design/checks-deterministic-vs-agentic.md);
-   see the STOP banner. Remaining: same verdict on the health-check surface,
-   and calibrate the verdict via the evidence layer.
-5. Eval methodology v2 (expert-specific metrics + continuity-property
-   metrics, versioned methodology); A/B shadow mode once there are
-   metrics to compare. Continuity-property metrics shipped 2026-06-13
-   (`deepr eval continuity`); see Phase 3.
-6. Engineering evidence (Phase E continuation): `mcp/` strict gate,
-   mutation-score baseline + ratchet, fault-injection tests; [x] frontend
-   lint/tsc/build now a blocking CI job (2026-06-11 - previously
-   local-only, which is how a type-breaking dangling identifier and a
-   missing ESLint config survived for months)
-
-### v2.16 - The capacity release ("stop paying twice")
-
-Phase 6 in full: plans and hardware people already pay for become bounded
-research capacity, making always-on freshness affordable. Design:
-[docs/design/capacity-waterfall.md](docs/design/capacity-waterfall.md).
-
-Current baseline: `deepr capacity` visibility, `deepr capacity next`, local-only
-expert creation, the local Ollama execution path, `deepr eval local` with a
-local Ollama judge, `deepr eval local-context`, source-pack sync artifacts,
-saved-artifact local admission, runtime admitted-score quality gating, routing
-quality priors, coordinated expert/report/runtime roots through guided setup
-([ADR 0004](docs/decisions/0004-one-experts-root-and-portable-data-dir.md)),
-normalized `ResearchBackend` profiles, the append-only `quota_ledger.jsonl`
-substrate, backend eligibility decisions, and backend selection with measured
-quality floors are in place. The remaining work connects real plan-quota
-adapters to that substrate and teaches schedulers to consume it. Completed
-release details live in [docs/CHANGELOG.md](docs/CHANGELOG.md).
-
-1. [~] Backend abstraction + quota ledger + eligibility/selection gates + `deepr capacity` visibility (visibility, `ResearchBackend`, quota ledger, eligibility decisions, backend selection, and local score-gated runtime selection are in place; live vendor probes and adapter writes remain)
-2. [x] Local-first process validation (ollama-backed `research_fn` through the injectable seams) - in place, the substrate the rest builds on
-3. [~] `expert make --local`, `local-ollama`, and `--local` wiring are in place; local sync now supports `--fresh-context` and `--deep-context` with free-only retrieval, saved local eval artifacts and source-pack run artifacts are in place, and automatic local routing requires a measured admitted score; plan-quota CLI adapter work remains
-4. [~] Capacity-waterfall routing with quality gates; local rung, local/CLI comparison, local context eval, fresh/deep-context local sync, source-pack artifacts, eval-artifact admission, runtime admitted-score gating, eligibility gate, and pure selector are in place. Remaining work is adapters, live probes, auto-mode runtime integration, and scheduler integration.
-5. [x] Capacity QOL completion: `deepr capacity next` ranked actions, latest-artifact hints, and concrete job previews are in place (`--expert`, `--report-id`, `--context-mode`, `--scheduled`), including wait guidance for fresh/deep scheduled sync jobs that should not fall through to metered API. `deepr expert sync --scheduled` consumes that guidance for due subscription syncs and returns a wait payload instead of spending when owned/prepaid capacity is blocked. `deepr expert route-gaps --execute --scheduled` runs only when the waterfall returns local or trusted plan capacity for `gap_fill`; otherwise it returns pending routes and waits instead of starting metered gap-fill research. `deepr expert reflect --scheduled` waits before the reflection evaluator or follow-up research can run from recurring jobs. `deepr expert health-check --scheduled` emits the read-only v2 scheduler action plan without a loop run, and `--archive-stale --scheduled` waits with durable state for explicit confirmation before any local mutation unless `--yes` is set.
-6. [ ] Multi-account pools last (multiplies a working mechanism)
-
-### v2.17 - The loop/interchange release ("keep it current, prove it, hand it off")
-
-Makes the loop-engineering promise explicit while staying inside Deepr's role:
-experts maintain verified knowledge state; they do not become a general-purpose
-workflow orchestrator. This release lands after capacity because routine loops
-need cheap/default-free execution, and before hosted reach because remote agents
-need a stable local contract to consume.
-
-Design: [docs/design/verified-expert-loops.md](docs/design/verified-expert-loops.md).
-
-1. [x] Loop admission contract: no surface graduates from advisory to
-   autonomous until the task repeats, the verifier is automated, the
-   budget/capacity envelope is explicit, and the loop has tools/logs/state for
-   failure diagnosis. The contract is now codified in `LoopAdmissionContract`
-   and exposed through the loop-status dashboard API. Sync, reflection, and
-   health-check are admitted; gap-fill remains supervised until gap-closure
-   verifier evidence is recorded.
-2. [x] `ExpertLoopRun` substrate + `deepr expert loop-status` + MCP read tool:
-   schema-versioned loop-run records, typed stop reasons, append-only
-   per-expert storage, acceptance metrics, cost per accepted change, and
-   read-only CLI and MCP status are in place. Scheduled wait and action-plan
-   surfaces for sync, gap-fill, reflection, and health-check now append
-   loop-run snapshots and return `loop_run` JSON. Successful sync, non-dry
-   gap-fill execution, reflection, health-check audit, and confirmed health
-   archive runs also record completed, failed, budget-stopped,
-   verifier-failed, or human-gated loop snapshots with spend, verifier outcome,
-   and accepted-change metrics where applicable. The dashboard API now exposes
-   `/api/experts/{name}/loop-status` as a read-only rollup over those records.
-3. [x] Loop completion contract: a loop closes only on verifier pass, no due work
-   under the current contract, budget/capacity exhaustion, human gate, or a typed
-   failure reason. `ExpertLoopRun` now rejects terminal records without a typed
-   stop reason and rejects stop reasons that do not match the run status, so
-   model self-declared completion cannot enter the durable loop record.
-4. [x] Loop dashboard/API surface: `/api/experts/{name}/loop-status` returns the
-   latest run, last sync result, next scheduled action, capacity source, spend,
-   acceptance metrics, verifier-failure counts, freshness telemetry, 7-day and
-   30-day gap velocity, top open gaps, and contested/open claim state.
-5. [x] OKF export/import: `export-okf` as a regenerated derived view over the
-   belief/event/edge store; `absorb-okf` as a verified ingestion path. Include
-   `index.md`, `log.md`, bundle-relative links, citations, gaps, contested claims,
-   and optional `llms.txt` discovery. Export is now implemented as a `$0`
-   derived bundle with marker-based overwrite protection; `absorb-okf` parses
-   OKF concept documents into source text and routes them through the existing
-   extraction, grounding, dedup, and contradiction gates.
-
-### v2.18 - The reach release ("callable from anywhere")
-
-Opens the remote door after evidence (2.15), cheap capacity (2.16), and a local
-loop/interchange contract (2.17), because a hosted endpoint invites always-on
-consumers who will exercise all three. Design:
-[docs/design/hosted-mcp-endpoint.md](docs/design/hosted-mcp-endpoint.md).
-
-1. [~] Streamable HTTP transport; scoped API keys (mode/expert/budget/rate);
-   tool-call audit log (doubles as the mutation audit trail). `deepr mcp serve
-   --http` now runs the existing MCP server over HTTP/SSE, and the
-   scoped-key/audit primitive authenticates key records, enforces mode plus
-   expert allowlists before tool dispatch, enforces per-key budget ceilings from
-   audited spend plus deterministic tool estimates, fails closed for metered
-   remote tools that lack an estimate, enforces per-key rate limits from recent
-   audited calls, enforces a global HTTP POST concurrency cap with 429 retry
-   metadata, and records append-only remote-call audit events with response cost
-   attribution when available. `deepr mcp audit list` and
-   `deepr mcp audit summary` now make those local audit records operable with
-   filters, JSON output, and aggregate counts/costs by key, tool, and outcome.
-   `deepr-mcp-remote-audit-v1` is now published under `docs/schemas/` so the
-   append-only audit trail has a stable validation contract.
-   `deepr mcp smoke-http` now blocks before network access, and
-   `deepr mcp registration-manifest` emits a network-free, token-redacted
-   `deepr-mcp-registration-manifest-v1` endpoint packet that records remote
-   smoke as blocked pending cost authority.
-   `deploy/mcp-http.md` documents the TLS reverse-proxy recipe.
-   `deploy/mcp-http/` now adds the
-   container variant with scoped-key bootstrap, loopback-only host publishing,
-   and network-free manifest guidance. The Azure Container Apps, AWS ECS
-   Fargate, GCP Cloud Run, and Cloudflare Worker files are mechanically inert
-   reference templates. They are not supported deployments and have no live
-   cloud validation or ledger-bound cost guarantee. A2A now serves the current
-   `/.well-known/agent-card.json` discovery path while preserving the legacy
-   `/.well-known/agent.json` alias. `deepr a2a validate-host` validates its
-   offline fixture, while URL-based validation blocks before network because a
-   remote host cannot attest its own spend posture. Future hosted support
-   requires independent service-cost authority plus live third-party host
-   validation; neither is shipped. The key CLI is shipped as `deepr mcp keys`.
-2. [~] Versioned handoff schemas (downstream agents get stability guarantees):
-   `deepr_expert_handoff` and `/api/experts/{name}/handoff` now return the
-   `$0`, read-only `deepr-expert-handoff-v1` payload with profile summary,
-   manifest counts, bounded claims/gaps, dashboard telemetry, loop-status
-   rollup, OKF interchange hints, and an additive compatibility contract.
-   JSON Schema is published at `docs/schemas/expert-handoff-v1.json`.
-   `deepr-loop-status-v1`, `deepr-okf-profile-v2` (with deprecated v1), and
-   `deepr-mcp-remote-audit-v1`, `deepr-mcp-registration-manifest-v1`,
-   `deepr-a2a-task-v1`, `deepr-a2a-host-validation-v1`, and the scheduled
-   maintenance schemas in
-   `docs/schemas/registry.json` now publish the adjacent loop, OKF mapping,
-   hosted remote-audit, hosted registration, A2A task/result, A2A host
-   validation, and scheduler contracts with additive compatibility policy.
-3. Phase 4c `$0` structured-consultation comparison; only then consider a
-   read-only named-crew manifest when the repeated-roster and predeclared
-   non-regression gates pass. Autonomous research campaigns (Phase 4b) remain
-   last - the multi-expert deliverables, consumable remotely
-4. Ops analytics: cost-vs-quality frontier, routing-drift and anomaly
-   alerts (flying blind ends before 3.0)
-
-### v3.0 - The contract release (criteria, not features)
-
-3.0 is declared when an always-on agent platform can rely on Deepr as
-organizational knowledge infrastructure *without the author in the loop*.
-The criteria, all measurable:
-
-- [x] Handoff schemas versioned with a published deprecation policy
-- [x] Loop-status and OKF profile schemas versioned with backward compatibility
-- [x] Scheduled maintenance wait/action-plan schemas versioned with backward
-      compatibility
-- [ ] Calibration published and current for the shipping extraction model
-- [ ] Hosted endpoint with scoped auth, per-key budgets/rate limits, audit log
-- [ ] Multi-user safety: RBAC, workspace isolation, mutation audit trail
-- [x] A documented supported-surface statement (what is stable, what is
-      experimental, what export guarantees exist if the project stops)
-- [ ] Zero known silent-money paths (every spend source writes the
-      canonical ledger; proven by fault-injection, not assertion)
-
-Anything not on this list ships in a 2.x when ready; nothing waits for 3.0
-that does not gate the contract.
-
-### Deliberately unversioned
-
-- **Phase E** (engineering standards), **Phase Q** (code-health hardening),
-  and **model-registry currency** are continuous - every release carries its
-  share.
-- **Bug-hunt sweeps and live validations** happen per release, not as
-  versioned features (they have found real bugs every time they have run).
-- **Intentionally not planned**: hosted-by-Deepr SaaS, SLAs, enterprise
-  SSO before team features exist, full SLSA L3 (see Non-Goals) - listed so
-  their absence reads as a decision, not an oversight.
+The active dependency ladder is
+[Next Order Of Operations](#next-order-of-operations). Completed release
+history and superseded planning live in the changelog and published Git
+references, not in a competing roadmap section.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,8 +54,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profiles, OpenClaw, DeepSeek Harness, Grok Build, Codex, NemoClaw and
   OpenShell, lineage-only steering, and external workspace evidence. Optional
   MCP extensions remain deferred until the core bridge exposes a measured gap.
+- Reconciled the active roadmap into one dependency-ordered version ladder and
+  refreshed host evidence against current official OpenClaw, DeepSeek Harness,
+  Grok Build, Grok Bot, NemoClaw, and OpenShell releases. Stable, prerelease,
+  fixture-validated, and reference-only claims remain distinct.
 
 ### Fixed
+
+- Restored fail-closed production blocks for Codex, Grok Build, and Antigravity
+  plan adapters. Hardened argument builders remain defense-in-depth fixtures;
+  only Claude Code currently satisfies Deepr's native-tool and authenticated
+  paid-extra-usage-off gates.
+- Registered the existing pause and resume task handlers in MCP discovery,
+  restoring the documented 36-tool catalog while keeping both write-class
+  tools outside read-only profiles.
 
 - The installed `deepr-mcp` entrypoint no longer imports optional DOCX and
   Azure storage implementations during startup. The local read-only Agent
@@ -639,14 +651,14 @@ gives an expert a way to decide what to read.
 - House style is enforced rather than requested: en dashes, em dashes and curly
   quotes are normalized out of brief fields.
 
-## [2.44.0] - 2026-08-05
+### Expert v2 development included in 2.45.0
 
 Experts stop being fact ledgers. This release lands the first executable slice of
 the v2 expert architecture: an expert now keeps the material it learned from, can
 read that material several ways, and renders what it found as a notebook rather
 than a confidence-sorted bullet list.
 
-### Added
+#### Added
 
 - **Corpus retention** (`deepr.experts.corpus_store`): sources are kept
   content-addressed under the expert, with origin identity, publisher, and trust
@@ -672,7 +684,7 @@ than a confidence-sorted bullet list.
   reading order - how it works, what breaks, where sources disagree, what is
   missing - with confidence off the headline and coverage stated in the body.
 
-### Fixed
+#### Fixed
 
 - Belief dedup routing was polarity-blind, so "X ships in v2" and "X does not
   ship in v2" scored as near-identical. Combined with the new provenance merge,
@@ -690,7 +702,7 @@ than a confidence-sorted bullet list.
   define, and did not say that the step it runs is metered-gated and fails
   closed while paid dispatch is frozen.
 
-### Documentation
+#### Documentation
 
 - [Expert v2 architecture](design/expert-v2-architecture.md): an expert is a
   maintained corpus, study notes derived from it, positions it will defend, and a
@@ -702,7 +714,7 @@ than a confidence-sorted bullet list.
   tradecraft) with what they support, what they contradict, and what not to
   build. Includes findings that went against choices already made here.
 
-### Known limitations
+#### Known limitations
 
 - Perspective lenses are provisional. Two independent studies found expert
   personas do not improve factual accuracy; the claim that they surface
@@ -712,9 +724,9 @@ than a confidence-sorted bullet list.
   calibration harness has not produced a non-degenerate curve. Do not read a
   confidence value as a probability.
 
-## [Previously unreleased]
+### Earlier development included in 2.45.0
 
-### Fixed
+#### Fixed
 
 - A2A lightweight HTTP transport no longer labels non-2xx responses as
   `OK`, and incomplete or timed-out request bodies/headers return explicit
@@ -725,7 +737,7 @@ than a confidence-sorted bullet list.
 - Dependency audit: `cryptography` 50.0.0 and frontend npm high-severity
   advisory fixes (`brace-expansion`, `socket.io-parser`).
 
-### Changed
+#### Changed
 
 - Research Studio surfaces a paid-API-freeze banner, blocks submit while frozen,
   and steers operators to local/plan expert workflows.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Registered the existing pause and resume task handlers in MCP discovery,
   restoring the documented 36-tool catalog while keeping both write-class
   tools outside read-only profiles.
+- Updated the blocking dependency-audit environment to pip 26.2 after
+  `PYSEC-2026-3721` made the runner-provided pip 26.1.2 fail the clean audit.
 
 - The installed `deepr-mcp` entrypoint no longer imports optional DOCX and
   Azure storage implementations during startup. The local read-only Agent

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -1,6 +1,6 @@
 # Supported Surface
 
-Status: v2.49.2 current main, 2026-08-20. This document defines what users and host
+Status: v2.49.2 current main, 2026-08-21. This document defines what users and host
 agents can rely on today, what is experimental, what is planned only, and what
 data remains portable if development stops. Unattended metered dispatch remains
 frozen until provider account-control adapters land. The narrow attended absorb
@@ -24,10 +24,12 @@ hard stop with overage disabled are also mandatory for dispatch. An open
 postpaid account remains blocked even with wallet credits. MCP,
 schedules, loops, and automatic fallback ignore the local wallet.
 
-The Expert Hub has an explicit 25-expert flagship tier and a complete standard
-tier. Its readiness field reports only whether durable presentation structure
-exists: a portrait, standpoint, position, studied finding, and retained
-source. It does not certify correctness, importance, or expert quality.
+The Expert Hub has a user-curated flagship tier and a complete standard tier.
+The pictured maintainer reference fleet currently selects 25 flagship experts;
+a clean install does not seed that roster or guarantee that count. Its readiness
+field reports only whether durable presentation structure exists: a portrait,
+standpoint, position, studied finding, and retained source. It does not certify
+correctness, importance, or expert quality.
 
 **Historical v2.47.0 attended authority is superseded by the v2.49.0 wallet.** A person at the CLI could issue a typed,
 expiring grant with a non-configurable $2 total maximum, then run the supported
@@ -46,11 +48,14 @@ This matters to the portability contract below, so it is stated here rather
 than only in the changelog. Nothing is lost and nothing needs converting by
 hand: `deepr expert migrate` moves an expert in place, dry run by default, and
 every reader resolves the old path when only the old path exists, so an
-un-migrated expert stays fully readable. All 57 experts in the reference fleet
-were migrated and verified field by field against a pre-migration backup with
-zero differences. `beliefs/` and `knowledge/` are v1 storage and are untouched.
+un-migrated expert stays fully readable. The maintainer's 57-expert reference
+fleet was migrated and verified field by field against a pre-migration backup
+with zero differences; that count is evidence from one local fleet, not an
+installed product invariant. `beliefs/` and `knowledge/` are v1 storage and are
+untouched.
 
-**v2.44.0 added the expert study surface as experimental**: retained corpus
+**Development later shipped in v2.45.0 added the expert study surface as
+experimental**: retained corpus
 (`corpus/index.jsonl` plus content-addressed sources), the multi-lens study pass,
 coverage reporting, and the notebook render. These are additive; existing belief
 stores are untouched and keep working. The study pass proposes findings and never
@@ -649,10 +654,17 @@ must not be described as usable capacity.
   marginal-cost, or process-safety gates.
 - Multi-account capacity pools are planned after a single-account mechanism is
   complete.
-- Host-specific Agent Plugin installation recipes, remote MCP routes, steering,
-  and external computer control remain planned. They require independently
-  validated host capability profiles and cannot widen the shipped local
-  read-only package boundary.
+- Host-specific profiles, remote MCP routes, steering, and external computer
+  control remain planned. The first local fixtures target OpenClaw stable
+  `v2026.7.1-2` through explicit MCP plus a skill, DeepSeek Harness
+  `dsh-v0.1.1-rc.2`, and Grok Build 1.0.6. OpenClaw native Agent Plugins support
+  remains a separate `v2026.8.1-beta.2` prerelease evidence lane. Manual Grok
+  Bot installation is a valid future host path, but no public Bot lifecycle API
+  is claimed. NemoClaw `v0.0.113` with its pinned OpenShell 0.0.106 remains a
+  reference-only remote profile. Every path requires independently validated
+  host capability evidence and cannot widen the shipped local read-only package
+  boundary. See
+  [external-harness-investigation-bridge.md](design/external-harness-investigation-bridge.md).
 - OKF 0.2 export and offline form validation ship under
   `deepr-okf-profile-v2`. Import remains permissive, untrusted, and
   verification-gated. Runtime computation execution and attestation do not

--- a/docs/design/agent-harness-lessons-2026.md
+++ b/docs/design/agent-harness-lessons-2026.md
@@ -1,6 +1,6 @@
 # Agent Harness Lessons for Deepr
 
-Status: researched roadmap design, updated 2026-08-20. Nothing in this document is
+Status: researched roadmap design, updated 2026-08-21. Nothing in this document is
 shipped merely because it is described here.
 
 The current Deepr-specific integration decision is
@@ -24,13 +24,16 @@ safe.
   backends behind one personal-agent gateway
   ([repository](https://github.com/NousResearch/hermes-agent),
   [release](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.7)).
-- OpenClaw 2026.6.6, released 2026-06-12, emphasizes an always-on local
+- OpenClaw stable `v2026.7.1-2`, released 2026-08-04, emphasizes an always-on local
   gateway, scoped skills, session snapshots, device pairing, sandboxing,
   prepared approvals, fail-closed execution, and release-integrity evidence
   ([repository](https://github.com/openclaw/openclaw),
   [security model](https://github.com/openclaw/openclaw/blob/main/docs/gateway/security/index.md),
   [skills](https://github.com/openclaw/openclaw/blob/main/docs/tools/skills.md),
-  [release](https://github.com/openclaw/openclaw/releases/tag/v2026.6.6)).
+  [release](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1-2)).
+  Agent Plugins support is currently limited to prerelease
+  `v2026.8.1-beta.2`, so stable integration must use explicit MCP plus a skill
+  ([prerelease](https://github.com/openclaw/openclaw/releases/tag/v2026.8.1-beta.2)).
 - Pi v0.73.1, released 2026-05-07, keeps the harness composable across model
   APIs, core loop, TUI, SDK, and JSON-RPC. Its session model distinguishes
   steering from follow-up input and supports abort recovery, trees, and forks
@@ -54,24 +57,31 @@ safe.
   experience, not the shared authority model
   ([overview](https://docs.x.ai/grok-bot/overview),
   [security](https://docs.x.ai/grok-bot/approvals-security-and-privacy)).
-- Grok Build supports MCP configuration and reusable workflows with parallel
-  agents and verification. It is therefore a plausible external Deepr host,
-  separately from any eligibility as a Deepr plan-capacity adapter
+- Grok Bot is now listed as an Agent Plugins client, making manual package or
+  MCP installation a real host target. No public Bot lifecycle API is
+  documented, so automated creation, routing, takeover, and routine management
+  remain outside the implementation target
+  ([compatible clients](https://agent-plugins.org/compatible-clients)).
+- Grok Build 1.0.6 supports MCP configuration and reusable workflows with
+  parallel agents and verification. Its inspected executable version and
+  disabled auto-update state must be evidence, and its lack of an exact MCP
+  tool filter leaves Deepr authorization authoritative. It is a plausible
+  external Deepr host, separately from any eligibility as plan capacity
   ([MCP](https://docs.x.ai/build/features/mcp-servers),
   [workflows](https://x.ai/news/workflows)).
-- DeepSeek Harness developer preview makes capabilities profile-composed
+- DeepSeek Harness `dsh-v0.1.1-rc.2` makes capabilities profile-composed
   plugins and reconstructs resume, fork, search, replay, and UI views from an
   append-only session log. Deepr should adopt the narrower host-profile and
   projection seams, not the general plugin kernel or private-reasoning log
   ([overview](https://deepseek.com/harness/en/),
-  [architecture](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/architecture.md)).
+  [architecture](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/docs/architecture.md)).
 - OpenClaw now documents remote and stdio MCP servers with tool filters and
-  distinct sandbox, tool-policy, and elevated-execution controls. NemoClaw adds
-  an OpenShell deployment profile with sandbox, egress, credential-alias,
-  snapshot, and lifecycle controls. Both are practical external host targets,
-  not Deepr runtime dependencies
+  distinct sandbox, tool-policy, and elevated-execution controls. NemoClaw
+  `v0.0.113` pins OpenShell 0.0.106 for its managed-MCP boundary. Both are
+  practical external host targets, not Deepr runtime dependencies, and the
+  NemoClaw pair remains reference-only until Deepr validates it
   ([OpenClaw MCP](https://docs.openclaw.ai/gateway/configuration-reference),
-  [NemoClaw overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html)).
+  [NemoClaw release](https://github.com/NVIDIA/NemoClaw/releases/tag/v0.0.113)).
 
 ## Adopt
 

--- a/docs/design/evidence-first-expert-investigations.md
+++ b/docs/design/evidence-first-expert-investigations.md
@@ -116,7 +116,7 @@ following boundary:
 The implementation composes these primitives without creating a second belief
 store, a second cost system, or a hidden agent runtime.
 
-## Research basis through 2026-08-20
+## Research basis through 2026-08-21
 
 The strongest current evidence favors centralized, selective collaboration:
 
@@ -140,14 +140,15 @@ The strongest current evidence favors centralized, selective collaboration:
   [Grok Bot security](https://docs.x.ai/grok-bot/approvals-security-and-privacy),
   [Grok Build MCP](https://docs.x.ai/build/features/mcp-servers), and
   [Grok Build workflows](https://x.ai/news/workflows).
-- DeepSeek Harness's append-only session projection, OpenClaw's filtered MCP
-  client, and NemoClaw's sandboxed managed-MCP path strengthen the case for a
-  versioned observer profile and replayable event projection. They do not
+- DeepSeek Harness `dsh-v0.1.1-rc.2` append-only session projection, OpenClaw
+  stable `v2026.7.1-2` filtered MCP client, and NemoClaw `v0.0.113` with its
+  pinned OpenShell 0.0.106 managed-MCP path strengthen the case for a versioned
+  observer profile and replayable event projection. They do not
   justify replacing the investigation state machine or moving credentials and
   computer workspaces into Deepr. Sources:
   [DeepSeek Harness](https://deepseek.com/harness/en/),
   [OpenClaw MCP](https://docs.openclaw.ai/gateway/configuration-reference), and
-  [NemoClaw managed MCP](https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/manage-sandboxes/mcp-servers/add-an-mcp-server).
+  [NemoClaw managed MCP](https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/manage-sandboxes/mcp-servers/about-managed-mcp-servers).
 - Anthropic's production research system uses a lead agent to delegate
   breadth-first searches to parallel subagents, then adds citation processing.
   It reports a substantial internal quality gain and roughly 15 times the token

--- a/docs/design/external-harness-investigation-bridge.md
+++ b/docs/design/external-harness-investigation-bridge.md
@@ -1,6 +1,6 @@
 # External Harness Bridge for Expert Investigations
 
-Status: proposed boundary refinement, researched 2026-08-20. No remote
+Status: proposed boundary refinement, researched 2026-08-21. No remote
 investigation bridge or direct Grok Bot integration is shipped by this note.
 
 Read [AGENTIC_BALANCE.md](../plans/AGENTIC_BALANCE.md),
@@ -48,26 +48,43 @@ Deepr. Sources: [overview](https://docs.x.ai/grok-bot/overview),
 [computer](https://docs.x.ai/grok-bot/computer-and-apps), and
 [security](https://docs.x.ai/grok-bot/approvals-security-and-privacy).
 
-Grok Build supports project MCP configuration and workflow files that can
-coordinate parallel agents with verification. That makes Grok Build a
-plausible host for Deepr's MCP tools. It does not make its hidden children or
-tools eligible Deepr capacity. Sources:
-[MCP servers](https://docs.x.ai/build/features/mcp-servers) and
+Agent Plugins now lists Grok Bot as a compatible client for Agent Skills and
+stdio, Streamable HTTP, and legacy SSE MCP. This makes manual Deepr plugin or
+MCP installation a real host target. It does not add a public Bot lifecycle API
+or make the shared VM a Deepr security boundary. Source:
+[compatible clients](https://agent-plugins.org/compatible-clients).
+
+Grok Build 1.0.6 supports project MCP configuration in `.grok/config.toml`,
+resolved-configuration evidence through `grok inspect --json`, and workflow
+files that can coordinate parallel agents with verification. Controlled host
+evidence must disable auto-update and bind the inspected executable version.
+The documented MCP configuration has no exact tool filter, so Deepr's scoped
+server surface remains authoritative. It does not make Grok Build's hidden
+children or tools eligible Deepr capacity. Sources:
+[settings](https://docs.x.ai/build/settings),
+[MCP servers](https://docs.x.ai/build/features/mcp-servers),
+[headless operation](https://docs.x.ai/build/cli/headless-scripting), and
 [workflows](https://x.ai/news/workflows).
 
 No documented public Grok Bot management API was found in the official Grok
-Bot material reviewed on 2026-08-20. A direct Bot adapter is therefore not a
-current implementation target. Grok Build can be evaluated as an MCP host, and
-a Grok Bot user can supervise that host manually, but Deepr must not claim
-automated Bot creation, routing, or takeover support without a published and
-testable interface.
+Bot material reviewed on 2026-08-21. Automated Bot creation, routing, takeover,
+and routine management are therefore not current implementation targets. A
+Grok Bot operator may install or supervise a Deepr plugin or MCP connection
+manually, but Deepr must not claim automated lifecycle support without a
+published and testable interface. Grok Bot also lacks a documented per-product
+spend cap, so its host controls cannot replace Deepr's zero-spend or bounded
+server-side authority. Source:
+[team controls](https://docs.x.ai/grok-bot/teams-and-enterprises).
 
 ### DeepSeek Harness
 
-DeepSeek Harness is a developer preview built around replaceable plugins and
-profiles. Its append-only session log drives resume, fork, search, replay, and
-UI trajectory projections. Its MCP client maps remote server tools into the
-host tool registry. These are strong evidence for two narrow Deepr additions:
+DeepSeek Harness `dsh-v0.1.1-rc.2` is a developer preview built around
+replaceable plugins and profiles. Its append-only session log drives resume,
+fork, search, replay, and UI trajectory projections. Its MCP client maps remote
+server tools into the host tool registry. A Deepr profile should fail on MCP
+startup errors instead of silently degrading. Harness tool restriction is a
+visibility mechanism, not Deepr authorization. These are strong evidence for
+two narrow Deepr additions:
 
 - a versioned host profile with an exact tool allowlist; and
 - replayable UI or chat projections over Deepr's authoritative event journal.
@@ -76,42 +93,48 @@ Deepr should not copy the Cordis plugin kernel, record private model reasoning,
 or let plugins replace budget, evidence, or memory authority. The Harness is in
 developer preview and states that its APIs will continue to evolve. Sources:
 [product overview](https://deepseek.com/harness/en/),
-[architecture](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/architecture.md),
+[release](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.1-rc.2),
+[architecture](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/docs/architecture.md),
 and
-[MCP client](https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/mcp/mcp-client/README.md).
+[MCP client](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/mcp/mcp-client/README.md).
 
 ### OpenClaw
 
-OpenClaw is an external gateway, channel, session, workspace, tool, skill, and
-agent runtime. Its current configuration supports stdio and remote MCP servers,
-per-server timeouts, tool include and exclude filters, OAuth identity posture,
-TLS controls, and per-agent projection. Its sandbox, tool policy, and elevated
-execution controls are intentionally distinct.
+OpenClaw stable `v2026.7.1-2` is an external gateway, channel, session,
+workspace, tool, skill, and agent runtime. Its configuration supports stdio and
+remote MCP servers, per-server timeouts, tool include and exclude filters,
+OAuth identity posture, TLS controls, and per-agent projection. Its sandbox,
+tool policy, and elevated execution controls are intentionally distinct.
 
-That makes OpenClaw a practical first host integration. The first Deepr recipe
-should use MCP plus the existing exported `SKILL.md`, with an exact observer
-tool allowlist. A Deepr-specific OpenClaw plugin is unnecessary until MCP and a
-skill cannot express a measured requirement. Sources:
+That makes OpenClaw a practical first host integration. The first stable Deepr
+profile should use explicit MCP plus the existing exported `SKILL.md`, with an
+exact observer tool allowlist. Native Agent Plugins support appears only in
+prerelease `v2026.8.1-beta.2`, so it belongs in a separate prerelease evidence
+lane until a stable release carries the capability. In either lane, the host
+still needs an installed `deepr-mcp` executable. Sources:
+[stable release](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1-2),
 [MCP configuration](https://docs.openclaw.ai/gateway/configuration-reference),
 [tool policy](https://docs.openclaw.ai/tools), and
-[sandboxing](https://docs.openclaw.ai/sandboxing).
+[prerelease](https://github.com/openclaw/openclaw/releases/tag/v2026.8.1-beta.2).
 
 ### NemoClaw and OpenShell
 
-NVIDIA documents NemoClaw as a reference stack for running supported harnesses,
-including OpenClaw, inside OpenShell sandboxes with network, filesystem,
-process, inference, snapshot, and lifecycle controls. Its managed MCP flow keeps
-the secret value outside sandbox configuration and resolves a credential alias
-at egress.
+NVIDIA NemoClaw `v0.0.113` pins OpenShell 0.0.106 as the supported boundary,
+even though a newer standalone OpenShell release exists. It runs supported
+harnesses, including OpenClaw, inside sandboxes with network, filesystem,
+process, inference, snapshot, and lifecycle controls. Its managed MCP flow
+accepts authenticated HTTPS Streamable HTTP, keeps the secret value outside
+sandbox configuration, and resolves a credential alias at egress.
 
 NemoClaw is therefore a deployment and isolation profile for an external host,
 not a Deepr runtime dependency. A first recipe should connect a NemoClaw
 sandbox to Deepr's HTTP MCP endpoint using a dedicated scoped key and explicit
-egress rule. It should be labeled WSL or Linux reference integration until
-validated on a supported host. Sources:
-[overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html),
-[repository](https://github.com/NVIDIA/NemoClaw), and
-[managed MCP](https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/manage-sandboxes/mcp-servers/add-an-mcp-server).
+egress rule. It remains reference-only until Deepr validates that exact
+NemoClaw and OpenShell pair, including its managed-MCP path and release
+exceptions. Sources:
+[release](https://github.com/NVIDIA/NemoClaw/releases/tag/v0.0.113),
+[OpenShell pin](https://github.com/NVIDIA/NemoClaw/blob/v0.0.113/scripts/install-openshell.sh), and
+[managed MCP](https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/manage-sandboxes/mcp-servers/about-managed-mcp-servers).
 
 ### Other hosts and protocols
 
@@ -445,12 +468,15 @@ through the package with byte-reproducible output and no secret material.
 
 ### Bridge 3: contracts and drift audit
 
+Status: active. The 2026-08-21 re-audit restored explicit production blocks
+for Codex, Grok Build, and Antigravity. Contract publication remains pending.
+
 - Publish zero-call schemas for host profile, capability snapshot, control
   evidence, event page, artifact metadata page, follow-up, and fork lineage.
 - Add fixture validation proving projections cannot mutate a run or imply
   semantic acceptance.
-- Resolve Grok plan-adapter documentation and runtime drift by either restoring
-  the block or proving an exact-empty ambient capability set under tests.
+- Keep every non-Claude plan adapter blocked until its exact ambient capability
+  set, provider identity, and marginal-cost posture are proven before dispatch.
 
 Gate: all contracts are versioned, bounded, path-safe, backward-compatible, and
 accepted by the approach and supported-surface documents.
@@ -473,14 +499,19 @@ reconstructs the same visible lifecycle without changing canonical state.
 
 ### Bridge 5: popular host conformance
 
-- Prefer the conformant Agent Plugin package where a host supports it.
+- Prefer the conformant Agent Plugin package only where a stable host release
+  supports it. Keep prerelease support in a separate evidence lane.
 - Generate an offline observer profile and exact configuration fragment for
-  OpenClaw, DeepSeek Harness, Grok Build, and Codex where needed.
-- Treat NemoClaw plus OpenShell as a remote isolation recipe after HTTP auth,
-  egress, and endpoint-cost prerequisites pass.
+  OpenClaw `v2026.7.1-2`, DeepSeek Harness `dsh-v0.1.1-rc.2`, Grok Build 1.0.6,
+  and Codex where needed. Test OpenClaw Agent Plugins separately against
+  prerelease `v2026.8.1-beta.2` until the feature reaches stable.
+- Treat NemoClaw `v0.0.113` plus its pinned OpenShell 0.0.106 as a remote
+  isolation recipe after HTTP auth, egress, and endpoint-cost prerequisites
+  pass. Do not substitute a newer standalone OpenShell release.
 - Record host version, transport, exact tool inventory, validation evidence,
   and `reference`, `fixture_validated`, or `live_validated` status.
-- Do not claim direct Grok Bot automation or supported public hosting.
+- Allow a manual Grok Bot Agent Plugin or MCP host profile, but do not claim Bot
+  lifecycle automation or supported public hosting.
 
 Gate: every advertised host claim has a reproducible fixture or live evidence;
 reference-only recipes remain labeled as such.

--- a/docs/design/plan-quota-cli-backends.md
+++ b/docs/design/plan-quota-cli-backends.md
@@ -301,7 +301,7 @@ which CLI answered best.
 
 | Concern | Setting |
 |---|---|
-| auth-mode detection, metered-adapter cost-lifecycle gate, exhaustion and attempt-outcome accounting, redacted tail diagnostics, quota+cost ledger writes, argv construction, tool lockdown (`--deny-tool`/read-only sandbox), scratch cwd | **workflow** (deterministic, gated) |
+| auth-mode detection, metered-adapter cost-lifecycle gate, exhaustion and attempt-outcome accounting, redacted tail diagnostics, quota+cost ledger writes, argv construction, defense-in-depth CLI flags, scratch cwd | **workflow** (deterministic, gated) |
 | the research answer and the extracted beliefs | **agent** (model), then through the existing absorb gates: confidence floor, source-trust ceiling (research-derived = tertiary, capped), contradiction + dedup verdicts |
 
 The plan CLI is an answer generator on the cheap-capacity side of the waterfall;
@@ -315,7 +315,8 @@ high-confidence belief.
   auto-routing rung light up only when the candidate backend has observed
   headroom. The shared snapshot contract exists, and Codex, Claude Code, and
   Grok now write `VENDOR_REPORTED` ledger events from metadata-only
-  refreshes. Next probe: Antigravity as explicit-only metadata visibility.
+  refreshes. A future Antigravity probe is metadata visibility only and cannot
+  grant execution authority.
 - `deepr capacity` detection ids are exe-based (`kiro-cli`, `agy`) while
   execution ids are canonical (`kiro`, `antigravity`); the capacity quota display
   for those two does not yet join to execution-recorded usage. Cosmetic.
@@ -347,10 +348,12 @@ high-confidence belief.
   `answer_from_transcript=True` and the client uses this invocation-correlated
   result instead of stdout.
   Validated end to end 2026-06-25: `probe_plan_quota(antigravity)` returned the
-  expected reply in ~5.5s on plan auth. Antigravity stays explicit-only and ToS
-  gray-zone (active ban wave) despite working. Grok transport was previously
-  validated, but current execution is blocked and its policy remains gray. A ConPTY wrapper remains a possible alternative if
-  the transcript path ever changes.
+  expected reply in about 5.5 seconds on plan auth. That is historical
+  transport evidence only. Current Antigravity execution is blocked because
+  native tools and transcript side effects are not confined, and its headless
+  policy remains unproven. Grok transport was also previously validated, but
+  current execution is blocked and its policy remains gray. A ConPTY wrapper
+  remains a possible transport fixture if the transcript path ever changes.
 - OpenCode is BYO-provider and now fails closed as `unknown` before dispatch. A
   future adapter needs a trustworthy per-run provider identity, stored
   credential classification, marginal-cost proof, and native-tool confinement

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -1,5 +1,7 @@
 # External standards pins
 
+Last reviewed: 2026-08-21.
+
 Deepr validates external interoperability contracts offline. The pin registry
 records the upstream version, immutable revision, canonical byte length, and
 SHA-256 digest used by blocking checks. Network access is required only when an
@@ -11,6 +13,12 @@ contract, so Deepr pins the specification and implements its required fields,
 types, lengths, and directory identity in `deepr.skills.contract`. MCP keeps its
 existing dual-era conformance suite and pins the current 2026-07-28 schema as
 the external dependency anchor.
+
+Agent Plugins 1.0.0 and Agent Skills remain current at the pinned revisions.
+The MCP repository head has advanced through SDK and proposal guidance changes,
+but its published 2026-07-28 normative schema remains byte-identical to Deepr's
+pin. Deepr does not repin a normative fixture solely because an unrelated
+upstream head moved.
 
 These standards define installation and transport boundaries. They do not
 replace Deepr's authoritative runs, tasks, beliefs, evidence, budgets,

--- a/src/deepr/backends/plan_quota/adapters.py
+++ b/src/deepr/backends/plan_quota/adapters.py
@@ -268,10 +268,9 @@ def validate_model_identifier(model: str) -> str:
 
 def _codex_argv(prompt: str, model: str | None) -> list[str]:
     # `codex exec` is the non-interactive subcommand; stdout = final message,
-    # stderr = progress. Confined at dispatch: the read-only sandbox permits no
-    # writes and no execution outside it, and approvals are off so nothing can
-    # prompt its way past that. Network is disabled too, so a retrieved prompt
-    # cannot talk back out.
+    # stderr = progress. These flags are defense in depth for transport tests,
+    # not execution authority: the CLI still retains native read and shell tools
+    # and Deepr cannot prove an exact empty ambient capability set before launch.
     args = [
         "codex",
         "exec",
@@ -354,12 +353,9 @@ def _grok_argv(prompt_path: str, model: str | None) -> list[str]:
     # `--prompt-file <path>` is the only headless-safe delivery. The client writes
     # the prompt to the temp file at prompt_path.
     #
-    # Tools are stripped rather than trusted. A study or brief prompt carries
-    # retrieved web text, which is untrusted input that may contain
-    # instructions aimed at whatever reads it. Deepr wants one thing from this
-    # dispatch - text back - so every built-in that could touch the machine is
-    # removed and web access is turned off. Verified on this build: the answer
-    # returns clean with all of them gone.
+    # The deny list and disabled web search are defense in depth only. A deny
+    # list cannot prove that a newer CLI has no additional ambient tools, so the
+    # production adapter remains blocked before process construction.
     args = ["grok", "--no-auto-update", "--no-alt-screen", "--disable-web-search"]
     args += ["--disallowed-tools", ",".join(_GROK_DENIED_TOOLS)]
     args = _append_model(args, "--model", model)
@@ -372,13 +368,9 @@ def _antigravity_argv(prompt: str, model: str | None) -> list[str]:
     # because the non-TTY stdout-drop bug (June 2026) leaves captured stdout
     # empty on exit 0; the client treats empty output as an error.
     #
-    # `--sandbox` and `--mode plan` are the confinement. agy has no tool
-    # allowlist flag, so the two available levers are used instead: sandbox
-    # restricts the terminal, and plan mode cannot apply edits. Without both,
-    # a retrieved prompt reaches live file and shell tools, which is the thing
-    # the old execution block existed to prevent - removing the block without
-    # adding these left the invariant unsatisfied rather than satisfied by a
-    # different route.
+    # `--sandbox` and `--mode plan` are defense in depth. They do not prove an
+    # empty native-tool surface or contain transcript side effects, so the
+    # production adapter remains blocked before process construction.
     args = _append_model(["agy"], "--model", model)
     args += ["--sandbox", "--mode", "plan", "--disable-slash-commands", "--output-format", "text"]
     return [*args, "-p", prompt]
@@ -409,7 +401,10 @@ _ADAPTERS: tuple[PlanQuotaAdapter, ...] = (
         error_channel_exhaustion_signals=("you've hit your usage limit",),
         enabled_by_default=False,
         stdin_prompt=True,
-        value_note="visible/read-only; confined at dispatch by a read-only sandbox with no approvals and no network",
+        execution_block_reason=(
+            "Codex native read and shell tools cannot be reduced to an exact empty capability set before dispatch"
+        ),
+        value_note="visible/read-only; native tools are not proven absent before dispatch",
     ),
     PlanQuotaAdapter(
         backend_id="claude",
@@ -491,11 +486,15 @@ _ADAPTERS: tuple[PlanQuotaAdapter, ...] = (
         enabled_by_default=False,
         experimental=True,
         prompt_is_file=True,
+        execution_block_reason=(
+            "Grok Build native tool confinement, subscription automation policy, and exact non-metered posture "
+            "cannot be proven before dispatch"
+        ),
         tos_note=(
             "subscription (SuperGrok/X Premium+) headless use is ToS gray-zone; xAI steers "
             "automation to the metered API key. Verify the exhaustion signature on your build."
         ),
-        value_note="visible/read-only; built-in tools stripped at dispatch and web access off",
+        value_note="visible/read-only; deny-list confinement and non-metered posture are not sufficient proof",
     ),
     PlanQuotaAdapter(
         backend_id="antigravity",
@@ -511,12 +510,16 @@ _ADAPTERS: tuple[PlanQuotaAdapter, ...] = (
         experimental=True,
         needs_pty=True,
         answer_from_transcript=True,
+        execution_block_reason=(
+            "Antigravity native tools and transcript side effects cannot be confined for untrusted prompts, "
+            "and headless automation policy remains unproven"
+        ),
         tos_note=(
             "automated/headless use is ToS gray-zone amid an active account-ban wave; "
             "the CLI also drops stdout under a non-TTY pipe (June 2026), so the answer is "
             "recovered from its transcript file. Use at your own risk."
         ),
-        value_note="Google AI plan weekly compute cap, hard-stop (no overage)",
+        value_note="visible/read-only; native tools, transcript side effects, and automation policy are unproven",
     ),
     PlanQuotaAdapter(
         backend_id="copilot",

--- a/src/deepr/backends/plan_quota/process_launch.py
+++ b/src/deepr/backends/plan_quota/process_launch.py
@@ -30,10 +30,10 @@ cmd.exe and stops the argv Deepr built from being the argv that runs. The
 resolved path is required to sit under the shim's own directory and to be a
 real .exe, which is what keeps this an allowlist rather than a search.
 
-An installed CLI missing from this table is not blocked because it is unsafe;
-it is blocked because nobody has pointed at its native binary yet. Codex was
-in exactly that state - fully confined at dispatch, quota available, and
-unreachable."""
+    An installed CLI missing from this table is blocked because nobody has
+    pointed at its native binary yet. A listed native binary only establishes
+    argv-safe process launch. It does not grant adapter execution authority or
+    prove tool, billing, or policy confinement."""
 
 
 @dataclass(frozen=True)

--- a/src/deepr/mcp/tool_surface.py
+++ b/src/deepr/mcp/tool_surface.py
@@ -107,6 +107,25 @@ def register_bridge_tool_schemas(registry: ToolRegistry) -> None:
             cost_tier="free",
         )
     )
+    for name, action in (
+        ("deepr_resume_task", "Resume a paused durable task from its latest checkpoint."),
+        ("deepr_pause_task", "Pause a running durable task and retain its latest checkpoint."),
+    ):
+        registry.register(
+            ToolSchema(
+                name=name,
+                description=action,
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "task_id": {"type": "string", "description": "Durable task identifier"},
+                    },
+                    "required": ["task_id"],
+                },
+                category="tasks",
+                cost_tier="free",
+            )
+        )
     registry.register(
         ToolSchema(
             name="deepr_install_skill",

--- a/tests/unit/test_backends/test_plan_quota_adapters.py
+++ b/tests/unit/test_backends/test_plan_quota_adapters.py
@@ -134,27 +134,11 @@ class TestRegistry:
         assert adapter.execution_block_reason
 
     def test_read_capable_native_tool_backends_never_run_unconfined(self):
-        """Blocked, or confined at dispatch. Never neither.
-
-        The invariant is that no backend with live file and shell tools sees an
-        untrusted prompt with those tools available. An execution block is one
-        way to satisfy it; stripping the tools in the argv is the other, and is
-        strictly better because the backend stays usable.
-        """
+        """Every adapter with an unproven native-tool surface stays blocked."""
         for backend_id in ("codex", "kiro", "grok", "antigravity"):
             adapter = get_adapter(backend_id)
             assert adapter is not None, backend_id
-            if adapter.execution_block_reason:
-                continue
-            argv = " ".join(adapter.argv_builder("prompt.txt", None))
-            if "--disallowed-tools" in argv:
-                for tool in ("bash", "edit", "write", "read"):
-                    assert tool in argv, f"{backend_id} does not strip {tool}"
-                continue
-            # No tool-allowlist flag on this CLI, so the sandbox is the
-            # confinement. It satisfies the same invariant by a different
-            # route: the tools exist and cannot write or reach the network.
-            assert "--sandbox" in argv, f"{backend_id} runs with native tools live"
+            assert adapter.execution_block_reason, backend_id
 
     def test_codex_sandbox_is_read_only_and_offline(self):
         argv = " ".join(get_adapter("codex").argv_builder("prompt.txt", None))
@@ -163,19 +147,14 @@ class TestRegistry:
         assert 'approval_policy="never"' in argv
 
     def test_antigravity_cannot_edit_or_run_a_terminal(self):
-        """agy has no tool allowlist, so both available levers are pulled.
-
-        Removing its execution block without these left the invariant
-        unsatisfied rather than satisfied another way: a retrieved prompt
-        reached live file and shell tools.
-        """
+        """Blocked transport keeps all available defense-in-depth flags."""
         argv = " ".join(get_adapter("antigravity").argv_builder("prompt.txt", None))
         assert "--sandbox" in argv
         assert "--mode plan" in argv
         assert "--dangerously-skip-permissions" not in argv
 
     def test_grok_strips_its_tools_and_web_access(self):
-        """Pins the confinement that replaced grok's execution block."""
+        """Blocked transport still strips known tools as defense in depth."""
         argv = " ".join(get_adapter("grok").argv_builder("prompt.txt", None))
         assert "--disable-web-search" in argv
         assert "--disallowed-tools" in argv

--- a/tests/unit/test_backends/test_plan_quota_attempt_accounting.py
+++ b/tests/unit/test_backends/test_plan_quota_attempt_accounting.py
@@ -96,8 +96,9 @@ def test_quota_durability_failure_preserves_paired_cost_partial_status(
     ("backend_id", "auth_mode"),
     [
         ("opencode", AuthMode.UNKNOWN),
-        # kiro rather than codex: codex is confined at dispatch now instead of
-        # execution-blocked, so it no longer exercises the disabled-adapter arm.
+        ("codex", AuthMode.PLAN),
+        ("grok", AuthMode.PLAN),
+        ("antigravity", AuthMode.PLAN),
         ("kiro", AuthMode.PLAN),
         ("claude", AuthMode.METERED),
     ],

--- a/tests/unit/test_backends/test_plan_quota_client.py
+++ b/tests/unit/test_backends/test_plan_quota_client.py
@@ -39,6 +39,9 @@ from deepr.observability.cost_ledger import CostLedger
 @pytest.fixture(autouse=True)
 def _enable_blocked_adapters_for_transport_unit_tests(monkeypatch):
     """Keep transport tests isolated from production adapter admission policy."""
+    from deepr.backends.plan_quota import transcript_dispatch
+
+    monkeypatch.setattr(transcript_dispatch, "transcript_snapshot", lambda *_args, **_kwargs: {})
     for adapter in REGISTRY.values():
         for variable in adapter.metered_env_vars:
             monkeypatch.delenv(variable, raising=False)
@@ -48,6 +51,32 @@ def _enable_blocked_adapters_for_transport_unit_tests(monkeypatch):
             backend_id,
             replace(REGISTRY[backend_id], execution_block_reason=""),
         )
+
+
+@pytest.mark.parametrize("backend_id", ["codex", "grok", "antigravity"])
+def test_blocked_production_adapter_refuses_before_runner_or_ledger(tmp_path, backend_id):
+    called = False
+
+    async def runner(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("blocked adapter reached the runner")
+
+    adapter = replace(get_adapter(backend_id), execution_block_reason="unproven production capability boundary")
+    quota_path = tmp_path / "quota.jsonl"
+    cost_path = tmp_path / "cost.jsonl"
+
+    with pytest.raises(PlanQuotaError, match="execution is disabled"):
+        PlanQuotaChatClient(
+            adapter,
+            runner=runner,
+            quota_ledger_path=quota_path,
+            cost_ledger_path=cost_path,
+        )
+
+    assert called is False
+    assert not quota_path.exists()
+    assert not cost_path.exists()
 
 
 def _runner(

--- a/tests/unit/test_backends/test_plan_quota_fleet.py
+++ b/tests/unit/test_backends/test_plan_quota_fleet.py
@@ -90,11 +90,9 @@ class TestFleetStatus:
     def test_routability_classes(self, tmp_path):
         rows = build_fleet_status(which=_which(), env={}, quota_ledger_path=tmp_path / "q.jsonl")
         assert _row(rows, "claude")["routable"] == "auto"
-        # Confined at dispatch rather than blocked, so usable when asked for by
-        # name. Only claude auto-routes: the rest stay explicit-only because
-        # their terms or their quota accounting are not provable in advance.
-        assert _row(rows, "antigravity")["routable"] == "explicit"
-        assert _row(rows, "codex")["routable"] == "explicit"
+        assert _row(rows, "antigravity")["routable"] == "blocked"
+        assert _row(rows, "codex")["routable"] == "blocked"
+        assert _row(rows, "grok")["routable"] == "blocked"
         assert _row(rows, "opencode")["routable"] == "blocked"
         assert _row(rows, "kiro")["routable"] == "blocked"
         assert _row(rows, "copilot")["routable"] == "metered"

--- a/tests/unit/test_backends/test_plan_quota_safety.py
+++ b/tests/unit/test_backends/test_plan_quota_safety.py
@@ -73,21 +73,18 @@ class TestDetectAuthMode:
         assert detect_auth_mode(get_adapter("opencode"), {"OPENAI_API_KEY": "sk-x"}) == AuthMode.UNKNOWN
 
     def test_other_adapters_remain_blocked_by_their_own_gates(self):
-        """Every other adapter is either blocked or confined at dispatch.
-
-        grok, antigravity and codex are confined rather than blocked, which is
-        strictly better: the invariant holds and the backend stays usable.
-        test_plan_quota_adapters pins the confinement itself.
-        """
-        confined = {"grok", "antigravity", "codex"}
+        """Explicit selection cannot override incomplete capability proof."""
         for backend_id in ("codex", "grok", "kiro", "opencode", "antigravity"):
             adapter = get_adapter(backend_id)
             assert adapter is not None
-            if backend_id in confined:
-                argv = " ".join(adapter.argv_builder("p.txt", None))
-                assert "--disallowed-tools" in argv or "--sandbox" in argv, backend_id
-                continue
             assert adapter.execution_block_reason, f"{backend_id} lost its execution block"
+
+    def test_blocked_native_tool_adapters_fail_before_dispatch(self):
+        for backend_id in ("codex", "grok", "antigravity"):
+            decision = evaluate_plan_quota_safety(get_adapter(backend_id), env={})
+            assert not decision.safe, backend_id
+            assert decision.auth_mode == AuthMode.PLAN
+            assert "execution is disabled" in decision.reason
 
 
 class TestSafetyGate:
@@ -144,15 +141,11 @@ class TestSafetyGate:
         assert "native read tools" in d.reason
         assert "explicit read allowlist" in d.reason
 
-    def test_codex_is_safe_once_its_sandbox_confines_the_tools(self):
-        """Codex was gated on native tools; it now runs read-only and offline.
-
-        The gate existed to stop an untrusted prompt reaching live file and
-        shell tools. An OS sandbox satisfies that as well as a tool allowlist
-        does, so the refusal was pinning the mechanism rather than the property.
-        """
+    def test_codex_read_only_sandbox_does_not_replace_exact_tool_proof(self):
+        """A sandbox narrows effects but does not prove an empty tool surface."""
         d = evaluate_plan_quota_safety(get_adapter("codex"), env={})
-        assert d.safe, d.reason
+        assert not d.safe
+        assert "native read and shell tools" in d.reason
 
     def test_opencode_unknown_stored_auth_is_blocked(self):
         d = evaluate_plan_quota_safety(get_adapter("opencode"), env={})

--- a/tests/unit/test_backends/test_waterfall.py
+++ b/tests/unit/test_backends/test_waterfall.py
@@ -177,22 +177,12 @@ class TestExplicitPlanQuota:
         choice = choose_plan_quota_backend("claude", env={"ANTHROPIC_API_KEY": "sk-x"})
         assert choice.plan_backend_id == "claude"
 
-    def test_native_tool_backend_is_accepted_once_confined(self):
-        """codex was refused for its native tools; it now runs sandboxed.
-
-        The refusal protected against an untrusted prompt reaching live file
-        and shell tools. Once the argv runs read-only and offline with
-        escalation off, the property holds and the refusal was pinning the
-        mechanism. test_plan_quota_adapters pins the sandbox itself.
-        """
-        choice = choose_plan_quota_backend("codex", env={})
-        assert choice.plan_backend_id == "codex", choice.reason
-
-    def test_unconfinable_backend_is_still_refused(self):
-        """kiro cannot confine its native read tools, so the gate still holds."""
-        choice = choose_plan_quota_backend("kiro", env={})
-        assert choice.backend == BACKEND_UNAVAILABLE
-        assert choice.plan_backend_id is None
+    def test_unproven_native_tool_backends_are_refused(self):
+        for backend_id in ("codex", "kiro", "grok", "antigravity"):
+            choice = choose_plan_quota_backend(backend_id, env={})
+            assert choice.backend == BACKEND_UNAVAILABLE, backend_id
+            assert choice.plan_backend_id is None, backend_id
+            assert "execution is disabled" in choice.reason, backend_id
 
     def test_unknown_backend_is_unavailable(self):
         choice = choose_plan_quota_backend("bogus", env={})

--- a/tests/unit/test_cli/test_capacity_command.py
+++ b/tests/unit/test_cli/test_capacity_command.py
@@ -144,13 +144,8 @@ class TestAdmitPlan:
         assert r.exit_code == 0, r.output
 
     def test_admit_choice_restricted_to_auto_routable(self):
-        """Only backends provable non-metered and read-confined can auto-route.
-
-        codex, grok and antigravity left this list once their tools could be
-        stripped at dispatch, which is the property the refusal existed to
-        protect rather than the refusal itself.
-        """
-        for backend in ("opencode", "kiro", "copilot"):
+        """Only a backend with complete execution proof can auto-route."""
+        for backend in ("codex", "opencode", "kiro", "grok", "antigravity", "copilot"):
             r = CliRunner().invoke(capacity, ["admit-plan", backend])
             assert r.exit_code != 0, backend
 
@@ -458,26 +453,25 @@ class TestProbeFleet:
         assert payload["selected_count"] == 1
         assert payload["results"][0]["backend"] == "claude"
 
-    def test_explicit_unconfined_experimental_backend_is_refused(self, monkeypatch):
-        """kiro stays refused: its read tools cannot be confined at dispatch.
+    def test_explicit_unproven_native_tool_backends_are_refused(self, monkeypatch):
+        for backend, executable in (
+            ("codex", "codex"),
+            ("kiro", "kiro-cli"),
+            ("grok", "grok"),
+            ("antigravity", "agy"),
+        ):
+            _clean_env(monkeypatch)
+            _stub_path(monkeypatch, executable)
+            _stub_probe(monkeypatch, ok=True, reply="OK")
 
-        codex, grok and antigravity are deliberately absent. They carry the
-        same class of native tools and are now confined in their argv instead
-        of blocked, so asserting a refusal for them would pin the block rather
-        than the property the block exists to protect.
-        """
-        _clean_env(monkeypatch)
-        _stub_path(monkeypatch, "kiro-cli")
-        _stub_probe(monkeypatch, ok=True, reply="OK")
+            r = CliRunner().invoke(capacity, ["probe-fleet", "--backend", backend, "--json"])
 
-        r = CliRunner().invoke(capacity, ["probe-fleet", "--backend", "kiro", "--json"])
-
-        assert r.exit_code == 1, r.output
-        payload = json.loads(r.output)
-        assert payload["ok_count"] == 0
-        assert payload["failed_count"] == 1
-        assert [result["backend"] for result in payload["results"]] == ["kiro"]
-        assert "confined" in payload["results"][0]["error"]
+            assert r.exit_code == 1, (backend, r.output)
+            payload = json.loads(r.output)
+            assert payload["ok_count"] == 0
+            assert payload["failed_count"] == 1
+            assert [result["backend"] for result in payload["results"]] == [backend]
+            assert "execution is disabled" in payload["results"][0]["error"]
 
     def test_explicit_metered_backend_is_blocked_by_default(self, monkeypatch):
         _clean_env(monkeypatch)

--- a/tests/unit/test_mcp/test_server_bridge_hardening.py
+++ b/tests/unit/test_mcp/test_server_bridge_hardening.py
@@ -77,9 +77,17 @@ async def test_read_only_discovery_uses_effective_registered_surface(
     registered = {tool.name for tool in read_only_server.registry.all_tools()}
     available = read_only_server.available_tool_names()
 
-    assert {"deepr_get_task_progress", "deepr_list_recoverable_tasks"} <= registered
+    assert len(registered) == 36
+    assert {
+        "deepr_get_task_progress",
+        "deepr_list_recoverable_tasks",
+        "deepr_pause_task",
+        "deepr_resume_task",
+    } <= registered
     assert available <= registered
+    assert len(available) == 10
     assert "deepr_research" not in available
+    assert {"deepr_pause_task", "deepr_resume_task"}.isdisjoint(available)
 
     full_list = await _handle_tools_list(read_only_server, {"_fullList": True})
     assert {tool["name"] for tool in full_list["tools"]} == available


### PR DESCRIPTION
## Summary
- restore fail-closed production blocks for Codex, Grok Build, and Antigravity plan adapters
- register pause and resume MCP schemas so the documented 36-tool catalog matches discovery while read-only remains 10 tools
- reconcile README, Supported Surface, standards notes, changelog, and one dependency-ordered roadmap against current runtime and official host evidence

## Verification
- 283 focused plan-quota, capacity, and MCP tests passed
- 34 Agent Plugin and standards tests passed
- Ruff, strict MCP mypy, docs consistency, paid API boundary, file-size, complexity, and security ratchets passed
- full unit coverage suite running locally; one timing-sensitive cleanup test passed on immediate isolated rerun