### PR TITLE
fix: settle web jobs first and refuse unreadable graph overwrites

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -106,6 +106,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP tool errors redact provider keys before they are returned to the host.
 - Webhook and instruction-signing HMAC comparisons treat malformed signatures
   as invalid instead of raising.
+- Unreadable concept or edge graph files are no longer treated as empty.
+  Later indexing refuses to overwrite the surviving files.
+- Cost dashboard cache flush no longer treats a swallowed save error as
+  success and drop the in-memory buffer.
+- Cost daily-total property tests no longer fail when a recording loop
+  crosses UTC midnight.
+- Web research completion settles the reservation before the queue result
+  write so `job:{id}:completion` cannot be stolen and leave a hold open.
+- Belief event logs use the interprocess JSONL append lock, snapshots fsync,
+  and a malformed edge fails closed instead of being dropped on the next save.
+- Investigation create retries when `plan.json` exists without `state.json`.
+  Artifact keys reject Windows reserved device names.
+- Nested dashboard routes serve the SPA as HTTP 200. Portrait files prefix
+  reserved Windows device stems and the static portrait route rejects them.
+- Parent-budget consume replay preserves a real `$0` settlement instead of
+  substituting the child ceiling.
 
 - Restored fail-closed production blocks for Codex, Grok Build, and Antigravity
   plan adapters. Hardened argument builders remain defense-in-depth fixtures;

--- a/src/deepr/experts/beliefs.py
+++ b/src/deepr/experts/beliefs.py
@@ -3,10 +3,8 @@
 import json
 import logging
 import math
-import os
 import re
 import threading
-from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -17,7 +15,7 @@ from urllib.parse import urlsplit
 from deepr.experts import mutation_audit as audit
 from deepr.experts.belief_edges import EDGE_TYPES, Edge, normalized_edge_temporal_context
 from deepr.experts.maker_checker import strongest_grounding_event
-from deepr.utils.atomic_io import atomic_write_json
+from deepr.utils.atomic_io import append_jsonl_durable, atomic_write_json
 
 logger = logging.getLogger(__name__)
 
@@ -568,11 +566,7 @@ class BeliefStore:
 
         self.changes.append(change)
         with self._lock:
-            with open(self.events_path, "a", encoding="utf-8") as f:
-                f.write(json.dumps(change.to_dict(), ensure_ascii=True) + "\n")
-                f.flush()
-                with suppress(OSError):
-                    os.fsync(f.fileno())
+            append_jsonl_durable(self.events_path, change.to_dict(), fsync=True)
             audit_entry = audit.build_mutation_audit_entry(
                 expert=self.expert_name,
                 actor=actor,
@@ -1386,6 +1380,7 @@ class BeliefStore:
                 "beliefs": {bid: b.to_dict() for bid, b in self.beliefs.items()},
                 "changes": [c.to_dict() for c in self.changes[-100:]],
             },
+            fsync=True,
         )
 
     def _load(self):
@@ -1411,9 +1406,10 @@ class BeliefStore:
         for edata in data.get("edges", []):
             try:
                 edge = Edge.from_dict(edata)
-            except (KeyError, ValueError) as exc:
-                logger.warning("Skipping malformed edge in %s: %s", self.storage_path, exc)
-                continue
+            except (KeyError, TypeError, ValueError) as exc:
+                self._unreadable = True
+                logger.error("Malformed edge in %s: %s. Refusing writes.", self.storage_path, exc)
+                return
             self.edges[edge.key()] = edge
         # One-time, idempotent migration (TKG step 2): legacy
         # contradictions_with lists become typed contradicts edges. Key-based

--- a/src/deepr/experts/investigation/store.py
+++ b/src/deepr/experts/investigation/store.py
@@ -24,6 +24,7 @@ from deepr.experts.investigation.models import (
     validate_plan,
 )
 from deepr.utils.atomic_io import append_jsonl_durable, atomic_write_bytes, atomic_write_json
+from deepr.utils.security import reserved_windows_device_stem
 
 _RUN_ID_RE = re.compile(r"^inv_[a-z0-9_]{4,80}$")
 _ARTIFACT_COMPONENT_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,99}$")
@@ -50,7 +51,7 @@ def _safe_run_id(value: Any) -> str:
 
 def _artifact_component(value: str, *, field_name: str) -> str:
     normalized = value.strip().lower()
-    if not _ARTIFACT_COMPONENT_RE.fullmatch(normalized):
+    if not _ARTIFACT_COMPONENT_RE.fullmatch(normalized) or reserved_windows_device_stem(normalized):
         raise InvestigationStorageError(f"invalid artifact {field_name}")
     return normalized
 
@@ -93,11 +94,13 @@ class InvestigationStore:
                 existing = self.load_plan(run_id)
                 if existing["plan_sha256"] != validated["plan_sha256"]:
                     raise InvestigationStorageError("run id already belongs to a different plan")
-                return self.load_state(run_id)
-            # exist_ok lets a crash between mkdir and plan.json retry the same
-            # run id instead of raising FileExistsError on an incomplete dir.
-            path.mkdir(parents=False, exist_ok=True)
-            atomic_write_json(plan_path, validated, sort_keys=True, fsync=True)
+                if (path / "state.json").exists():
+                    return self.load_state(run_id)
+            else:
+                # exist_ok lets a crash between mkdir and plan.json retry the same
+                # run id instead of raising FileExistsError on an incomplete dir.
+                path.mkdir(parents=False, exist_ok=True)
+                atomic_write_json(plan_path, validated, sort_keys=True, fsync=True)
             state = {
                 "schema_version": "deepr-investigation-state-v1",
                 "kind": "deepr.expert.investigation_state",

--- a/src/deepr/experts/lazy_graph_rag.py
+++ b/src/deepr/experts/lazy_graph_rag.py
@@ -1393,15 +1393,12 @@ class KnowledgeGraph:
         Args:
             expert_name: Name of the expert
             storage_dir: Directory for persistence
-            max_edges: Hard safety cap on total edges. A backstop against
-                runaway edge growth (the O(C^2) co-occurrence blow-up that once
-                produced multi-GB edge files); once reached, new distinct edges
-                are dropped with a one-time warning. Generous enough that a
-                healthy graph never hits it.
+            max_edges: Hard cap on total edges; extra distinct edges are dropped.
         """
         self.expert_name = expert_name
         self.max_edges = max_edges
         self._edge_cap_warned = False
+        self._unreadable = False
 
         if storage_dir is None:
             from deepr.experts.paths import canonical_expert_dir
@@ -1620,46 +1617,43 @@ class KnowledgeGraph:
         return [concept for _, concept in scored[:top_k]]
 
     def save(self):
-        """Persist graph to disk (atomic writes)."""
+        """Persist graph to disk (atomic writes). Unreadable loads refuse."""
+        if self._unreadable:
+            raise RuntimeError(f"refusing to overwrite unreadable graph for {self.expert_name}")
         from deepr.utils.atomic_io import atomic_write_json
 
         atomic_write_json(self.storage_dir / "concepts.json", [c.to_dict() for c in self.concepts.values()])
         atomic_write_json(self.storage_dir / "edges.json", [e.to_dict() for e in self.edges.values()])
 
     def _load(self):
-        """Load graph from disk.
-
-        Falls back to an empty graph when persisted files are corrupted
-        or too large to load in available memory.
-        """
-        # Load concepts
-        concepts_path = self.storage_dir / "concepts.json"
-        if concepts_path.exists():
+        """Load graph from disk. Unreadable files fail closed; save cannot clobber them."""
+        self._unreadable = False
+        loaded: dict[str, list] = {}
+        for name in ("concepts.json", "edges.json"):
+            path = self.storage_dir / name
+            if not path.exists():
+                loaded[name] = []
+                continue
             try:
-                with open(concepts_path, encoding="utf-8") as f:
-                    concepts_data = json.load(f)
-            except (json.JSONDecodeError, OSError, MemoryError) as e:
-                logger.warning("Failed to load concepts graph for %s: %s", self.expert_name, e)
-                concepts_data = []
-            for data in concepts_data:
-                concept = Concept.from_dict(data)
-                self.concepts[concept.id] = concept
-                self._text_index[concept.text.lower()] = concept.id
-
-        # Load edges
-        edges_path = self.storage_dir / "edges.json"
-        if edges_path.exists():
-            try:
-                with open(edges_path, encoding="utf-8") as f:
-                    edges_data = json.load(f)
-            except (json.JSONDecodeError, OSError, MemoryError) as e:
-                logger.warning("Failed to load edges graph for %s: %s", self.expert_name, e)
-                edges_data = []
-            for data in edges_data:
-                edge = Edge.from_dict(data)
-                self.edges[edge.id] = edge
-                self.adjacency[edge.source_id].append((edge.target_id, edge))
-                self.adjacency[edge.target_id].append((edge.source_id, edge))
+                with open(path, encoding="utf-8") as handle:
+                    payload = json.load(handle)
+            except (json.JSONDecodeError, OSError, MemoryError) as exc:
+                logger.error("Failed to load %s for %s: %s", name, self.expert_name, exc)
+                self._unreadable = True
+                return
+            if not isinstance(payload, list):
+                self._unreadable = True
+                return
+            loaded[name] = payload
+        for data in loaded["concepts.json"]:
+            concept = Concept.from_dict(data)
+            self.concepts[concept.id] = concept
+            self._text_index[concept.text.lower()] = concept.id
+        for data in loaded["edges.json"]:
+            edge = Edge.from_dict(data)
+            self.edges[edge.id] = edge
+            self.adjacency[edge.source_id].append((edge.target_id, edge))
+            self.adjacency[edge.target_id].append((edge.source_id, edge))
 
     def get_stats(self) -> dict[str, Any]:
         """Get graph statistics.

--- a/src/deepr/experts/parent_budget_store.py
+++ b/src/deepr/experts/parent_budget_store.py
@@ -94,7 +94,8 @@ def _apply_consumed_event(parent: ParentBudgetTransaction, event: Mapping[str, A
     child = parent.children.get(child_id)
     if child is None:
         raise ParentBudgetError(f"missing child {child_id!r} for consume replay")
-    child.settled_usd = float(event.get("settled_usd") or child.max_usd)
+    settled = event.get("settled_usd")
+    child.settled_usd = float(child.max_usd if settled is None else settled)
     child.state = ChildCallState.CONSUMED
     if event.get("freeze"):
         parent.state = ParentBudgetState.FROZEN

--- a/src/deepr/experts/portraits.py
+++ b/src/deepr/experts/portraits.py
@@ -306,6 +306,10 @@ async def generate_portrait(
     safe_name = "".join(c if c.isalnum() or c in "-_ " else "" for c in name).strip().replace(" ", "-").lower()
     if not safe_name:
         safe_name = "portrait"
+    from deepr.utils.security import reserved_windows_device_stem
+
+    if reserved_windows_device_stem(safe_name):
+        safe_name = f"expert-{safe_name}"
     filename = f"{safe_name}.png"
     filepath = out / filename
     archive_path = await asyncio.to_thread(_write_portrait_file, filepath, image_bytes)

--- a/src/deepr/observability/costs.py
+++ b/src/deepr/observability/costs.py
@@ -870,9 +870,7 @@ class CostDashboard:
             "monthly_limit": self.monthly_limit,
         }
 
-        # Atomic write using the shared helper (tempfile + os.replace +
-        # Windows retry). The previous ad-hoc ``.tmp`` pattern raced with
-        # Windows indexers and could leave .tmp orphans.
+        # Atomic write via tempfile + os.replace (Windows retry in helper).
         try:
             if not self.storage_path.parent.exists():
                 logger.debug("Cost data directory no longer exists, skipping save")
@@ -881,7 +879,8 @@ class CostDashboard:
 
             atomic_write_json(self.storage_path, data)
         except OSError as e:
-            logger.debug(f"Failed to save cost data: {e}")
+            logger.debug("Failed to save cost data: %s", e)
+            raise
 
     def _load_cache_state(self, data: dict[str, Any]) -> None:
         """Load dashboard-owned state (triggered alerts, user-set limits) from

--- a/src/deepr/web/app.py
+++ b/src/deepr/web/app.py
@@ -31,7 +31,7 @@ from deepr.services.provider_completion import authoritative_completion_usage
 
 # Shared sync-to-async bridge, retaining the historical local alias.
 from deepr.utils.async_runner import run_async_command as run_async
-from deepr.utils.security import is_contained_path, is_loopback_bind_host
+from deepr.utils.security import is_contained_path, is_loopback_bind_host, reserved_windows_device_stem
 from deepr.web import action_safety, council_api
 from deepr.web.expert_chat_contract import BrowserChatContractError, parse_browser_expert_chat_request  # noqa: F401
 from deepr.web.expert_chat_rest import (
@@ -537,13 +537,19 @@ def fallback_to_spa(e):
     relative = request.path.lstrip("/")
     if relative:
         parts = Path(relative).parts
-        if parts and not any(part in ("", ".", "..") for part in parts):
+        if (
+            parts
+            and not any(part in ("", ".", "..") for part in parts)
+            and not any(reserved_windows_device_stem(part) for part in parts)
+        ):
             joined = safe_join(str(_frontend_dist.resolve()), *parts)
             if joined:
                 resolved = Path(joined)
                 if resolved.is_file() and is_contained_path(resolved, _frontend_dist.resolve()):
                     return send_from_directory(str(_frontend_dist), Path(*parts).as_posix())
-    return render_template("index.html")
+    # Flask 404 handlers keep status 404 unless a code is set. Nested SPA
+    # routes must be a 200 document so refresh and client routing work.
+    return render_template("index.html"), 200
 
 
 def _ensure_utc(dt: datetime) -> datetime:
@@ -1893,7 +1899,7 @@ def generate_expert_portrait(name):
 @app.route("/portraits/<filename>")
 def serve_portrait(filename):
     """Serve a generated portrait image."""
-    if not filename.endswith(".png"):
+    if not filename.endswith(".png") or reserved_windows_device_stem(filename):
         return jsonify({"error": "Invalid file type"}), 400
     portraits_dir = runtime_data_path("portraits")
     return send_from_directory(str(portraits_dir.resolve()), filename)

--- a/src/deepr/web/research_cost_api.py
+++ b/src/deepr/web/research_cost_api.py
@@ -332,6 +332,12 @@ class WebResearchCostCoordinator:
         Report paths are recorded whenever a report was saved, even when
         the provider returned no usage payload.
         """
+        # Settle before queue result writes. Both use job:{id}:completion;
+        # writing the queue row first steals that key as research_job and
+        # leaves the durable hold open after settlement conflicts.
+        self.settle_job(job, actual_cost=actual_cost, tokens=tokens or 0)
+        if not self.reconcile_completed_job(job):
+            raise RuntimeError(f"Canonical cost settlement missing for completed job {job.id}")
         if report_saved:
             loop.run_until_complete(
                 queue.update_results(
@@ -341,7 +347,9 @@ class WebResearchCostCoordinator:
                     tokens_used=tokens,
                 )
             )
-        elif actual_cost is not None or tokens is not None:
+            loop.run_until_complete(queue.update_status(job_id=job.id, status=JobStatus.COMPLETED))
+            return
+        if actual_cost is not None or tokens is not None:
             loop.run_until_complete(
                 queue.update_results(
                     job_id=job.id,
@@ -350,22 +358,16 @@ class WebResearchCostCoordinator:
                     tokens_used=tokens,
                 )
             )
-        self.safe_settle_job(job, actual_cost=actual_cost, tokens=tokens or 0)
-        if not self.reconcile_completed_job(job):
-            raise RuntimeError(f"Canonical cost settlement missing for completed job {job.id}")
-        if report_saved:
-            loop.run_until_complete(queue.update_status(job_id=job.id, status=JobStatus.COMPLETED))
-        else:
-            loop.run_until_complete(
-                queue.update_status(
-                    job_id=job.id,
-                    status=JobStatus.FAILED,
-                    error=(
-                        "Provider reported completion but no report content was extracted; "
-                        "cost settled conservatively and no artifact was saved"
-                    ),
-                )
+        loop.run_until_complete(
+            queue.update_status(
+                job_id=job.id,
+                status=JobStatus.FAILED,
+                error=(
+                    "Provider reported completion but no report content was extracted; "
+                    "cost settled conservatively and no artifact was saved"
+                ),
             )
+        )
 
     def settle_job(self, job: Any, *, actual_cost: float | None, tokens: int) -> None:
         """Settle actual cost, or the reserved estimate when usage is absent."""

--- a/tests/unit/test_belief_revision.py
+++ b/tests/unit/test_belief_revision.py
@@ -222,6 +222,19 @@ class TestBeliefStore:
             store.add_belief(Belief(claim="Python is great", confidence=0.9, domain="programming"))
         assert path.read_text(encoding="utf-8") == original
 
+    def test_malformed_edge_refuses_overwrite(self, tmp_path):
+        storage_dir = tmp_path / "beliefs"
+        storage_dir.mkdir()
+        path = storage_dir / "beliefs.json"
+        original = '{"beliefs": {}, "edges": [{"not": "an-edge"}], "changes": []}'
+        path.write_text(original, encoding="utf-8")
+
+        store = BeliefStore(expert_name="test", storage_dir=storage_dir)
+        assert store._unreadable is True
+        with pytest.raises(BeliefStoreError, match="unreadable"):
+            store.add_belief(Belief(claim="Python is great", confidence=0.9, domain="programming"))
+        assert path.read_text(encoding="utf-8") == original
+
     def test_read_only_store_cannot_save(self, tmp_path):
         store = BeliefStore(expert_name="test", storage_dir=tmp_path / "beliefs", read_only=True)
         with pytest.raises(BeliefStoreError, match="read-only"):

--- a/tests/unit/test_cost_buffering.py
+++ b/tests/unit/test_cost_buffering.py
@@ -12,8 +12,9 @@ Properties: 7 (Flush Triggers), 8 (Retention on Failure)
 
 import tempfile
 import threading
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -24,6 +25,17 @@ from deepr.observability.costs import (
     COST_FLUSH_INTERVAL,
     BufferedCostDashboard,
 )
+
+
+def _assert_recorded_costs_queryable(dashboard: BufferedCostDashboard, expected_total: float) -> None:
+    """Daily totals must partition recorded costs even across a UTC date change."""
+    assert abs(sum(entry.cost for entry in dashboard.entries) - expected_total) < 0.0001
+    by_date: dict[date, float] = {}
+    for entry in dashboard.entries:
+        by_date[entry.date] = by_date.get(entry.date, 0.0) + entry.cost
+    for day, total in by_date.items():
+        assert abs(dashboard.get_daily_total(day) - total) < 0.0001
+
 
 # =============================================================================
 # Test Strategies
@@ -329,10 +341,8 @@ class TestCostBufferFlushTriggersProperty:
             # All entries should still be in memory
             assert len(dashboard.entries) == num_entries
 
-            # Daily total should reflect all entries
-            expected_total = num_entries * 0.01
-            actual_total = dashboard.get_daily_total()
-            assert abs(actual_total - expected_total) < 0.0001
+            # Daily totals should reflect all entries, even if recording crossed UTC midnight.
+            _assert_recorded_costs_queryable(dashboard, num_entries * 0.01)
 
 
 # =============================================================================
@@ -477,10 +487,8 @@ class TestCostBufferRetentionOnFailureProperty:
             # Entries should still be in memory for queries
             assert len(dashboard.entries) == num_entries
 
-            # Daily total should still work
-            expected_total = num_entries * 0.01
-            actual_total = dashboard.get_daily_total()
-            assert abs(actual_total - expected_total) < 0.0001
+            # Daily totals should still work, even if recording crossed UTC midnight.
+            _assert_recorded_costs_queryable(dashboard, num_entries * 0.01)
 
 
 # =============================================================================
@@ -557,6 +565,17 @@ class TestBufferedCostDashboardThreadSafety:
 
         assert len(errors) == 0, f"Errors during concurrent flushing: {errors}"
         assert dashboard.buffer_count == 0
+
+    def test_flush_retains_buffer_when_atomic_write_fails(self, temp_storage):
+        """A real save OSError must keep buffered entries for retry."""
+        dashboard = BufferedCostDashboard(storage_path=temp_storage, buffer_size=1000, flush_interval=3600)
+        dashboard.record("research", "openai", 0.01)
+        assert dashboard.buffer_count == 1
+
+        with patch("deepr.utils.atomic_io.atomic_write_json", side_effect=OSError("disk full")):
+            assert dashboard.flush() is False
+
+        assert dashboard.buffer_count == 1
 
 
 # =============================================================================

--- a/tests/unit/test_cost_dashboard.py
+++ b/tests/unit/test_cost_dashboard.py
@@ -1243,10 +1243,13 @@ class TestCostDashboardEdgeCases:
             dashboard.record("research", "openai", small_cost)
 
         expected_total = small_cost * num_entries
-        actual_total = dashboard.get_daily_total()
-
-        # Allow small floating-point tolerance
+        actual_total = sum(entry.cost for entry in dashboard.entries)
         assert abs(actual_total - expected_total) < 0.0001
+        by_date: dict = {}
+        for entry in dashboard.entries:
+            by_date[entry.date] = by_date.get(entry.date, 0.0) + entry.cost
+        for day, total in by_date.items():
+            assert abs(dashboard.get_daily_total(day) - total) < 0.0001
 
     def test_atomic_write_temp_file_cleanup(self, temp_storage):
         """Temp files should be cleaned up after successful save."""

--- a/tests/unit/test_experts/test_investigation_store.py
+++ b/tests/unit/test_experts/test_investigation_store.py
@@ -107,6 +107,32 @@ def test_store_create_retries_incomplete_run_directory(tmp_path: Path) -> None:
     assert store.load_plan("inv_store_test") == plan
 
 
+def test_store_create_retries_after_plan_without_state(tmp_path: Path) -> None:
+    store = InvestigationStore(tmp_path / "runs")
+    plan = _plan(tmp_path)
+    created = store.create(plan)
+    run_dir = store.run_dir("inv_store_test")
+    (run_dir / "state.json").unlink()
+    (run_dir / "control.json").unlink()
+    (run_dir / "events.jsonl").unlink()
+
+    retried = store.create(copy.deepcopy(plan))
+
+    assert retried["run_id"] == created["run_id"]
+    assert store.load_state("inv_store_test")["plan_sha256"] == plan["plan_sha256"]
+
+
+def test_artifact_component_rejects_windows_device_names(tmp_path: Path) -> None:
+    store = InvestigationStore(tmp_path / "runs")
+    store.create(_plan(tmp_path))
+    with pytest.raises(InvestigationStorageError, match="invalid artifact"):
+        store.write_artifact("inv_store_test", phase="nul", key="note", payload={"ok": True}, max_disk_bytes=1_000_000)
+    with pytest.raises(InvestigationStorageError, match="invalid artifact"):
+        store.write_artifact(
+            "inv_store_test", phase="notes", key="com1.txt", payload={"ok": True}, max_disk_bytes=1_000_000
+        )
+
+
 def test_store_state_uses_optimistic_versions(tmp_path: Path) -> None:
     store = InvestigationStore(tmp_path / "runs")
     state = store.create(_plan(tmp_path))

--- a/tests/unit/test_experts/test_parent_budget_store.py
+++ b/tests/unit/test_experts/test_parent_budget_store.py
@@ -8,6 +8,7 @@ import pytest
 
 from deepr.experts.parent_budget_store import (
     DurableParentBudget,
+    _apply_consumed_event,
     load_parent_budget_events,
     open_gated_lifecycle_budget,
     replay_parent_budget,
@@ -90,6 +91,18 @@ def _complete_envelope(**overrides: object) -> dict[str, object]:
     }
     base.update(overrides)
     return base
+
+
+def test_consume_replay_preserves_zero_settled_usd(tmp_path: Path) -> None:
+    durable = DurableParentBudget.open(
+        surface="fill_gaps",
+        parent_ceiling_usd=1.0,
+        run_id="run-zero-consume",
+        path=tmp_path / "parent_budget_transactions.jsonl",
+    )
+    child = durable.admit_child(operation="gap", max_usd=0.4, child_id="c0")
+    _apply_consumed_event(durable.parent, {"child_id": child.child_id, "settled_usd": 0.0})
+    assert durable.parent.children["c0"].settled_usd == pytest.approx(0.0)
 
 
 def test_open_requires_complete_contract_when_requested(tmp_path: Path) -> None:

--- a/tests/unit/test_experts/test_portraits.py
+++ b/tests/unit/test_experts/test_portraits.py
@@ -143,6 +143,22 @@ class TestLocalImageProvider:
         assert (tmp_path / "portable-data" / "portraits" / "portable-expert.png").read_bytes() == b"NEWPORTRAIT"
 
     @pytest.mark.asyncio
+    async def test_generate_portrait_prefixes_windows_device_names(self, monkeypatch, tmp_path):
+        output_dir = tmp_path / "portraits"
+        monkeypatch.setenv("DEEPR_LOCAL_IMAGE_URL", "http://localhost:8188")
+        monkeypatch.setattr(P, "_require_attested_local_image_capacity", lambda: None)
+
+        async def fake_generate_local(_prompt):
+            return b"DEVICEPORTRAIT"
+
+        monkeypatch.setattr(P, "_generate_local", fake_generate_local)
+
+        url = await P.generate_portrait("CON", provider="local", output_dir=output_dir)
+
+        assert url == "/portraits/expert-con.png"
+        assert (output_dir / "expert-con.png").read_bytes() == b"DEVICEPORTRAIT"
+
+    @pytest.mark.asyncio
     async def test_generate_portrait_archives_existing_file_before_replacement(self, monkeypatch, tmp_path):
         output_dir = tmp_path / "portraits"
         output_dir.mkdir()

--- a/tests/unit/test_lazy_graph_rag.py
+++ b/tests/unit/test_lazy_graph_rag.py
@@ -662,7 +662,7 @@ class TestSubgraphCache:
         assert "node1" in result.node_ids
 
     def test_load_handles_memory_error_in_edges_file(self, tmp_path):
-        """Graph load should recover from MemoryError in persisted edges."""
+        """Graph load should fail closed on MemoryError in persisted edges."""
         storage_dir = tmp_path / "graph"
         storage_dir.mkdir(parents=True, exist_ok=True)
         (storage_dir / "edges.json").write_text("[]", encoding="utf-8")
@@ -672,6 +672,9 @@ class TestSubgraphCache:
 
         assert graph is not None
         assert len(graph.edges) == 0
+        with pytest.raises(RuntimeError, match="unreadable graph"):
+            graph.save()
+        assert (storage_dir / "edges.json").read_text(encoding="utf-8") == "[]"
 
     def test_get_stats(self, tmp_path):
         """Test getting cache statistics."""
@@ -897,8 +900,22 @@ class TestKnowledgeGraph:
         assert len(graph2.concepts) == 2
         assert len(graph2.edges) == 1
 
+    def test_unreadable_graph_refuses_overwrite(self, tmp_path):
+        """Corrupt graph files must not be replaced by a later save."""
+        storage_dir = tmp_path / "graph"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        corrupt = "{not-json"
+        (storage_dir / "concepts.json").write_text(corrupt, encoding="utf-8")
+
+        graph = KnowledgeGraph(expert_name="test_expert", storage_dir=storage_dir)
+        graph.add_concept(Concept(text="should not persist"))
+
+        with pytest.raises(RuntimeError, match="unreadable graph"):
+            graph.save()
+        assert (storage_dir / "concepts.json").read_text(encoding="utf-8") == corrupt
+
     def test_load_handles_memory_error_in_edges_file(self, tmp_path):
-        """Graph load should recover from MemoryError in persisted edges."""
+        """Graph load should fail closed on MemoryError in persisted edges."""
         storage_dir = tmp_path / "graph"
         storage_dir.mkdir(parents=True, exist_ok=True)
         (storage_dir / "edges.json").write_text("[]", encoding="utf-8")
@@ -908,6 +925,9 @@ class TestKnowledgeGraph:
 
         assert graph is not None
         assert len(graph.edges) == 0
+        with pytest.raises(RuntimeError, match="unreadable graph"):
+            graph.save()
+        assert (storage_dir / "edges.json").read_text(encoding="utf-8") == "[]"
 
     def test_get_stats(self, tmp_path):
         """Test getting graph statistics."""
@@ -1026,7 +1046,7 @@ Deep learning uses multiple layers of neural networks.
         assert isinstance(complex_query, bool)
 
     def test_load_handles_memory_error_in_edges_file(self, tmp_path):
-        """Graph load should recover from MemoryError in persisted edges."""
+        """Graph load should fail closed on MemoryError in persisted edges."""
         storage_dir = tmp_path / "graph"
         storage_dir.mkdir(parents=True, exist_ok=True)
         (storage_dir / "edges.json").write_text("[]", encoding="utf-8")
@@ -1036,6 +1056,9 @@ Deep learning uses multiple layers of neural networks.
 
         assert graph is not None
         assert len(graph.edges) == 0
+        with pytest.raises(RuntimeError, match="unreadable graph"):
+            graph.save()
+        assert (storage_dir / "edges.json").read_text(encoding="utf-8") == "[]"
 
     def test_get_stats(self, tmp_path):
         """Test getting LazyGraphRAG statistics."""

--- a/tests/unit/test_web/test_poller_startup.py
+++ b/tests/unit/test_web/test_poller_startup.py
@@ -669,9 +669,10 @@ def test_finalize_completed_job_settles_before_queue_result_write():
 
 
 def test_spa_nested_route_is_http_200(client, monkeypatch):
-    monkeypatch.setattr(web_app, "_check_auth", lambda: None)
+    monkeypatch.setattr(web_app, "render_template", lambda *_args, **_kwargs: "spa")
     response = client.get("/experts/fixture-expert")
     assert response.status_code == 200
+    assert response.get_data(as_text=True) == "spa"
 
 
 def test_portrait_route_rejects_windows_device_name(client, monkeypatch):

--- a/tests/unit/test_web/test_poller_startup.py
+++ b/tests/unit/test_web/test_poller_startup.py
@@ -636,6 +636,50 @@ def test_web_completion_uses_canonical_usage_before_settlement(monkeypatch):
     emitted.assert_called_once()
 
 
+def test_finalize_completed_job_settles_before_queue_result_write():
+    coordinator = WebResearchCostCoordinator(None, None)
+    order: list[str] = []
+
+    def settle_job(job, *, actual_cost, tokens):
+        order.append("settle")
+
+    def reconcile_completed_job(job):
+        order.append("reconcile")
+        return True
+
+    loop = MagicMock()
+    loop.run_until_complete.side_effect = lambda _awaitable: order.append("queue") or True
+    queue = MagicMock()
+    queue.update_results = AsyncMock()
+    queue.update_status = AsyncMock()
+    coordinator.settle_job = settle_job  # type: ignore[method-assign]
+    coordinator.reconcile_completed_job = reconcile_completed_job  # type: ignore[method-assign]
+
+    coordinator.finalize_completed_job(
+        loop=loop,
+        queue=queue,
+        job=SimpleNamespace(id="job-settle-first"),
+        actual_cost=0.4,
+        tokens=10,
+        report_saved=True,
+    )
+
+    assert order[:2] == ["settle", "reconcile"]
+    assert "queue" in order
+
+
+def test_spa_nested_route_is_http_200(client, monkeypatch):
+    monkeypatch.setattr(web_app, "_check_auth", lambda: None)
+    response = client.get("/experts/fixture-expert")
+    assert response.status_code == 200
+
+
+def test_portrait_route_rejects_windows_device_name(client, monkeypatch):
+    monkeypatch.setattr(web_app, "_check_auth", lambda: None)
+    response = client.get("/portraits/CON.png")
+    assert response.status_code == 400
+
+
 def test_web_terminal_cleanup_factory_uses_recorded_provider(monkeypatch):
     from deepr.queue.base import JobStatus, ResearchJob
 


### PR DESCRIPTION
## Why

A second hunt after #148 found remaining fail-closed holes and a CI flake that already failed main on 3.13 around UTC midnight.

## Fixes

- Web research completion settles the reservation **before** the queue result write so `job:{id}:completion` cannot be stolen as `research_job` and leave a durable hold open.
- Unreadable concept/edge graph files refuse later saves instead of replacing surviving data with an empty graph plus new docs.
- Malformed belief edges fail closed. Belief event logs use the interprocess JSONL append lock. Belief snapshots fsync.
- Cost dashboard cache flush re-raises save errors so the buffer is retained.
- Cost daily-total property tests partition recorded costs by UTC date instead of assuming all records fall on ``datetime.now(UTC).date()``.
- Investigation create retries when ``plan.json`` exists without ``state.json``. Artifact keys reject Windows reserved device names.
- Nested dashboard routes serve the SPA as HTTP 200. Portrait files prefix reserved Windows device stems; the static portrait route rejects them.
- Parent-budget consume replay preserves a real ``$0`` settlement.

## Verification

- Targeted unit tests for the new regressions passed locally.
- File-size ratchet and ruff passed on the changed files.