### PR TITLE
fix: report failed installer repair accurately

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -414,6 +414,12 @@ reliable product, not a four-language architecture diagram.
 
 ## Current Status (v2.50.12)
 
+- [x] **Installer validation finding (2026-09-05):** both public installers
+  reported success after the CLI remained broken through repair. They now
+  return a failure status before the success footer. Executed PowerShell and
+  Bash scenarios cover success, recovery, and persistent failure without real
+  installation or network effects.
+
 **v2.50.12:** consultation preserves literal cited excerpts
 beyond the beginning of retained sources within the existing packet ceilings.
 First-world hard negatives no longer contaminate negative-transfer measures.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.50.12] - 2026-09-04
+## [2.50.12] - 2026-09-05
 
 ### Fixed
 
+- The Windows and macOS/Linux installers now exit with a failure status if the
+  CLI still fails after their one repair attempt. They no longer print a
+  success footer for a broken installation. Executed shell regressions cover
+  immediate success, successful repair, and persistent failure without network
+  requests or real package changes.
 - Expert consultation now selects literal retained-source excerpts around
   exact study anchors. Evidence after the first 2,000 characters, distant
   anchors shared by several findings, and the separate 1,200-character render

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -26,7 +26,8 @@ curl -fsSL https://raw.githubusercontent.com/blisspixel/deepr/main/scripts/insta
 The installers resolve the latest supported wheel from GitHub Releases and
 install it in an isolated pipx environment. They exit without changing an
 existing Deepr installation when GitHub is unreachable or the latest release
-does not contain a supported wheel.
+does not contain a supported wheel. If the CLI still fails after the automatic
+repair attempt, the installer exits with a failure status and recovery guidance.
 
 ### Development or source install
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -166,6 +166,7 @@ if (Test-DeeprWorks) {
     }
 } else {
     Write-Err "Install completed but '$Cli' still does not run. Try a new terminal, or: pipx reinstall $Package"
+    exit 1
 }
 
 Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -137,6 +137,7 @@ if deepr_works; then
     esac
 else
     echo "Install completed but '$CLI' still does not run. Open a new terminal, or: pipx reinstall $PACKAGE" >&2
+    exit 1
 fi
 
 echo ""

--- a/tests/unit/test_release_installers.py
+++ b/tests/unit/test_release_installers.py
@@ -1,10 +1,126 @@
 """Regression checks for the public GitHub Releases install channel."""
 
+import json
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).parents[2]
+
+
+def _installer_shell(family: str) -> str:
+    if family == "powershell":
+        executable = shutil.which("powershell") or shutil.which("pwsh")
+    elif sys.platform == "win32":
+        git_bash = Path(os.environ.get("ProgramFiles", "C:/Program Files")) / "Git/bin/bash.exe"
+        executable = str(git_bash) if git_bash.is_file() else None
+    else:
+        executable = shutil.which("bash")
+    if executable is None:
+        pytest.skip(f"{family} is not installed on this platform")
+    return executable
+
+
+@pytest.mark.parametrize("family", ["powershell", "bash"])
+@pytest.mark.parametrize("behavior", ["works", "repair_works", "stays_broken"])
+def test_installer_exit_status_reflects_cli_after_repair(tmp_path: Path, family: str, behavior: str) -> None:
+    """Run the real installer with local command doubles, without network or installs."""
+    shell = _installer_shell(family)
+    release = {
+        "tag_name": "v2.50.12",
+        "assets": [
+            {
+                "name": "deepr_research-2.50.12-py3-none-any.whl",
+                "browser_download_url": (
+                    "https://github.com/blisspixel/deepr/releases/download/"
+                    "v2.50.12/deepr_research-2.50.12-py3-none-any.whl"
+                ),
+            }
+        ],
+    }
+    env = {
+        **os.environ,
+        "DEEPR_INSTALL_TEST_BEHAVIOR": behavior,
+        "DEEPR_INSTALL_TEST_RELEASE": json.dumps(release),
+        "DEEPR_INSTALL_TEST_PYTHON": Path(sys.executable).as_posix(),
+        "DEEPR_INSTALL_TEST_OPERATIONS": (tmp_path / "operations.txt").as_posix(),
+        "DEEPR_INSTALL_TEST_SCRIPT": (
+            ROOT / "scripts" / f"install.{'ps1' if family == 'powershell' else 'sh'}"
+        ).as_posix(),
+    }
+    if family == "powershell":
+        wrapper = tmp_path / "installer-test.ps1"
+        wrapper.write_text(
+            """$global:installCount = 0
+function python {
+    $global:LASTEXITCODE = 0
+    if ($args[0] -eq '-c') { & $env:DEEPR_INSTALL_TEST_PYTHON @args; return }
+    if ($args[2] -eq '--version') { '1.17.2'; return }
+    if ($args[2] -eq 'list') { 'deepr-research'; return }
+    if ($args[2] -eq 'install') { $global:installCount += 1 }
+    Add-Content -LiteralPath $env:DEEPR_INSTALL_TEST_OPERATIONS -Value $args[2]
+}
+function deepr {
+    if ($env:DEEPR_INSTALL_TEST_BEHAVIOR -eq 'stays_broken' -or
+        ($env:DEEPR_INSTALL_TEST_BEHAVIOR -eq 'repair_works' -and $global:installCount -lt 2)) {
+        $global:LASTEXITCODE = 7
+        return
+    }
+    $global:LASTEXITCODE = 0
+    'deepr, version 2.50.12'
+}
+function Invoke-RestMethod { $env:DEEPR_INSTALL_TEST_RELEASE | ConvertFrom-Json }
+Invoke-Expression (Get-Content -LiteralPath $env:DEEPR_INSTALL_TEST_SCRIPT -Raw)
+""",
+            encoding="utf-8",
+        )
+        command = [shell, "-NoProfile", "-NonInteractive", "-File", str(wrapper)]
+    else:
+        wrapper = tmp_path / "installer-test.sh"
+        wrapper.write_text(
+            """install_count=0
+python3() {
+    if [ "$1" = '-c' ]; then "$DEEPR_INSTALL_TEST_PYTHON" "$@"; return; fi
+    case "$3" in
+        --version) printf '1.17.2\\n' ;;
+        list) printf 'deepr-research\\n' ;;
+        install) install_count=$((install_count + 1)); printf 'install\\n' >> "$DEEPR_INSTALL_TEST_OPERATIONS" ;;
+        uninstall) printf 'uninstall\\n' >> "$DEEPR_INSTALL_TEST_OPERATIONS" ;;
+        *) return 90 ;;
+    esac
+}
+curl() { printf '%s' "$DEEPR_INSTALL_TEST_RELEASE"; }
+deepr() {
+    if [ "$DEEPR_INSTALL_TEST_BEHAVIOR" = stays_broken ] ||
+       { [ "$DEEPR_INSTALL_TEST_BEHAVIOR" = repair_works ] && [ "$install_count" -lt 2 ]; }; then
+        return 7
+    fi
+    printf 'deepr, version 2.50.12\\n'
+}
+source "$DEEPR_INSTALL_TEST_SCRIPT"
+""",
+            encoding="utf-8",
+            newline="\n",
+        )
+        command = [shell, str(wrapper)]
+    result = subprocess.run(command, env=env, cwd=tmp_path, capture_output=True, text=True, timeout=30, check=False)
+    output = result.stdout + result.stderr
+    operations = (tmp_path / "operations.txt").read_text(encoding="utf-8-sig").splitlines()
+    assert operations.count("install") == (1 if behavior == "works" else 2), output
+    assert operations.count("uninstall") == (0 if behavior == "works" else 1), output
+    if behavior == "stays_broken":
+        assert result.returncode != 0, output
+        assert "still does not run" in output
+        assert "==> Done." not in output
+        assert "Next steps:" not in output
+    else:
+        assert result.returncode == 0, output
+        assert "==> Done." in output
+        assert "deepr, version 2.50.12" in output
 
 
 @pytest.mark.parametrize("relative_path", ["scripts/install.sh", "scripts/install.ps1"])


### PR DESCRIPTION
The public Windows and macOS/Linux installers printed the success footer and returned success even when the CLI remained broken after repair. Both now exit unsuccessfully with recovery guidance before printing next steps.

The regression harness executes each real installer with local command doubles. Immediate success, successful repair, and persistent failure are covered without network requests or package changes. The persistent-failure scenarios fail against the original files and pass with the correction; all 11 installer checks pass on Windows using Windows PowerShell and Git Bash.

Ruff, formatting, strict mypy, file-size and complexity ratchets, and documentation consistency pass. This completes the still-unreleased 2.50.12 candidate; the changelog and install guide reflect the correction. All hosted CI and CodeQL checks pass, including the full Python 3.12, 3.13, and 3.14 matrix. Python 3.14 reports 11,872 passed, 20 platform skips, and 84.89% coverage against the 80% gate: https://github.com/blisspixel/deepr/actions/runs/33953169130. The three installer scenarios also pass independently in PowerShell 7.
