### PR TITLE
feat: allow historical briefing cutoffs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1257,6 +1257,14 @@ longitudinal proof; it is not itself proof that an expert improved.
 - [x] September 5, 2026: Windows regressions reproduced trailing-period and
   trailing-space paths counting the same file through aliases. The preparation
   reader now rejects these ambiguous names while preserving internal spaces.
+- [x] September 5, 2026: freeze the local four-arm operational rehearsal
+  protocol covering arm preparation, memory scope across worlds, native local
+  binding and retained request evidence, worker isolation, and blocked/failed/
+  answered outcome handling.
+  [Protocol and limits](docs/design/local-four-arm-rehearsal.md). Briefing
+  synthesis now accepts an explicit historical cutoff so a synthetic world's
+  prospective predictions survive a later execution date. Writing a protocol
+  is not executing it and supports no value claim.
 - [ ] Materialize equal neutral source inventories into isolated arm roots,
   bind effective model/context/memory state, and collect blinded answer reviews.
   Structural preparation does not satisfy the v2.51 value gate.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   links, junctions, special files, and changed inputs are refused. Experimental
   schemas describe the preparation contract. A passing report grants no
   execution authority and makes no semantic, historical, or blinding claim.
+- `build_brief` accepts an optional `as_of_date` so a briefing can be
+  synthesized at a stated historical information cutoff. The same effective
+  date governs the prompt instruction and prospective-prediction registration,
+  so a falsifier that is still future-facing at that cutoff is no longer
+  discarded merely because the run executes later. The default remains the
+  current UTC date, and no shipped command passes the parameter yet.
 
 ## [2.50.13] - 2026-09-05
 

--- a/docs/design/local-four-arm-rehearsal.md
+++ b/docs/design/local-four-arm-rehearsal.md
@@ -1,0 +1,87 @@
+# Local four-arm operational rehearsal
+
+Status: unreviewed experiment protocol, 2026-09-05. This uses the existing
+source preflight, corpus, study, briefing, position history, and native local
+completion primitives. It is not a replacement for the attested value workbook
+or a claim that the v2.51 value gate is complete.
+
+## Decision and scope
+
+Exercise all four treatments over the prepared three synthetic source worlds
+and twelve draft cases before commissioning semantic review. Keep the original
+drafts unchanged. Freeze a separate policy and question-only case inventory
+before any answer collection. Construction and maintenance receive sources,
+never the held-out questions, acceptance criteria, organizer roles, or answers.
+Consultation receives the current sources as well as any permitted memory.
+
+| Arm | Preparation | Memory across worlds |
+| --- | --- | --- |
+| Fresh research | A new local study and brief for each case | None; each case starts empty |
+| Static history | Retain raw cumulative sources | Raw corpus only |
+| Compiled expert | One study and brief from world 1 | Frozen initial checkpoint |
+| Maintained expert | Copy the identical compiled checkpoint, then study and brief before worlds 2 and 3 | Its own last completed checkpoint and position history |
+
+Use the same `synopsis` and `change` lenses for every preparation. Final answers
+use a common prompt and the complete current-world source packet, in the same
+order and with neutral content-hash labels. The normal consultation assembler
+retrieves passages through study findings, so using it unchanged for a raw
+corpus would mechanically deny static history the promised source access.
+
+This is fresh local evidence reading, not live web or frontier research. Full
+source packets avoid introducing a retrieval confound in this small fixture;
+they cannot demonstrate retrieval scalability. Preprocessing compute differs
+by treatment and must be reported separately, including fresh per-case work
+and initial compilation attributable to both persistent arms.
+
+## Binding and isolation
+
+Use the existing native Ollama backend with per-dispatch owned-local and cloud
+disable checks. Also compare the observed model digest with the frozen model
+identity. Retain the application commit and runtime source hashes, server and
+model metadata, exact requests and raw responses, context/output settings,
+generation counts and durations, stop reasons, and errors. The native endpoint
+exposes runtime generation options and timing fields; the compatibility endpoint
+does not expose per-request context size. See the official
+[native chat contract](https://docs.ollama.com/api/chat) and
+[compatibility context guidance](https://docs.ollama.com/api/openai-compatibility).
+
+Memory shares the context ceiling with instructions, questions, and sources.
+Freeze any mechanical memory-prefix limit before execution and retain the full
+memory plus the exact rendered prefix. Missing usage remains missing evidence.
+Do not claim exact tokenizer verification, fixed seed, equal compute, or equal
+warm-cache latency when these were not established. No native tools or fallback
+are available to the model. Every dispatched attempt writes an append-only
+local cost record, including unsuccessful attempts, at $0 API cost.
+
+Separate child processes use explicit credential-free environments, disabled
+dotenv loading, isolated data roots, and only their permitted input copies.
+Copy each frozen memory snapshot again for consultation, hash it before and
+after, and keep outputs elsewhere. Construction and maintenance run in workers
+that receive no case questions. Future sources and organizer files never enter
+worker inputs. Ordinary file copies and restricted prompts do not constitute
+hostile-process OS confinement. Preserve original source bytes and all canonical
+expert files. Keep coexisting historical versions active in the retained corpus.
+
+## Completion and failures
+
+A study must clear its existing usable/complete status; a brief must contain
+orientation and positions before its checkpoint is accepted. Keep failed and
+partial artifacts. Failed initial or fresh construction refuses the dependent
+answer. Failed maintenance retains the last completed checkpoint, explicitly
+reports the update failure, and does not claim completed-update latency. No
+retry overwrites an attempt. Terminal cell records distinguish blocked,
+failed, and answered outcomes.
+
+Historical briefing requires an explicit information date. `build_brief` now
+accepts optional `as_of_date` and passes the same effective date into the prompt
+and falsifier registration. Its default remains current UTC. This avoids
+discarding a prediction that is future-facing at a synthetic historical cutoff
+merely because the rehearsal executes later. Execution timestamps remain real.
+
+Operational completion requires 48 terminal cells, all distinct treatments,
+chronological worlds, matching permitted source inventories, unchanged
+consultation memory and canonical experts, and reconciled request/cost records.
+Saved answers remain unreviewed. There are no reviewer identities, semantic
+attestations, correctness scores, or claims of successful blinding. The next
+value step remains review of the protocol and exact outputs, followed by the
+attested longitudinal evaluation; this rehearsal cannot promote itself.

--- a/src/deepr/experts/brief.py
+++ b/src/deepr/experts/brief.py
@@ -412,8 +412,13 @@ async def build_brief(
     completion: BriefCompletion,
     domain: str = "",
     prior_positions: list[Any] | None = None,
+    as_of_date: date | None = None,
 ) -> ExpertBrief:
-    """Synthesize one brief. Returns an empty brief rather than raising."""
+    """Synthesize one brief at the supplied cutoff or the current UTC date.
+
+    The same date governs the prompt and prediction registration even if the
+    completion crosses midnight. Returns an empty brief rather than raising.
+    """
     from deepr.experts.study import extract_json_object
 
     if not result.findings:
@@ -424,13 +429,13 @@ async def build_brief(
         )
         return brief
 
-    today = _utc_today()
+    effective_date = as_of_date or _utc_today()
     prompt = build_brief_prompt(
         result,
         expert_name=expert_name,
         domain=domain,
         prior_positions=prior_positions,
-        as_of_date=today,
+        as_of_date=effective_date,
     )
     try:
         raw = await completion(prompt)
@@ -451,7 +456,7 @@ async def build_brief(
         expert_name=expert_name,
         result=result,
         corpus=corpus,
-        as_of_date=today,
+        as_of_date=effective_date,
     )
 
 

--- a/tests/unit/test_experts/test_brief.py
+++ b/tests/unit/test_experts/test_brief.py
@@ -415,6 +415,62 @@ class TestEvidentialDepth:
 
 class TestBuildBrief:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("prediction_date", "registered"),
+        [("2026-01-19", False), ("2026-01-20", True), ("2026-01-21", True)],
+    )
+    async def test_historical_cutoff_controls_prompt_and_prediction_registration(
+        self, corpus, monkeypatch, prediction_date, registered
+    ):
+        monkeypatch.setattr("deepr.experts.brief._utc_today", lambda: date(2026, 9, 5))
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"][0]["falsifier_resolution_date"] = prediction_date
+        prompts = []
+
+        async def _completion(prompt):
+            prompts.append(prompt)
+            return json.dumps(payload)
+
+        brief = await build_brief(
+            expert_name="E",
+            result=_result([_finding("F1")]),
+            corpus=corpus,
+            completion=_completion,
+            as_of_date=date(2026, 1, 20),
+        )
+
+        assert len(prompts) == 1
+        assert "2026-01-20; never use an earlier date" in prompts[0]
+        assert "2026-09-05" not in prompts[0]
+        position = brief.positions[0]
+        assert position.falsifier_resolution_date == (prediction_date if registered else "")
+        assert position.is_registered_prediction is registered
+
+    @pytest.mark.asyncio
+    async def test_default_date_stays_fixed_when_completion_crosses_midnight(self, corpus, monkeypatch):
+        monkeypatch.setattr("deepr.experts.brief._utc_today", lambda: date(2026, 1, 20))
+        payload = json.loads(json.dumps(_GOOD))
+        payload["positions"][0]["falsifier_resolution_date"] = "2026-01-20"
+        prompts = []
+
+        async def _completion(prompt):
+            prompts.append(prompt)
+            monkeypatch.setattr("deepr.experts.brief._utc_today", lambda: date(2026, 1, 21))
+            return json.dumps(payload)
+
+        brief = await build_brief(
+            expert_name="E",
+            result=_result([_finding("F1")]),
+            corpus=corpus,
+            completion=_completion,
+        )
+
+        assert len(prompts) == 1
+        assert "2026-01-20; never use an earlier date" in prompts[0]
+        assert brief.positions[0].falsifier_resolution_date == "2026-01-20"
+        assert brief.positions[0].is_registered_prediction
+
+    @pytest.mark.asyncio
     async def test_no_findings_refuses_rather_than_inventing(self, corpus):
         calls = []
 


### PR DESCRIPTION
## What

`build_brief` accepts an optional `as_of_date` so a briefing can be synthesized at a stated historical information cutoff. The same effective date governs both the prompt instruction and prospective-prediction registration.

Previously the synthesis date was always the current UTC date. When a briefing runs against a synthetic source world with a historical availability cutoff, a falsifier that is legitimately future-facing at that cutoff was discarded as already-resolved simply because the run executed later.

The default remains the current UTC date. No shipped command passes the parameter yet, so there is no user-visible behavior change.

## Also

Freezes `docs/design/local-four-arm-rehearsal.md`: the local four-arm operational rehearsal protocol covering arm preparation, memory scope across source worlds, native local binding and retained request evidence, worker isolation, and blocked/failed/answered outcome handling. Writing a protocol is not executing it and supports no value claim. The v2.51 value gate is unchanged.

## Verification

- `tests/unit/test_experts/test_brief.py`: 61 passed, including a parametrized guard that the supplied cutoff governs both prompt text and registration, and a guard that the default date stays fixed if the completion crosses midnight.
- Full unit suite, ruff check/format, strict mypy islands, and the docs-consistency, ratchet, file-size, and paid-API-boundary guards all pass locally.
- No paid API call. Validation spend: $0.