### PR TITLE
fix: describe gated chat tool inventory

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1261,6 +1261,14 @@ longitudinal proof; it is not itself proof that an expert improved.
   bind effective model/context/memory state, and collect blinded answer reviews.
   Structural preparation does not satisfy the v2.51 value gate.
 
+### Shared chat inventory correction
+
+- [x] September 5, 2026: a command-level reproduction found blocked research
+  and stored skills advertised as available, an unsupported free-search claim,
+  and model-switch help for an inspection-only handler. Shared inventory,
+  mode, and model help now match their runtime limits. Regressions cover both
+  command prefixes and all modes without provider calls or tool execution.
+
 ## Detailed Promotion Gates
 
 The [Active Release Plan](#active-release-plan) is the only delivery sequence.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Shared chat help describes configured tools as inventory, labels research
+  and skill execution blocks, and removes unsupported free-search and fixed
+  price claims. Mode descriptions no longer imply unrestricted access or
+  completed reasoning. Model help matches the existing read-only handler.
+
 ### Added
 
 - A read-only `eval expert-value-sources` preflight for versioned source-world

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -497,14 +497,14 @@ The disabled interactive design includes slash commands, chat modes, and
 research triggers. CLI, web, and MCP API chat fail before provider dispatch;
 the capabilities below do not authorize metered execution.
 
-**Chat Modes** control how the expert responds:
+**Chat Modes** configure the retained interactive design:
 
 ```bash
-# In chat, switch modes with slash commands:
+# Shared command syntax for the gated design:
 /ask        # Quick answers, KB-only tools
-/research   # Default - all tools available
+/research   # Research tool configuration; execution gates still apply
 /advise     # Structured consulting-style recommendations
-/focus      # Always-on chain-of-thought reasoning
+/focus      # Requests Tree of Thoughts; does not prove execution
 ```
 
 **Slash Commands** (27 total, organized by category):
@@ -514,11 +514,17 @@ the capabilities below do not authorize metered execution.
 | Mode | `/ask`, `/research`, `/advise`, `/focus`, `/mode [name]` |
 | Session | `/clear`, `/compact`, `/remember <text>`, `/forget <idx>`, `/memories`, `/new` |
 | Reasoning | `/trace`, `/why`, `/decisions`, `/thinking [on/off]` |
-| Control | `/model [name]`, `/tools`, `/effort [low/med/high]`, `/budget [amount]` |
+| Control | `/model`, `/tools`, `/effort [low/med/high]`, `/budget [amount]` |
 | Management | `/save [name]`, `/load <id>`, `/export [md/json]`, `/council <query>`, `/plan <query>` |
 | Utility | `/help [cmd]`, `/status`, `/quit` |
 
 Use `/` prefix in web, `\` prefix in CLI.
+
+In the unreleased source checkout, `/tools` and `/help tools` describe a
+configured inventory. Stored skills remain visible with execution blocked;
+neither a listed tool nor a mode switch grants capacity. The handler makes no
+provider call. `/model` reports the configured model; a legacy name argument
+does not switch it. Interactive metered chat remains disabled.
 
 **Context Compaction** keeps sessions usable over long conversations:
 

--- a/docs/SUPPORTED_SURFACE.md
+++ b/docs/SUPPORTED_SURFACE.md
@@ -760,6 +760,11 @@ must not be described as usable capacity.
   proof, conservative identity mismatch handling, cancellation settlement,
   canonical-ledger idempotency, concurrency, and ledger-failure regressions.
   Local and explicit plan read-only query is shipped and unaffected.
+  **Unreleased source checkout:** shared `/tools` and command help describe
+  configured inventory, explicitly mark skill execution blocked, and omit
+  unbound free-search and price claims. A mode switch does not grant capacity;
+  `/model` reports the current model without switching it. These corrections
+  do not enable the retained interactive chat design.
 - Unsafe metered expert lifecycle surfaces also fail closed:
   nonlocal `expert make` and `--learn`, API curriculum `expert plan`,
   provider-backed `expert refresh` and `--synthesize`, `expert resume`, normal

--- a/src/deepr/experts/command_handlers.py
+++ b/src/deepr/experts/command_handlers.py
@@ -212,16 +212,17 @@ async def handle_model(session: ExpertChatSession, args: str, context: dict) -> 
 async def handle_tools(session: ExpertChatSession, args: str, context: dict) -> CommandResult:
     cfg = MODE_CONFIGS[session.chat_mode]
     allowed = cfg["tools"]
-    lines = [f"Tools available in **{session.chat_mode.value}** mode:"]
+    lines = [f"Configured tool inventory for **{session.chat_mode.value}** mode:"]
     for tool_name in allowed:
         desc = TOOL_DESCRIPTIONS.get(tool_name, tool_name)
         lines.append(f"  - {tool_name}: {desc}")
     if session.active_skills:
         lines.append("")
-        lines.append("Skill tools:")
+        lines.append("Skill inventory (execution blocked):")
         for skill in session.active_skills:
             for tool in skill.tools:
                 lines.append(f"  - {skill.name}/{tool.name}")
+    lines.extend(["", "Inventory only. Metered calls and skill execution are blocked. See deepr capacity."])
     return CommandResult(output="\n".join(lines))
 
 

--- a/src/deepr/experts/commands.py
+++ b/src/deepr/experts/commands.py
@@ -44,7 +44,7 @@ MODE_CONFIGS: dict[ChatMode, dict[str, Any]] = {
         "model_bias": "balanced",
         "force_tot": False,
         "label": "Research",
-        "description": "Default - full tool access",
+        "description": "Research tool configuration - execution gates apply",
     },
     ChatMode.ADVISE: {
         "tools": ["search_knowledge_base", "standard_research"],
@@ -65,7 +65,7 @@ MODE_CONFIGS: dict[ChatMode, dict[str, Any]] = {
         "model_bias": "quality",
         "force_tot": True,
         "label": "Focus",
-        "description": "Deep reasoning - Tree of Thoughts always on",
+        "description": "Deep reasoning - Tree of Thoughts requested",
     },
 }
 
@@ -230,15 +230,14 @@ class CommandRegistry:
             ChatCommand(
                 "model",
                 [],
-                "Show or change model",
+                "Show the current model",
                 CommandCategory.CONTROL,
                 CommandScope.SESSION_REQUIRED,
-                args="[name]",
             ),
             ChatCommand(
                 "tools",
                 [],
-                "List available tools for current mode",
+                "List configured tool inventory for current mode",
                 CommandCategory.CONTROL,
                 CommandScope.SESSION_REQUIRED,
             ),

--- a/src/deepr/experts/constants.py
+++ b/src/deepr/experts/constants.py
@@ -15,9 +15,9 @@ ALL_TOOL_NAMES = frozenset({TOOL_SEARCH_KB, TOOL_STANDARD_RESEARCH, TOOL_DEEP_RE
 
 # Human-readable tool descriptions
 TOOL_DESCRIPTIONS: dict[str, str] = {
-    TOOL_SEARCH_KB: "Search expert's documents (free)",
-    TOOL_STANDARD_RESEARCH: "Web search via Grok (free)",
-    TOOL_DEEP_RESEARCH: "Deep analysis ($0.10-0.30)",
+    TOOL_SEARCH_KB: "Search configured expert knowledge",
+    TOOL_STANDARD_RESEARCH: "Web research (metered calls blocked)",
+    TOOL_DEEP_RESEARCH: "Deep analysis (metered calls blocked)",
 }
 
 # Budget constants

--- a/tests/unit/test_experts/test_command_inventory.py
+++ b/tests/unit/test_experts/test_command_inventory.py
@@ -1,0 +1,70 @@
+"""Shared command help must distinguish configuration from executable capacity."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from deepr.experts.command_handlers import dispatch_command
+from deepr.experts.commands import MODE_CONFIGS, ChatMode
+
+
+@pytest.mark.parametrize("prefix", ["/", "\\"])
+@pytest.mark.parametrize("mode", list(ChatMode))
+async def test_tool_inventory_preserves_mode_selection_without_advertising_dispatch(prefix, mode):
+    session = SimpleNamespace(chat_mode=mode, active_skills=[], budget=0, cost_accumulated=0)
+    before = vars(session).copy()
+    result = await dispatch_command(session, f"{prefix}tools")
+
+    assert result is not None and result.success
+    assert "inventory" in result.output.lower()
+    assert "Metered calls and skill execution are blocked" in result.output
+    assert "free" not in result.output.lower() and "$0.10" not in result.output
+    for tool in {name for config in MODE_CONFIGS.values() for name in config["tools"]}:
+        assert (tool in result.output) == (tool in MODE_CONFIGS[mode]["tools"])
+    assert vars(session) == before
+
+
+async def test_stored_skills_remain_visible_as_blocked_inventory():
+    session = SimpleNamespace(
+        chat_mode=ChatMode.ASK,
+        active_skills=[SimpleNamespace(name="stored-skill", tools=[SimpleNamespace(name="inspect")])],
+    )
+    result = await dispatch_command(session, "/tools")
+
+    assert result is not None and result.success
+    assert "stored-skill/inspect" in result.output
+    assert "Skill inventory (execution blocked)" in result.output
+
+
+@pytest.mark.parametrize("command", ["/mode", "/research", "/focus"])
+async def test_mode_help_and_switches_do_not_grant_tool_access(command):
+    session = SimpleNamespace(chat_mode=ChatMode.ASK)
+    result = await dispatch_command(session, command)
+
+    assert result is not None and result.success
+    assert "full tool access" not in result.output.lower()
+    assert "always on" not in result.output.lower()
+    if command != "/mode":
+        assert session.chat_mode == ChatMode(command[1:])
+        assert result.mode_changed == session.chat_mode
+
+
+@pytest.mark.parametrize("command", ["/help tools", "/help"])
+async def test_command_help_describes_tools_as_inventory(command):
+    result = await dispatch_command(None, command)
+
+    assert result is not None and result.success
+    assert "tool inventory" in result.output.lower()
+    assert "list available tools" not in result.output.lower()
+
+
+async def test_model_help_matches_read_only_model_handler():
+    session = SimpleNamespace(expert=SimpleNamespace(model="current-model"))
+    help_result = await dispatch_command(session, "/help model")
+    response = await dispatch_command(session, "/model another-model")
+
+    assert help_result is not None and response is not None
+    assert "change model" not in help_result.output.lower()
+    assert "[name]" not in help_result.output
+    assert "current-model" in response.output
+    assert session.expert.model == "current-model"


### PR DESCRIPTION
The shared chat `/tools` handler described blocked research and stored skills as available, called provider search free, and printed an unbound fixed price. Mode and model help also promised access or switching that the retained handlers do not provide.

Describe configured tools and skills as inventory, state their execution limits, and align model help with the existing read-only handler. Preserve mode selection, tool membership, skill names, and all execution gates. Update the feature guide, supported surface, roadmap finding, and Unreleased changelog. Interactive metered chat remains disabled.

Validation:

- All 15 new command regressions fail before the correction and pass afterward, covering both command prefixes, all four modes, skill inventory, help, and read-only model behavior.
- 59 focused and adjacent gating checks pass on Windows; the final formatted source also passes the 34 command and registry checks.
- Lint, source formatting, blocking strict types, file-size and code-health ratchets, paid API boundaries, and all 21 doc consistency checks pass.
- The reproduction and tests use synthetic sessions. No provider, paid API, or tool execution was used.
- Full hosted CI passes on `46dc33d99449842a2e86a0e6ac2caa0477bdb76d`, including Python 3.12, 3.13, and 3.14, frontend/browser workflows, clean core installation, plugin packaging, security, lint, and strict types. Python 3.14 reports 11,965 passed, 20 skipped, and 84.93% branch-aware coverage.
- Twenty synthetic command observations are retained with commit and SHA-256 bindings; mode, budget, and configured model stay unchanged.

[Final hosted CI](https://github.com/blisspixel/deepr/actions/runs/33984858489)
